### PR TITLE
use /, not path.sep, when creating routes

### DIFF
--- a/lib/utils/create_routes.js
+++ b/lib/utils/create_routes.js
@@ -5,7 +5,7 @@ module.exports = function create_matchers(files) {
 		.map(file => {
 			if (/(^|\/|\\)_/.test(file)) return;
 
-			const parts = file.replace(/\.(html|js|mjs)$/, '').split(path.sep);
+			const parts = file.replace(/\.(html|js|mjs)$/, '').split('/'); // glob output is always posix-style
 			if (parts[parts.length - 1] === 'index') parts.pop();
 
 			const id = (


### PR DESCRIPTION
glob always returns results with forward-slashes, regardless of platform. Whyyyyyy?

This appears to fix https://github.com/sveltejs/sapper-template/issues/13