### PR TITLE
use wrong spelling of "grey"

### DIFF
--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -185,7 +185,7 @@ export default async function dev(port: number) {
 							console.log(`${hidden} duplicate ${hidden === 1 ? 'warning' : 'warnings'} hidden\n`);
 						}
 					} else {
-						console.log(`${clorox.bold.green(`✔ ${name}`)} ${clorox.grey(`(${prettyMs(info.time)})`)}`);
+						console.log(`${clorox.bold.green(`✔ ${name}`)} ${clorox.gray(`(${prettyMs(info.time)})`)}`);
 					}
 
 					result(info);


### PR DESCRIPTION
chalk offers `grey` as an alias for `gray` (though it should, of course, be the other way round; 'grey' is the correct spelling). clorox does not. hence this PR