### PR TITLE
implement --open

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,8 @@ const prog = sade('sapper').version(pkg.version);
 prog.command('dev')
 	.describe('Start a development server')
 	.option('-p, --port', 'Specify a port')
-	.action(async (opts: { port: number }) => {
+	.option('-o, --open', 'Open a browser window')
+	.action(async (opts: { port: number, open: boolean }) => {
 		const { dev } = await import('./cli/dev');
 		dev(opts);
 	});
@@ -40,7 +41,8 @@ prog.command('build [dest]')
 prog.command('start [dir]')
 	.describe('Start your app')
 	.option('-p, --port', 'Specify a port')
-	.action(async (dir = 'build', opts: { port: number }) => {
+	.option('-o, --open', 'Open a browser window')
+	.action(async (dir = 'build', opts: { port: number, open: boolean }) => {
 		const { start } = await import('./cli/start');
 		start(dir, opts);
 	});

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -70,7 +70,7 @@ function create_hot_update_server(port: number, interval = 10000) {
 	return { send };
 }
 
-export async function dev(opts: { port: number }) {
+export async function dev(opts: { port: number, open: boolean }) {
 	process.env.NODE_ENV = 'development';
 
 	let port = opts.port || +process.env.PORT;
@@ -241,6 +241,8 @@ export async function dev(opts: { port: number }) {
 		}
 	});
 
+	let first = true;
+
 	watch(compilers.client, {
 		name: 'client',
 
@@ -263,6 +265,12 @@ export async function dev(opts: { port: number }) {
 				hot_update_server.send({
 					status: 'completed'
 				});
+
+				if (first) {
+					first = false;
+					console.log(`${clorox.bold.cyan(`> Listening on localhost:${port}`)}`);
+					if (opts.open) child_process.exec(`open http://localhost:${port}`);
+				}
 			});
 
 			create_serviceworker_manifest({

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -4,7 +4,7 @@ import * as child_process from 'child_process';
 import * as clorox from 'clorox';
 import * as ports from 'port-authority';
 
-export async function start(dir: string, opts: { port: number }) {
+export async function start(dir: string, opts: { port: number, open: boolean }) {
 	let port = opts.port || +process.env.PORT;
 
 	const resolved = path.resolve(dir);
@@ -32,4 +32,8 @@ export async function start(dir: string, opts: { port: number }) {
 			SAPPER_DEST: dir
 		}, process.env)
 	});
+
+	await ports.wait(port);
+	console.log(`${clorox.bold.cyan(`> Listening on localhost:${port}`)}`);
+	if (opts.open) child_process.exec(`open http://localhost:${port}`);
 }


### PR DESCRIPTION
fixes #186. Also prints a 'Listening on localhost:${port}' message, which means we can remove the equivalent line from sapper-template.