### PR TITLE
Explicitly load style-loader/css-loader deps

### DIFF
--- a/webpack/config.js
+++ b/webpack/config.js
@@ -6,7 +6,12 @@ module.exports = {
 	client: {
 		entry: () => {
 			return {
-				main: entry.client
+				main: [
+					entry.client,
+					// workaround for https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/456
+					'style-loader/lib/addStyles',
+					'css-loader/lib/css-base'
+				]
 			};
 		},
 


### PR DESCRIPTION
This appears to fix sveltejs/sapper-template#27. It's based on the proposed workaround in https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/456#issuecomment-340287722

The downside is that the production size of `main.js` appears to increase from 4.2KB to 6.2KB. On the other hand... async style loading actually works. 😅 I don't see any more console errors while clicking around in the production app.