### PR TITLE
Hydrate on first load, not destroy

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -60,7 +60,7 @@ function render(Component: ComponentConstructor, data: any, scroll: ScrollPositi
 	component = new Component({
 		target,
 		data,
-		hydrate: !!component
+		hydrate: !component
 	});
 
 	if (scroll) {
@@ -73,7 +73,7 @@ function prepare_route(Component: ComponentConstructor, data: RouteData) {
 		return { Component, data };
 	}
 
-	if (!component && window.__SAPPER__ && window.__SAPPER__.preloaded) {
+	if (!component && window.__SAComponentPPER__ && window.__SAPPER__.preloaded) {
 		return { Component, data: Object.assign(data, window.__SAPPER__.preloaded) };
 	}
 

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -73,7 +73,7 @@ function prepare_route(Component: ComponentConstructor, data: RouteData) {
 		return { Component, data };
 	}
 
-	if (!component && window.__SAComponentPPER__ && window.__SAPPER__.preloaded) {
+	if (!component && window.__SAPPER__ && window.__SAPPER__.preloaded) {
 		return { Component, data: Object.assign(data, window.__SAPPER__.preloaded) };
 	}
 


### PR DESCRIPTION
I installed the svelte-hackernews project and put a trace on this line and saw that `hydrate` is false on the first load. The `component` var in the runtime is still undefined, so `!!component` evaluates to `false`. To hydrate on the first load, when `component` is `undefined`, it should be `!component`.

Can squash, if you merge.