### PR TITLE
rename preloadRoutes to prefetchRoutes

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -266,7 +266,7 @@ export function goto(href: string, opts = { replaceState: false }) {
 	}
 }
 
-export function preloadRoutes(pathnames: string[]) {
+export function prefetchRoutes(pathnames: string[]) {
 	if (!routes) throw new Error(`You must call init() first`);
 
 	return routes
@@ -282,3 +282,6 @@ export function preloadRoutes(pathnames: string[]) {
 			return promise.then(route.load);
 		}, Promise.resolve());
 }
+
+// remove this in 0.9
+export { prefetchRoutes as preloadRoutes };

--- a/test/app/app/client.js
+++ b/test/app/app/client.js
@@ -1,8 +1,8 @@
-import { init, preloadRoutes } from '../../../runtime.js';
+import { init, prefetchRoutes } from '../../../runtime.js';
 import { routes } from './manifest/client.js';
 
 window.init = () => {
 	return init(document.querySelector('#sapper'), routes);
 };
 
-window.preloadRoutes = preloadRoutes;
+window.prefetchRoutes = prefetchRoutes;

--- a/test/common/test.js
+++ b/test/common/test.js
@@ -23,8 +23,8 @@ Nightmare.action('init', function(done) {
 	this.evaluate_now(() => window.init(), done);
 });
 
-Nightmare.action('preloadRoutes', function(done) {
-	this.evaluate_now(() => window.preloadRoutes(), done);
+Nightmare.action('prefetchRoutes', function(done) {
+	this.evaluate_now(() => window.prefetchRoutes(), done);
 });
 
 function run(env) {
@@ -159,7 +159,7 @@ function run(env) {
 			});
 
 			it('navigates to a new page without reloading', () => {
-				return capture(() => nightmare.goto(base).init().preloadRoutes())
+				return capture(() => nightmare.goto(base).init().prefetchRoutes())
 					.then(() => {
 						return capture(() => nightmare.click('a[href="/about"]'));
 					})


### PR DESCRIPTION
`preloadRoutes` is preserved until 0.9, in the spirit of semver.