### PR TITLE
Fix: Remove HMR attempts in Prod~!

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,10 +1,11 @@
 import { build, export as exporter } from 'sapper/core.js';
-import { dest, dev, entry, src } from '../config';
+import { dest, entry, isDev, src } from '../config';
 
 process.env.NODE_ENV = 'production';
 
 const cmd = process.argv[2];
 const start = Date.now();
+const dev = isDev();
 
 if (cmd === 'build') {
 	build({ dest, dev, entry, src })

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-export const dev = process.env.NODE_ENV !== 'production';
+export const isDev = () => process.env.NODE_ENV !== 'production';
 
 export const templates = path.resolve(process.env.SAPPER_TEMPLATES || 'templates');
 export const src = path.resolve(process.env.SAPPER_ROUTES || 'routes');

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -5,8 +5,10 @@ import rimraf from 'rimraf';
 import serialize from 'serialize-javascript';
 import escape_html from 'escape-html';
 import { create_routes, templates, create_compilers, create_assets } from 'sapper/core.js';
+import { dest, entry, isDev, src } from '../config';
 import create_watcher from './create_watcher';
-import { dest, dev, entry, src } from '../config';
+
+const dev = isDev();
 
 function connect_dev() {
 	mkdirp.sync(dest);

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -1,7 +1,7 @@
-import { dest, dev, entry } from '../config';
+import { dest, isDev, entry } from '../config';
 
 export default {
-	dev,
+	dev: isDev(),
 
 	client: {
 		entry: () => {


### PR DESCRIPTION
In production apps, there were still attempts made to `/__webpack_hmr`, which meant that the dev-entry was being included.

The short-fix was to modify the build script: `NODE_ENV=production sapper build` ... but that's still ugly & not the intended.

I added some debuggers and saw that the `dev` block of `create_app` was still running. Then took a look at the compiled `cli.js` output:

<img width="747" alt="screen shot 2018-02-05 at 2 09 04 pm" src="https://user-images.githubusercontent.com/5855893/35831467-a86af50c-0a7e-11e8-8ed2-3c5dd71528bc.png">

The `dev` check is made before manually setting the `NODE_ENV`. Also, because of Rollup's "import hoisting" (is that the term?) moving [this line](https://github.com/sveltejs/sapper/blob/master/src/cli/index.ts#L4) to the top of the file, ahead of the `dev` import, didn't affect the compiled output.

Simply converting `config.dev` to `config.isDev()` solves this, deferring the check until needed.

Now, `sapper build && sapper start` works as expected, while preserving HMR for dev-mode. 🎉 