### PR TITLE
use window.location.hostname in dev client

### DIFF
--- a/sapper-dev-client.js
+++ b/sapper-dev-client.js
@@ -11,7 +11,7 @@ function check() {
 export function connect(port) {
 	if (source || !window.EventSource) return;
 
-	source = new EventSource(`http://localhost:${port}/__sapper__`);
+	source = new EventSource(`http://${window.location.hostname}:${port}/__sapper__`);
 
 	window.source = source;
 


### PR DESCRIPTION
fixes #165. With this change, you can e.g. visit `http://192.168.x.x:3000` (or whatever the IP address for your dev machine is on some internal network) on another device, and HMR works perfectly