### PR TITLE
Handle DELETE requests with del export

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -177,7 +177,11 @@ function get_route_handler(fn) {
 					}
 
 					else {
-						const handler = mod[req.method.toLowerCase()];
+						const method = req.method.toLowerCase();
+						// 'delete' cannot be exported from a module because it is a keyword, 
+						// so check for 'del' instead
+						const method_export = method === 'delete' ? 'del' : method;
+						const handler = mod[method_export];
 						if (handler) handler(req, res, next);
 					}
 


### PR DESCRIPTION
`export function delete(req, res) { /* ... */ }` throws a `Module parse failed: Unexpected token` error because `delete` is a reserved keyword.

This PR changes the handler of `DELETE` requests from `delete` to `del`, following the discussion in https://github.com/sveltejs/sapper/issues/77.