### PR TITLE
workaround clorox bug

### DIFF
--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -21,12 +21,12 @@ export async function build() {
 	const { client, server, serviceworker } = create_compilers();
 
 	const client_stats = await compile(client);
-	console.log(clorox.inverse(`\nbuilt client`).toString());
+	console.log(`${clorox.inverse(`\nbuilt client`)}`);
 	console.log(client_stats.toString({ colors: true }));
 	fs.writeFileSync(path.join(output, 'client_info.json'), JSON.stringify(client_stats.toJson()));
 
 	const server_stats = await compile(server);
-	console.log(clorox.inverse(`\nbuilt server`).toString());
+	console.log(`${clorox.inverse(`\nbuilt server`)}`);
 	console.log(server_stats.toString({ colors: true }));
 
 	let serviceworker_stats;
@@ -38,7 +38,7 @@ export async function build() {
 		});
 
 		serviceworker_stats = await compile(serviceworker);
-		console.log(clorox.inverse(`\nbuilt service worker`).toString());
+		console.log(`${clorox.inverse(`\nbuilt service worker`)}`);
 		console.log(serviceworker_stats.toString({ colors: true }));
 	}
 

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -77,7 +77,7 @@ export async function dev(opts: { port: number, open: boolean }) {
 
 	if (port) {
 		if (!await ports.check(port)) {
-			console.log(clorox.bold.red(`> Port ${port} is unavailable`));
+			console.log(`${clorox.bold.red(`> Port ${port} is unavailable`)}`);
 			return;
 		}
 	} else {
@@ -155,15 +155,15 @@ export async function dev(opts: { port: number, open: boolean }) {
 
 		compiler.watch({}, (err: Error, stats: any) => {
 			if (err) {
-				console.error(clorox.red(`✗ ${name}`));
-				console.error(clorox.red(err.message));
+				console.log(`${clorox.red(`✗ ${name}`)}`);
+				console.log(`${clorox.red(err.message)}`);
 				error(err);
 			} else {
 				const messages = format_messages(stats);
 				const info = stats.toJson();
 
 				if (messages.errors.length > 0) {
-					console.log(clorox.bold.red(`✗ ${name}`));
+					console.log(`${clorox.bold.red(`✗ ${name}`)}`);
 
 					const filtered = messages.errors.filter((message: string) => {
 						return !build.unique_errors.has(message);
@@ -180,7 +180,7 @@ export async function dev(opts: { port: number, open: boolean }) {
 					}
 				} else {
 					if (messages.warnings.length > 0) {
-						console.log(clorox.bold.yellow(`• ${name}`));
+						console.log(`${clorox.bold.yellow(`• ${name}`)}`);
 
 						const filtered = messages.warnings.filter((message: string) => {
 							return !build.unique_warnings.has(message);

--- a/src/cli/export.ts
+++ b/src/cli/export.ts
@@ -85,7 +85,7 @@ export async function exporter(export_dir: string) {
 				}
 			})
 			.catch((err: Error) => {
-				console.log(clorox.red(`> Error rendering ${url.pathname}: ${err.message}`));
+				console.log(`${clorox.red(`> Error rendering ${url.pathname}: ${err.message}`)}`);
 			});
 	}
 

--- a/src/cli/upgrade.ts
+++ b/src/cli/upgrade.ts
@@ -27,10 +27,10 @@ async function upgrade_sapper_main() {
 
 		if (/\%sapper\.main\%/.test(template)) {
 			if (!pattern.test(template)) {
-				console.log(clorox.red(`Could not replace %sapper.main% in ${file}`));
+				console.log(`${clorox.red(`Could not replace %sapper.main% in ${file}`)}`);
 			} else {
 				write(file, template.replace(pattern, `%sapper.scripts%`));
-				console.log(clorox.green(`Replaced %sapper.main% in ${file}`));
+				console.log(`${clorox.green(`Replaced %sapper.main% in ${file}`)}`);
 				replaced = true;
 			}
 		}


### PR DESCRIPTION
`console.log(clorox.red('string'))` prints

```
{ [Function: clorox] toString: [Function] }
```

instead of a red string. This works around it