### PR TITLE
Export prefetch

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -164,18 +164,22 @@ let prefetching: {
 	promise: Promise<{ Component: ComponentConstructor, data: any }>;
 } = null;
 
-function prefetch(event: MouseEvent | TouchEvent) {
-	const a: HTMLAnchorElement = <HTMLAnchorElement>findAnchor(<Node>event.target);
-	if (!a || a.rel !== 'prefetch') return;
-
-	const selected = select_route(new URL(a.href));
+export function prefetch(href: string) {
+	const selected = select_route(new URL(href));
 
 	if (selected) {
 		prefetching = {
-			href: a.href,
+			href,
 			promise: selected.route.load().then(mod => prepare_route(mod.default, selected.data))
 		};
 	}
+}
+
+function handle_touchstart_mouseover(event: MouseEvent | TouchEvent) {
+        const a: HTMLAnchorElement = <HTMLAnchorElement>findAnchor(<Node>event.target);
+        if (!a || a.rel !== 'prefetch') return;
+
+        prefetch(a.href);
 }
 
 let inited: boolean;
@@ -189,8 +193,8 @@ export function init(_target: Node, _routes: Route[]) {
 		window.addEventListener('popstate', handle_popstate);
 
 		// prefetch
-		window.addEventListener('touchstart', prefetch);
-		window.addEventListener('mouseover', prefetch);
+		window.addEventListener('touchstart', handle_touchstart_mouseover);
+		window.addEventListener('mouseover', handle_touchstart_mouseover);
 
 		inited = true;
 	}


### PR DESCRIPTION
Thank you for your hard work on Sapper. It is nothing short of amazing!

One of my favorite features is the prefetching that is done when hovering over an anchor tag with `rel=prefetch`. It is super awesome in 95% of use cases, but maybe it could also be useful to export `prefetch` so that it can be used imperatively?

This opens up for cool user land possibilities, like e.g. prefetching a page when an anchor tag leading to that page is scrolled into the viewport:

```html
<!-- MyAnchor.html  -->
<a href={{href}} ref:anchor>
    <slot></slot>
</a>

<script>
    import { prefetch } from 'sapper/runtime.js';
    const ioIsSupported = 
        typeof window !== 'undefined' && 'IntersectionObserver' in window;

    export default {
        oncreate() {
            if (!ioIsSupported) {
                return;
            }

            const { anchor } = this.refs;
            const { href } = anchor;
            let io = this.io = new IntersectionObserver(entries => {
                entries.forEach(entry => {
                    if (anchor === entry.target && entry.intersectionRatio > 0) {
                        io.unobserve(anchor);
                        io.disconnect();
                        this.io = null;
                        prefetch(href);
                    }
                });
            });

            io.observe(anchor);
        },

        ondestroy() {
            if (this.io) {
                const { anchor } = this.refs;
                this.io.unobserve(anchor);
                this.io.disconnect();
            }
        }
    }
</script>
```

![prefetch_io](https://user-images.githubusercontent.com/11573167/34531805-d9b24b22-f0b3-11e7-93a9-09f899f00121.gif)

I totally understand if you think this is outside the scope of Sapper, but maybe we could discuss it!