### PR TITLE
Recognize files with .ts file extension

### DIFF
--- a/lib/route_manager.js
+++ b/lib/route_manager.js
@@ -11,7 +11,7 @@ exports.onchange = fn => {
 
 function update() {
 	exports.routes = create_routes(
-		glob.sync('**/*.+(html|js|mjs)', { cwd: src })
+		glob.sync('**/*.+(html|js|mjs|ts)', { cwd: src })
 	);
 
 	callbacks.forEach(fn => fn());

--- a/lib/utils/create_routes.js
+++ b/lib/utils/create_routes.js
@@ -5,7 +5,7 @@ module.exports = function create_matchers(files) {
 		.map(file => {
 			if (/(^|\/|\\)_/.test(file)) return;
 
-			const parts = file.replace(/\.(html|js|mjs)$/, '').split('/'); // glob output is always posix-style
+			const parts = file.replace(/\.(html|js|mjs|ts)$/, '').split('/'); // glob output is always posix-style
 			if (parts[parts.length - 1] === 'index') parts.pop();
 
 			const id = (


### PR DESCRIPTION
Make it so that Sapper picks up non-component files with the `.ts` file extension.

Will bring TypeScript support to `sapper-template` in conjunction with https://github.com/sveltejs/sapper-template/pull/29.

This and https://github.com/sveltejs/sapper-template/pull/29 together resolve https://github.com/sveltejs/sapper/issues/57.