### PR TITLE
Identify js and html route clashes

### DIFF
--- a/lib/utils/create_routes.js
+++ b/lib/utils/create_routes.js
@@ -78,7 +78,7 @@ module.exports = function create_matchers(files) {
 				const b_is_dynamic = b_part[0] === '[';
 
 				if (a_is_dynamic === b_is_dynamic) {
-					if (!a_is_dynamic) same = false;
+					if (!a_is_dynamic && a_part !== b_part) same = false;
 					continue;
 				}
 

--- a/test/unit/create_routes.test.js
+++ b/test/unit/create_routes.test.js
@@ -70,6 +70,10 @@ describe('create_routes', () => {
 		assert.throws(() => {
 			create_routes(['[foo].html', '[bar]/index.html']);
 		}, /The \[foo\].html and \[bar\]\/index.html routes clash/);
+
+		assert.throws(() => {
+			create_routes(['foo.html', 'foo.js']);
+		}, /The foo.html and foo.js routes clash/);
 	});
 
 	it('matches nested routes', () => {


### PR DESCRIPTION
This modifies `create_routes.js` slightly in order to catch clashing non-dynamic routes.

It's been also added to the unit tests.

(this would previously fail at runtime with multiple similarly named exports in the generated js)