### PR TITLE
don't serve error page for unhandled server route errors

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -115,7 +115,7 @@ function get_asset_handler({ pathname, type, cache, body }: {
 const resolved = Promise.resolve();
 
 function get_route_handler(chunks: Record<string, string>, routes: RouteObject[], template: Template) {
-	function handle_route(route: RouteObject, req: Req, res: ServerResponse, next: () => void) {
+	function handle_route(route: RouteObject, req: Req, res: ServerResponse) {
 		req.params = route.params(route.pattern.exec(req.pathname));
 
 		const mod = route.module;
@@ -234,7 +234,7 @@ function get_route_handler(chunks: Record<string, string>, routes: RouteObject[]
 					};
 				}
 
-				const handle_error = err => {
+				const handle_error = (err?: Error) => {
 					if (err) {
 						console.error(err.stack);
 						res.statusCode = 500;
@@ -306,12 +306,12 @@ function get_route_handler(chunks: Record<string, string>, routes: RouteObject[]
 		}));
 	}
 
-	return function find_route(req: Req, res: ServerResponse, next: () => void) {
+	return function find_route(req: Req, res: ServerResponse) {
 		const url = req.pathname;
 
 		try {
 			for (const route of routes) {
-				if (!route.error && route.pattern.test(url)) return handle_route(route, req, res, next);
+				if (!route.error && route.pattern.test(url)) return handle_route(route, req, res);
 			}
 
 			handle_not_found(req, res, 404, 'Not found');

--- a/test/app/routes/throw-an-error.js
+++ b/test/app/routes/throw-an-error.js
@@ -1,0 +1,3 @@
+export function get() {
+	throw new Error('nope');
+}

--- a/test/common/test.js
+++ b/test/common/test.js
@@ -391,6 +391,14 @@ function run(env) {
 						JSON.parse(text);
 					});
 			});
+
+			it('does not serve error page for non-page errors', () => {
+				return nightmare.goto(`${base}/throw-an-error`)
+					.page.text()
+					.then(text => {
+						assert.equal(text, 'nope');
+					});
+			});
 		});
 
 		describe('headers', () => {


### PR DESCRIPTION
This addresses #138 — if a server route errors (or calls `next` with an error), Sapper will just serve the error message, rather than the `5xx.html` page.

Server routes should still handle their own errors, but this is probably a more sensible fallback.