### PR TITLE
Fix query param handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sapper",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5437,6 +5437,11 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
+    "querystringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+      "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
+    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
@@ -5745,6 +5750,11 @@
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
       }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.5.0",
@@ -6638,6 +6648,15 @@
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
+      }
+    },
+    "url-parse": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
+      "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
+      "requires": {
+        "querystringify": "1.0.0",
+        "requires-port": "1.0.0"
       }
     },
     "util": {

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -28,8 +28,12 @@ function select_route(url: URL): Target {
 			const params = route.params(match);
 
 			const query: Record<string, string | true> = {};
-			for (const [key, value] of url.searchParams) query[key] = value || true;
-
+			if (url.search.length > 0) {
+			    url.search.slice(1).split('&').forEach(searchParam => {
+			        const [, key, value] = /([^=]+)=(.*)/.exec(searchParam);
+			        query[key] = value || true;
+			    })
+			}
 			return { url, route, data: { params, query } };
 		}
 	}


### PR DESCRIPTION
This will resolve rollup/rollupjs.org#118.

The issue is that URL.searchParams, which is an iterator, is traversed via a for-of loop. This, however, is transpiled under the assumption we are traversing an array (which of course fails). This PR does two things
* replace the for-of loop with a more old-fashioned Array.forEach
* does not rely on URL.searchParams which is only supported in rather new browsers (for instance not in IE11 which is still widely used in e.g. corporate environments) but uses plain old regular expressions to parse URL.search

I must admit I did not add a specific test yet (I'm not even sure this is possible for this kind of transpilation issue but I like to stand corrected), still I hope this gets merged soon. In the meantime I will try to directly reference the PR to make Rollup's REPL work again.