### PR TITLE
Add init option to control prefetching of routes

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,9 +1,10 @@
 import { detach, findAnchor, scroll_state, which } from './utils';
-import { Component, ComponentConstructor, Params, Query, Route, RouteData, ScrollPosition, Target } from './interfaces';
+import { Component, ComponentConstructor, Params, Query, Route, InitOpts, RouteData, ScrollPosition, Target } from './interfaces';
 
 export let component: Component;
 let target: Node;
 let routes: Route[];
+let initOpts: InitOpts;
 
 const history = typeof window !== 'undefined' ? window.history : {
 	pushState: (state: any, title: string, href: string) => {},
@@ -54,7 +55,9 @@ function render(Component: ComponentConstructor, data: any, scroll: ScrollPositi
 		}
 
 		// preload additional routes
-		routes.reduce((promise: Promise<any>, route) => promise.then(route.load), Promise.resolve());
+		if (initOpts.preloadRoutes) {
+			routes.reduce((promise: Promise<any>, route) => promise.then(route.load), Promise.resolve());
+		}
 	}
 
 	component = new Component({
@@ -190,9 +193,10 @@ function handle_touchstart_mouseover(event: MouseEvent | TouchEvent) {
 
 let inited: boolean;
 
-export function init(_target: Node, _routes: Route[]) {
+export function init(_target: Node, _routes: Route[], _initOpts: InitOpts = { preloadRoutes: true }) {
 	target = _target;
 	routes = _routes;
+	initOpts = _initOpts;
 
 	if (!inited) { // this check makes HMR possible
 		window.addEventListener('click', handle_click);

--- a/src/runtime/interfaces.ts
+++ b/src/runtime/interfaces.ts
@@ -17,6 +17,10 @@ export type Route = {
 	load: () => Promise<{ default: ComponentConstructor }>
 };
 
+export type InitOpts = {
+	preloadRoutes: boolean;
+};
+
 export type ScrollPosition = {
 	x: number;
 	y: number;


### PR DESCRIPTION
It might be a useful addition to add options to the `init` function. I think being able to control the initial prefetching of all routes would be powerful, because I like to e.g. add inlined image previews in my JS files, which results in quite a large initial download if all JS is fetched.