### PR TITLE
implement this.fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "cheerio": "^1.0.0-rc.2",
     "chokidar": "^2.0.2",
     "clorox": "^1.0.3",
+    "cookie": "^0.3.1",
     "devalue": "^1.0.1",
     "glob": "^7.1.2",
     "html-minifier": "^3.5.11",

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -92,6 +92,8 @@ function prepare_route(Component: ComponentConstructor, data: RouteData) {
 	}
 
 	return Promise.resolve(Component.preload.call({
+		store,
+		fetch: (url: string, opts?: any) => window.fetch(url, opts),
 		redirect: (statusCode: number, location: string) => {
 			redirect = { statusCode, location };
 		},

--- a/test/app/app/server.js
+++ b/test/app/app/server.js
@@ -43,6 +43,13 @@ global.fetch = (url, opts) => {
 const middlewares = [
 	serve('assets'),
 
+	// set test cookie
+	(req, res, next) => {
+		res.setHeader('Set-Cookie', 'test=woohoo!; Max-Age=3600');
+		next();
+	},
+
+	// emit messages so we can capture requests
 	(req, res, next) => {
 		if (!pending) return next();
 

--- a/test/app/routes/credentials/index.html
+++ b/test/app/routes/credentials/index.html
@@ -1,0 +1,12 @@
+<h1>{{message}}</h1>
+
+<script>
+	export default {
+		preload({ query }) {
+			console.log(`here ${this.fetch}`);
+			return this.fetch(`credentials/test.json`, {
+				credentials: query.creds
+			}).then(r => r.json());
+		}
+	};
+</script>

--- a/test/app/routes/credentials/test.json.js
+++ b/test/app/routes/credentials/test.json.js
@@ -1,0 +1,28 @@
+export function get(req, res) {
+	const cookies = req.headers.cookie
+		? req.headers.cookie.split(/,\s+/).reduce((cookies, cookie) => {
+			const [pair] = cookie.split('; ');
+			const [name, value] = pair.split('=');
+			cookies[name] = value;
+			return cookies;
+		}, {})
+		: {};
+
+	if (cookies.test) {
+		res.writeHead(200, {
+			'Content-Type': 'application/json'
+		});
+
+		res.end(JSON.stringify({
+			message: cookies.test
+		}));
+	} else {
+		res.writeHead(403, {
+			'Content-Type': 'application/json'
+		});
+
+		res.end(JSON.stringify({
+			message: 'unauthorized'
+		}));
+	}
+}

--- a/test/app/routes/index.html
+++ b/test/app/routes/index.html
@@ -10,6 +10,7 @@
 <a href='redirect-from'>redirect</a>
 <a href='blog/nope'>broken link</a>
 <a href='blog/throw-an-error'>error link</a>
+<a href='credentials?creds=include'>credentials</a>
 <a rel=prefetch class='{{page === "blog"  ? "selected" : ""}}' href='blog'>blog</a>
 
 <div class='hydrate-test'></div>

--- a/test/common/test.js
+++ b/test/common/test.js
@@ -533,6 +533,32 @@ function run({ mode, basepath = '' }) {
 						assert.equal(title, 'Stored title');
 					});
 			});
+
+			it('sends cookies when using this.fetch with credentials: "include"', () => {
+				return nightmare.goto(`${base}/credentials?creds=include`)
+					.page.title()
+					.then(title => {
+						assert.equal(title, 'woohoo!');
+					});
+			});
+
+			it('does not send cookies when using this.fetch without credentials', () => {
+				return nightmare.goto(`${base}/credentials`)
+					.page.title()
+					.then(title => {
+						assert.equal(title, 'unauthorized');
+					});
+			});
+
+			it('delegates to fetch on the client', () => {
+				return nightmare.goto(base).init()
+					.click('[href="credentials?creds=include"]')
+					.wait(100)
+					.page.title()
+					.then(title => {
+						assert.equal(title, 'woohoo!');
+					});
+			});
 		});
 
 		describe('headers', () => {


### PR DESCRIPTION
The second half of #178. With this PR, `preload` functions can use `this.fetch` to fetch resources. URLs are resolved against the local server, and if `credentials` is set to `include` or `same-origin`, cookies (including cookies that are about to be sent to the client) will be included.

On the client, `this.fetch` is just an alias for `window.fetch`.

I opted for `this.fetch` (rather than a) polluting the request object or b) introducing a second argument to `preload`) because it means that the preload context (which now includes `fetch`, `store`, `error` and `redirect`) is something that can easily be passed around (e.g. to a set of API helpers). 