### PR TITLE
Fix DOMException when location.hash is invalid selector

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -208,7 +208,7 @@ export function init(_target: Node, _routes: Route[]) {
 	setTimeout(() => {
 		const { hash, href } = window.location;
 
-		const deep_linked = hash && document.querySelector(hash);
+		const deep_linked = hash && document.getElementById(hash.slice(1));
 		scroll_history[uid] = deep_linked ?
 			{ x: 0, y: deep_linked.getBoundingClientRect().top } :
 			scroll_state();


### PR DESCRIPTION
While building an app that uses location.hash extensively, the following error occurred often:
`Uncaught DOMException: Failed to execute 'querySelector' on 'Document': '#' is not a valid selector.`

querySelector throws on invalid selectors, but getElementById doesn't throw on invalid ids.