### PR TITLE
remove webpack-dev-middleware

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,39 +34,21 @@ module.exports = function connect(opts) {
 		dev
 	);
 
-	const dev_middleware = dev ? require('webpack-dev-middleware')(client, {
-		noInfo: true,
-		logLevel: 'silent',
-		publicPath: '/client/'
-	}) : null;
-
-	const hot_middleware = dev ? require('webpack-hot-middleware')(client, {
-		reload: true,
-		path: '/__webpack_hmr',
-		heartbeat: 10 * 1000
-	}) : null;
-
-	async function handle_webpack_generated_files(url, req, res, next) {
-		if (dev) {
-			dev_middleware(req, res, () => {
-				hot_middleware(req, res, next);
+	async function handle_webpack_generated_files(req, res, next) {
+		if (req.pathname.startsWith('/client/')) {
+			await compiler.ready;
+			res.set({
+				'Content-Type': 'application/javascript',
+				'Cache-Control': 'max-age=31536000'
 			});
+			res.end(compiler.asset_cache[req.pathname]);
 		} else {
-			if (url.startsWith('/client/')) {
-				await compiler.ready;
-				res.set({
-					'Content-Type': 'application/javascript',
-					'Cache-Control': 'max-age=31536000'
-				});
-				res.end(compiler.asset_cache[url]);
-			} else {
-				next();
-			}
+			next();
 		}
 	}
 
-	async function handle_index(url, req, res, next) {
-		if (url === '/index.html') {
+	async function handle_index(req, res, next) {
+		if (req.pathname === '/index.html') {
 			await compiler.ready;
 			res.set({
 				'Content-Type': 'text/html',
@@ -78,8 +60,8 @@ module.exports = function connect(opts) {
 		}
 	}
 
-	async function handle_service_worker(url, req, res, next) {
-		if (url === '/service-worker.js') {
+	async function handle_service_worker(req, res, next) {
+		if (req.pathname === '/service-worker.js') {
 			await compiler.ready;
 			res.set({
 				'Content-Type': 'application/javascript',
@@ -91,7 +73,9 @@ module.exports = function connect(opts) {
 		}
 	}
 
-	async function handle_route(url, req, res, next) {
+	async function handle_route(req, res, next) {
+		const url = req.pathname;
+
 		// whatever happens, we're going to serve some HTML
 		res.set({
 			'Content-Type': 'text/html'
@@ -148,15 +132,41 @@ module.exports = function connect(opts) {
 		}
 	}
 
-	return async function(req, res, next) {
-		const url = req.url.replace(/\?.+/, '');
+	const handler = compose_handlers([
+		dev && require('webpack-hot-middleware')(client, {
+			reload: true,
+			path: '/__webpack_hmr',
+			heartbeat: 10 * 1000
+		}),
 
-		handle_index(url, req, res, () => {
-			handle_service_worker(url, req, res, () => {
-				handle_webpack_generated_files(url, req, res, () => {
-					handle_route(url, req, res, next);
-				});
-			});
-		});
+		handle_index,
+		handle_service_worker,
+		handle_webpack_generated_files,
+		handle_route
+	].filter(Boolean));
+
+	return function(req, res, next) {
+		req.pathname = req.url.replace(/\?.+/, '');
+		handler(req, res, next);
 	};
 };
+
+function compose_handlers(handlers) {
+	return (req, res, next) => {
+		let i = 0;
+		function go() {
+			const handler = handlers[i];
+
+			if (handler) {
+				handler(req, res, () => {
+					i += 1;
+					go();
+				});
+			} else {
+				next();
+			}
+		}
+
+		go();
+	}
+}

--- a/lib/utils/create_compiler.js
+++ b/lib/utils/create_compiler.js
@@ -111,8 +111,16 @@ module.exports = function create_compiler(client, server, dest, routes, dev) {
 
 		server.plugin('failed', reject);
 
-		// client is already being watched by the middleware,
-		// so we only need to start the server compiler
+		client.watch({}, (err, stats) => {
+			if (stats.hasErrors()) {
+				reject(stats.toJson().errors[0]);
+			} else {
+				client_updated(stats);
+				client_is_ready = true;
+				if (server_is_ready) fulfil();
+			}
+		});
+
 		server.watch({}, (err, stats) => {
 			if (stats.hasErrors()) {
 				reject(stats.toJson().errors[0]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sapper",
-  "version": "0.0.21",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -89,11 +89,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
-    },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-unique": {
       "version": "0.2.1",
@@ -445,14 +440,6 @@
         "public-encrypt": "4.0.0",
         "randombytes": "2.0.5",
         "randomfill": "1.0.3"
-      }
-    },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "requires": {
-        "array-find-index": "1.0.2"
       }
     },
     "d": {
@@ -1880,37 +1867,10 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
-    "log-symbols": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
-      "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
-      "requires": {
-        "chalk": "2.3.0"
-      }
-    },
-    "loglevel": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.0.tgz",
-      "integrity": "sha1-rgyqVhERSYxboTcj1vtjHSQAOTQ="
-    },
-    "loglevel-plugin-prefix": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.5.3.tgz",
-      "integrity": "sha512-zRAJw3WYCQAJ6xfEIi04/oqlmR6jkwg3hmBcMW82Zic3iPWyju1gwntcgic0m5NgqYNJ62alCmb0g/div26WjQ=="
-    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
-    },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
-      }
     },
     "lru-cache": {
       "version": "4.1.1",
@@ -1986,11 +1946,6 @@
         "bn.js": "4.11.8",
         "brorand": "1.1.0"
       }
-    },
-    "mime": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.0.3.tgz",
-      "integrity": "sha512-TrpAd/vX3xaLPDgVRm6JkZwLR0KHfukMdU2wTEbqMDdCnY6Yo3mE+mjs9YE6oMNw2QRfXVeBEYpmpO94BIqiug=="
     },
     "mimic-fn": {
       "version": "1.1.0",
@@ -2373,11 +2328,6 @@
         "safe-buffer": "5.1.1"
       }
     },
-    "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
-    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -2649,11 +2599,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
     },
-    "time-stamp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
-      "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c="
-    },
     "timers-browserify": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
@@ -2727,11 +2672,6 @@
         }
       }
     },
-    "url-join": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.2.tgz",
-      "integrity": "sha1-wHJ1aWetJLi1nldBVRyqx49QuLc="
-    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -2751,11 +2691,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
@@ -2811,25 +2746,6 @@
         "watchpack": "1.4.0",
         "webpack-sources": "1.1.0",
         "yargs": "8.0.2"
-      }
-    },
-    "webpack-dev-middleware": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.1.tgz",
-      "integrity": "sha512-jEQgJK+eblBzE4blKmNuJqNd4cz3t4K3mFmN6uZz4Iq44x2vc1r+CwZBgcX+GzQoSOk5iWSVB3bIN5AYKpFRTw==",
-      "requires": {
-        "chalk": "2.3.0",
-        "log-symbols": "2.1.0",
-        "loglevel": "1.6.0",
-        "loglevel-plugin-prefix": "0.5.3",
-        "loud-rejection": "1.6.0",
-        "memory-fs": "0.4.1",
-        "mime": "2.0.3",
-        "path-is-absolute": "1.0.1",
-        "range-parser": "1.2.0",
-        "time-stamp": "2.0.0",
-        "url-join": "2.0.2",
-        "uuid": "3.1.0"
       }
     },
     "webpack-hot-middleware": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.2",
     "webpack": "^3.10.0",
-    "webpack-dev-middleware": "^2.0.1",
     "webpack-hot-middleware": "^2.21.0"
   },
   "devDependencies": {


### PR DESCRIPTION
webpack-dev-middleware seriously complicates things, by futzing around with an in-memory fs shim that isn't compatible with the built-in `fs`. The part of its functionality that we actually need can be reproduced in a 10-line function, so we'll do that instead.

This will enable #21.