### PR TITLE
Fix hard-coded port

### DIFF
--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -210,7 +210,7 @@ export default async function dev(port: number) {
 
 			deferreds.client.promise.then(() => {
 				function restart() {
-					ports.wait(3000).then(deferreds.server.fulfil); // TODO control port
+					ports.wait(port).then(deferreds.server.fulfil);
 				}
 
 				if (proc) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,7 +17,9 @@ const prog = sade('sapper').version(pkg.version);
 prog.command('dev')
 	.describe('Start a development server')
 	.option('-p, --port', 'Specify a port')
-	.action(async ({ port }: { port: number }) => {
+	.action(async (opts: { port: number }) => {
+		let port = opts.port || +process.env.PORT;
+
 		if (port) {
 			if (!await ports.check(port)) {
 				console.log(chalk.bold.red(`> Port ${port} is unavailable`));
@@ -53,7 +55,9 @@ prog.command('build [dest]')
 prog.command('start [dir]')
 	.describe('Start your app')
 	.option('-p, --port', 'Specify a port')
-	.action(async (dir = 'build', { port }: { port: number }) => {
+	.action(async (dir = 'build', opts: { port: number }) => {
+		let port = opts.port || +process.env.PORT;
+
 		const resolved = path.resolve(dir);
 		const server = path.resolve(dir, 'server.js');
 


### PR DESCRIPTION
This removes the hard-coded port in `sapper dev`, and makes these equivalent:

```bash
PORT=4567 npx sapper dev
npx sapper dev --port 4567
```