### PR TITLE
render main.js back to templates, to allow relative imports

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -18,4 +18,7 @@ if (exports.dev) {
 	rimraf.sync(path.join(exports.dest, '**/*'));
 }
 
-exports.server_routes = path.resolve(exports.dest, 'server-routes.js');
+exports.entry = {
+	client: path.resolve(exports.templates, '.main.rendered.js'),
+	server: path.resolve(exports.dest, 'server-entry.js')
+};

--- a/lib/utils/create_app.js
+++ b/lib/utils/create_app.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const chokidar = require('chokidar');
 const route_manager = require('../route_manager.js');
-const { src, dest, server_routes, dev } = require('../config.js');
+const { src, dest, entry, dev } = require('../config.js');
 
 function posixify(file) {
 	return file.replace(/[\/\\]/g, '/');
@@ -38,13 +38,11 @@ function create_app() {
 			main += `\n\nimport('${hmr_client}?path=/__webpack_hmr&timeout=20000'); if (module.hot) module.hot.accept();`
 		}
 
-		const file = path.resolve(dest, 'main.js');
-
-		fs.writeFileSync(file, main);
+		fs.writeFileSync(entry.client, main);
 
 		// need to fudge the mtime, because webpack is soft in the head
-		const { atime, mtime } = fs.statSync(file);
-		fs.utimesSync(file, new Date(atime.getTime() - 999999), new Date(mtime.getTime() - 999999));
+		const { atime, mtime } = fs.statSync(entry.client);
+		fs.utimesSync(entry.client, new Date(atime.getTime() - 999999), new Date(mtime.getTime() - 999999));
 	}
 
 	function create_server_routes() {
@@ -59,10 +57,10 @@ function create_app() {
 
 		const exports = `export { ${routes.map(route => route.id)} };`;
 
-		fs.writeFileSync(server_routes, `${imports}\n\n${exports}`);
+		fs.writeFileSync(entry.server, `${imports}\n\n${exports}`);
 
-		const { atime, mtime } = fs.statSync(server_routes);
-		fs.utimesSync(server_routes, new Date(atime.getTime() - 999999), new Date(mtime.getTime() - 999999));
+		const { atime, mtime } = fs.statSync(entry.server);
+		fs.utimesSync(entry.server, new Date(atime.getTime() - 999999), new Date(mtime.getTime() - 999999));
 	}
 
 	create_client_main();

--- a/lib/utils/generate_asset_cache.js
+++ b/lib/utils/generate_asset_cache.js
@@ -41,7 +41,7 @@ module.exports = function generate_asset_cache(clientInfo, serverInfo) {
 		},
 
 		server: {
-			entry: path.resolve(dest, 'server', serverInfo.assetsByChunkName.server_routes)
+			entry: path.resolve(dest, 'server', serverInfo.assetsByChunkName.main)
 		}
 	};
 };

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { src, dest, dev, server_routes } = require('../lib/config.js');
+const { src, dest, dev, entry } = require('../lib/config.js');
 
 module.exports = {
 	dev,
@@ -7,7 +7,7 @@ module.exports = {
 	client: {
 		entry: () => {
 			return {
-				main: `${dest}/main.js`
+				main: entry.client
 			};
 		},
 
@@ -24,7 +24,7 @@ module.exports = {
 	server: {
 		entry: () => {
 			return {
-				server_routes
+				main: entry.server
 			}
 		},
 


### PR DESCRIPTION
fixes #40. Not totally in love with this, as it clutters up the `templates` folder and adds some modest confusion about the service worker (#41), so am certainly open to suggestions for improvement. But this allows relative imports from main.js which is important, so it'll do for now.