### PR TITLE
URI-encode routes

### DIFF
--- a/src/core/create_routes.ts
+++ b/src/core/create_routes.ts
@@ -33,8 +33,8 @@ export default function create_routes({ files } = { files: glob.sync('**/*.+(htm
 			let i = parts.length;
 			let nested = true;
 			while (i--) {
-				const part = parts[i];
-				const dynamic = part[0] === '[';
+				const part = encodeURIComponent(parts[i].normalize()).replace(/%5B/g, '[').replace(/%5D/g, ']');
+				const dynamic = ~part.indexOf('[');
 
 				if (dynamic) {
 					const matcher = part.replace(param_pattern, `([^\/]+?)`);

--- a/test/app/routes/fünke.html
+++ b/test/app/routes/fünke.html
@@ -1,0 +1,1 @@
+<h1>I'm afraid I just blue myself</h1>

--- a/test/common/test.js
+++ b/test/common/test.js
@@ -400,6 +400,14 @@ function run(env) {
 						assert.equal(text, 'nope');
 					});
 			});
+
+			it('encodes routes', () => {
+				return nightmare.goto(`${base}/fünke`)
+					.page.title()
+					.then(title => {
+						assert.equal(title, `I'm afraid I just blue myself`);
+					});
+			});
 		});
 
 		describe('headers', () => {


### PR DESCRIPTION
Fixes #103. Along the way I learned that `'fünke' !== 'fünke'` — you can represent ü as a single character, or as two separate code points. Turns out using `string.normalize()` gives you the version that actually works (thank god for Mathias, who has [figured all this stuff out](https://mathiasbynens.be/notes/javascript-unicode) so that we don't have to)