### PR TITLE
Add handlers for client css files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,16 @@ function connect_dev() {
 		}),
 
 		get_asset_handler({
-			filter: pathname => pathname.startsWith('/client/'),
+			filter: pathname => pathname.startsWith('/client/')
+				&& pathname.endsWith('.css'),
+			type: 'text/css',
+			cache: 'max-age=31536000',
+			fn: pathname => asset_cache.client.chunks[pathname]
+		}),
+
+		get_asset_handler({
+			filter: pathname => pathname.startsWith('/client/')
+				&& pathname.endsWith('.js'),
 			type: 'application/javascript',
 			cache: 'max-age=31536000',
 			fn: pathname => asset_cache.client.chunks[pathname]
@@ -91,7 +100,16 @@ function connect_prod() {
 		}),
 
 		get_asset_handler({
-			filter: pathname => pathname.startsWith('/client/'),
+			filter: pathname => pathname.startsWith('/client/')
+				&& pathname.endsWith('.css'),
+			type: 'text/css',
+			cache: 'max-age=31536000',
+			fn: pathname => asset_cache.client.chunks[pathname]
+		}),
+
+		get_asset_handler({
+			filter: pathname => pathname.startsWith('/client/')
+				&& pathname.endsWith('.js'),
 			type: 'application/javascript',
 			cache: 'max-age=31536000',
 			fn: pathname => asset_cache.client.chunks[pathname]


### PR DESCRIPTION
This paves the way for using styles created via ExtractTextPlugin. Before, any CSS files would be served with `application/javascript`, which caused them to not work.

This still requires some manual work in `templates/2xx.html`, as sapper doesn't yet automatically add links to the generated styles, so the user still has to do it themselves (`/client/main.css` in the case of the default sapper starter template).

```html
<link rel="stylesheet" href="/client/main.css" />
```

Alternatively, instead of merging this patch, one can tell ExtractTextPlugin to output to `../../assets/main.css` for example, and then change the href to simply `/main.css` (and add a .gitignore entry). This works, but it feels pretty dirty.