### PR TITLE
fix route sorting

### DIFF
--- a/src/core/create_routes.ts
+++ b/src/core/create_routes.ts
@@ -74,30 +74,27 @@ export default function create_routes({ files } = { files: glob.sync('**/*.+(htm
 		})
 		.filter(Boolean)
 		.sort((a: Route, b: Route) => {
-			let same = true;
+			if (a.file === '4xx.html' || a.file === '5xx.html') return -1;
+			if (b.file === '4xx.html' || b.file === '5xx.html') return 1;
 
-			for (let i = 0; true; i += 1) {
+			const max = Math.max(a.parts.length, b.parts.length);
+
+			for (let i = 0; i < max; i += 1) {
 				const a_part = a.parts[i];
 				const b_part = b.parts[i];
-
-				if (!a_part && !b_part) {
-					if (same) throw new Error(`The ${a.file} and ${b.file} routes clash`);
-					return 0;
-				}
 
 				if (!a_part) return -1;
 				if (!b_part) return 1;
 
 				const a_sub_parts = get_sub_parts(a_part);
 				const b_sub_parts = get_sub_parts(b_part);
+				const max = Math.max(a_sub_parts.length, b_sub_parts.length);
 
-				for (let i = 0; true; i += 1) {
+				for (let i = 0; i < max; i += 1) {
 					const a_sub_part = a_sub_parts[i];
 					const b_sub_part = b_sub_parts[i];
 
-					if (!a_sub_part && !b_sub_part) break;
-
-					if (!a_sub_part) return 1; // note this is reversed from above — match [foo].json before [foo]
+					if (!a_sub_part) return 1; // b is more specific, so goes first
 					if (!b_sub_part) return -1;
 
 					if (a_sub_part.dynamic !== b_sub_part.dynamic) {
@@ -109,6 +106,8 @@ export default function create_routes({ files } = { files: glob.sync('**/*.+(htm
 					}
 				}
 			}
+
+			throw new Error(`The ${a.file} and ${b.file} routes clash`);
 		});
 
 	return routes;

--- a/test/unit/create_routes.test.js
+++ b/test/unit/create_routes.test.js
@@ -22,6 +22,41 @@ describe('create_routes', () => {
 		);
 	});
 
+	it('prefers index page to nested route', () => {
+		const routes = create_routes({
+			files: [
+				'api/examples/[slug].js',
+				'api/examples/index.js',
+				'blog/[slug].html',
+				'api/gists/[id].js',
+				'api/gists/index.js',
+				'4xx.html',
+				'5xx.html',
+				'blog/index.html',
+				'blog/rss.xml.js',
+				'guide/index.html',
+				'index.html'
+			]
+		});
+
+		assert.deepEqual(
+			routes.map(r => r.file),
+			[
+				'4xx.html',
+				'5xx.html',
+				'index.html',
+				'guide/index.html',
+				'blog/index.html',
+				'blog/rss.xml.js',
+				'blog/[slug].html',
+				'api/examples/index.js',
+				'api/examples/[slug].js',
+				'api/gists/index.js',
+				'api/gists/[id].js',
+			]
+		);
+	});
+
 	it('generates params', () => {
 		const routes = create_routes({
 			files: ['index.html', 'about.html', '[wildcard].html', 'post/[id].html']


### PR DESCRIPTION
Fixes a rare case where the sort comparator would erroneously return 0, causing situations where (for example) `foo/[id].js` would match before `foo.js` because they never got compared.