### PR TITLE
ensure old server is killed before listening for port on new server

### DIFF
--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -137,14 +137,21 @@ export default async function dev(src: string, dir: string) {
 			fs.writeFileSync(path.join(dir, 'server_info.json'), JSON.stringify(server_info, null, '  '));
 
 			deferreds.client.promise.then(() => {
-				if (proc) proc.kill();
+				function restart() {
+					wait_for_port(3000, deferreds.server.fulfil); // TODO control port
+				}
+
+				if (proc) {
+					proc.kill();
+					proc.on('exit', restart);
+				} else {
+					restart();
+				}
 
 				proc = child_process.fork(`${dir}/server.js`, [], {
 					cwd: process.cwd(),
 					env: Object.assign({}, process.env)
 				});
-
-				wait_for_port(3000, deferreds.server.fulfil); // TODO control port
 			});
 		}
 	});


### PR DESCRIPTION
This fixes an awkward race condition in which `sapper dev` would listen for a port to be open, find that it was, and send an HMR update *before* the invalidated server had shut down, meaning that the client would open a connection (to get the hot update) that was immediately closed by the server being killed.

HMR appears to work much more reliably now.