### PR TITLE
force NODE_ENV=production in build/export

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,6 +30,8 @@ const [cmd] = opts._;
 const start = Date.now();
 
 if (cmd === 'build') {
+	process.env.NODE_ENV = 'production';
+
 	build({ dest, dev: false, entry, src })
 		.then(() => {
 			const elapsed = Date.now() - start;
@@ -39,6 +41,8 @@ if (cmd === 'build') {
 			console.error(err ? err.details || err.stack || err.message || err : 'Unknown error');
 		});
 } else if (cmd === 'export') {
+	process.env.NODE_ENV = 'production';
+
 	build({ dest, dev: false, entry, src })
 		.then(() => exporter(dest))
 		.then(() => {

--- a/test/common/test.js
+++ b/test/common/test.js
@@ -389,7 +389,7 @@ function run(env) {
 					);
 
 					assert.ok(
-						/<\/client\/[^/]+\/main\.js>;rel="preload";as="script", <\/client\/[^/]+\/_\.0\.js>;rel="preload";as="script"/.test(headers['link']),
+						/<\/client\/[^/]+\/main\.js>;rel="preload";as="script", <\/client\/[^/]+\/_\.\d+\.js>;rel="preload";as="script"/.test(headers['link']),
 						headers['link']
 					);
 				});


### PR DESCRIPTION
This was broken between 0.6 and 0.7 😬 

fixes #141 