### PR TITLE
handle case where webpack asset is an array instead of a string

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -122,7 +122,12 @@ function get_route_handler(chunks: Record<string, string>, routes: RouteObject[]
 
 			// preload main.js and current route
 			// TODO detect other stuff we can preload? images, CSS, fonts?
-			res.setHeader('Link', `</client/${chunks.main}>;rel="preload";as="script", </client/${chunks[route.id]}>;rel="preload";as="script"`);
+			const link = []
+				.concat(chunks.main, chunks[route.id])
+				.map(file => `</client/${file}>;rel="preload";as="script"`)
+				.join(', ');
+
+			res.setHeader('Link', link);
 
 			const data = { params: req.params, query: req.query };
 
@@ -159,7 +164,11 @@ function get_route_handler(chunks: Record<string, string>, routes: RouteObject[]
 
 				const { html, head, css } = mod.render(data);
 
-				let scripts = `<script src='/client/${chunks.main}'></script>`;
+				let scripts = []
+					.concat(chunks.main) // chunks main might be an array. it might not! thanks, webpack
+					.map(file => `<script src='/client/${file}'></script>`)
+					.join('');
+
 				scripts = `<script>__SAPPER__ = { preloaded: ${serialized} };</script>${scripts}`;
 
 				const page = template.render({


### PR DESCRIPTION
Sometimes the items in `client_info.assetsByChunkName` are strings. Sometimes they're arrays! What fun. In order to handle either scenario, we need to ensure that we're always dealing with arrays, and `[].concat(maybeArrayButMaybeNot)` is the easiest way to do that.

Related issue: https://github.com/sveltejs/sapper/issues/130