### PR TITLE
Lazily Require Chokidar

### DIFF
--- a/lib/route_manager.js
+++ b/lib/route_manager.js
@@ -1,5 +1,4 @@
 const glob = require('glob');
-const chokidar = require('chokidar');
 const create_routes = require('./utils/create_routes.js');
 const { src, dev } = require('./config.js');
 
@@ -20,7 +19,7 @@ function update() {
 update();
 
 if (dev) {
-	const watcher = chokidar.watch(`${src}/**/*.+(html|js|mjs)`, {
+	const watcher = require('chokidar').watch(`${src}/**/*.+(html|js|mjs)`, {
 		ignoreInitial: true,
 		persistent: false
 	});

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const glob = require('glob');
-const chokidar = require('chokidar');
 const { dev } = require('./config.js');
 
 let templates;
@@ -65,7 +64,7 @@ function create_templates() {
 create_templates();
 
 if (dev) {
-	const watcher = chokidar.watch('templates/**.html', {
+	const watcher = require('chokidar').watch('templates/**.html', {
 		ignoreInitial: true,
 		persistent: false
 	});

--- a/lib/utils/create_app.js
+++ b/lib/utils/create_app.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const chokidar = require('chokidar');
 const route_manager = require('../route_manager.js');
 const { src, entry, dev } = require('../config.js');
 
@@ -70,7 +69,7 @@ function create_app() {
 if (dev) {
 	route_manager.onchange(create_app);
 
-	const watcher = chokidar.watch(`templates/main.js`, {
+	const watcher = require('chokidar').watch(`templates/main.js`, {
 		ignoreInitial: true,
 		persistent: false
 	});


### PR DESCRIPTION
Chokidar has a heavy footprint & is an unnecessary price to pay in production since it's unused. The benefit is that initial boot time is reduced... _slightly_ but it's still a small win.

I discovered the same benefit during Taskr/Fly development: https://github.com/lukeed/taskr/issues/236