### PR TITLE
fixes api route default content-type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -136,6 +136,9 @@ function get_route_handler(fn) {
 		const mod = require(server.entry)[route.id];
 
 		if (route.type === 'page') {
+			// for page routes, we're going to serve some HTML
+			res.setHeader('Content-Type', 'text/html');
+			
 			// preload main.js and current route
 			// TODO detect other stuff we can preload? images, CSS, fonts?
 			res.setHeader('Link', `<${client.main_file}>;rel="preload";as="script", <${client.routes[route.id]}>;rel="preload";as="script"`);
@@ -195,9 +198,6 @@ function get_route_handler(fn) {
 
 	return function find_route(req, res, next) {
 		const url = req.pathname;
-
-		// whatever happens, we're going to serve some HTML
-		res.setHeader('Content-Type', 'text/html');
 
 		resolved
 			.then(() => {


### PR DESCRIPTION
fixes issue where api routes were being defaulted to text/html. Page routes should be text/html, but api routes could be json, zip files, etc., and express does some type-guessing to assist in case the user code does not specify the content-type.