### PR TITLE
allow server routes to be .ts files (or anything else)

### DIFF
--- a/src/core/create_routes.ts
+++ b/src/core/create_routes.ts
@@ -3,7 +3,7 @@ import glob from 'glob';
 import { src } from '../config';
 import { Route } from '../interfaces';
 
-export default function create_routes({ files } = { files: glob.sync('**/*.+(html|js|mjs)', { cwd: src() }) }) {
+export default function create_routes({ files } = { files: glob.sync('**/*.*', { cwd: src() }) }) {
 	const routes: Route[] = files
 		.map((file: string) => {
 			if (/(^|\/|\\)_/.test(file)) return;

--- a/src/core/create_routes.ts
+++ b/src/core/create_routes.ts
@@ -3,7 +3,7 @@ import glob from 'glob';
 import { src } from '../config';
 import { Route } from '../interfaces';
 
-export default function create_routes({ files } = { files: glob.sync('**/*.*', { cwd: src() }) }) {
+export default function create_routes({ files } = { files: glob.sync('**/*.*', { cwd: src(), nodir: true }) }) {
 	const routes: Route[] = files
 		.map((file: string) => {
 			if (/(^|\/|\\)_/.test(file)) return;

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -6,7 +6,7 @@ export default {
 	client: {
 		entry: () => {
 			return {
-				main: './app/client.js'
+				main: './app/client'
 			};
 		},
 
@@ -23,7 +23,7 @@ export default {
 	server: {
 		entry: () => {
 			return {
-				server: './app/server.js'
+				server: './app/server'
 			};
 		},
 
@@ -40,7 +40,7 @@ export default {
 	serviceworker: {
 		entry: () => {
 			return {
-				'service-worker': './app/service-worker.js'
+				'service-worker': './app/service-worker'
 			};
 		},
 


### PR DESCRIPTION
fixes #57. It still leaves a lot of stuff for the user to do, in terms of configuring webpack, but that shouldn't be a barrier for the sorts of people who want to use TypeScript in their apps.