### PR TITLE
vastly better logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "mkdirp": "^0.5.1",
     "mri": "^1.1.0",
     "node-fetch": "^1.7.3",
+    "pretty-ms": "^3.1.0",
     "relative": "^3.0.2",
     "require-relative": "^0.8.7",
     "rimraf": "^2.6.2",
@@ -39,7 +40,8 @@
     "source-map-support": "^0.5.3",
     "tslib": "^1.8.1",
     "url-parse": "^1.2.0",
-    "walk-sync": "^0.3.2"
+    "walk-sync": "^0.3.2",
+    "webpack-format-messages": "^1.0.1"
   },
   "devDependencies": {
     "@std/esm": "^0.19.7",
@@ -55,6 +57,7 @@
     "nightmare": "^2.10.0",
     "npm-run-all": "^4.1.2",
     "rollup": "^0.53.0",
+    "rollup-plugin-commonjs": "^8.3.0",
     "rollup-plugin-json": "^2.3.0",
     "rollup-plugin-string": "^2.0.2",
     "rollup-plugin-typescript": "^0.8.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import typescript from 'rollup-plugin-typescript';
 import string from 'rollup-plugin-string';
 import json from 'rollup-plugin-json';
+import commonjs from 'rollup-plugin-commonjs';
 import pkg from './package.json';
 
 const external = [].concat(
@@ -18,6 +19,7 @@ const plugins = [
 		include: '**/*.md'
 	}),
 	json(),
+	commonjs(),
 	typescript({
 		typescript: require('typescript')
 	})

--- a/test/common/test.js
+++ b/test/common/test.js
@@ -25,7 +25,7 @@ Nightmare.action('init', function(done) {
 
 function run(env) {
 	describe(`env=${env}`, function () {
-		this.timeout(20000);
+		this.timeout(30000);
 
 		let PORT;
 		let proc;


### PR DESCRIPTION
...or 'that feeling when @lukeed has already solved your problem'. This substantially improves the logging:

* warnings are actually shown (they were squelched before). Related: https://github.com/sveltejs/svelte-loader/issues/35
* errors and warnings are deduped (e.g. a component has a syntax error — we don't want to print the frame for both the server *and* the client compiler
* invalidations are printed to the console
* output is nicely colourised

There are lots of ways it could be improved further. It would be nice to separate server console logs from Sapper console logs, for example (some kind of split screen?). For people who want it, it would be nice to show the details of the webpack output. It would be very cool to integrate with something like [Jarvis](https://github.com/zouhir/jarvis) or [electron-webpack-dashboard](https://github.com/FormidableLabs/electron-webpack-dashboard), though that might be tricky when there are multiple webpack configs. (Maybe it makes sense to have a dedicated Sapper electron app?) For now though, this is a decent leap forward.