### PR TITLE
Fix route not found when url is /?

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -125,7 +125,7 @@ function connect_prod() {
 export default dev ? connect_dev : connect_prod;
 
 function set_req_pathname(req, res, next) {
-	req.pathname = req.url.replace(/\?.+/, '');
+	req.pathname = req.url.replace(/\?.*/, '');
 	next();
 }
 


### PR DESCRIPTION
The regex should always remove the question mark, even when there is nothing behind it.

Alternative code without regex:
`req.url.slice(0, (req.url + '?').indexOf('?'))`