### PR TITLE
Add support for sourcemap *.map files

### DIFF
--- a/src/cli/export.ts
+++ b/src/cli/export.ts
@@ -25,6 +25,10 @@ export async function exporter(export_dir: string, { basepath = '' }) {
 		sander.copyFileSync(build_dir, 'service-worker.js').to(export_dir, 'service-worker.js');
 	}
 
+	if (sander.existsSync(build_dir, 'service-worker.js.map')) {
+		sander.copyFileSync(build_dir, 'service-worker.js.map').to(export_dir, 'service-worker.js.map');
+	}
+
 	const port = await ports.find(3000);
 
 	const origin = `http://localhost:${port}`;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -149,6 +149,7 @@ function get_route_handler(chunks: Record<string, string>, routes: RouteObject[]
 			// TODO detect other stuff we can preload? images, CSS, fonts?
 			const link = []
 				.concat(chunks.main, chunks[route.id])
+				.filter(file => !file.match(/\.map$/))
 				.map(file => `<${req.baseUrl}/client/${file}>;rel="preload";as="script"`)
 				.join(', ');
 
@@ -198,7 +199,7 @@ function get_route_handler(chunks: Record<string, string>, routes: RouteObject[]
 
 				let scripts = []
 					.concat(chunks.main) // chunks main might be an array. it might not! thanks, webpack
-					.filter(function (file) { return !file.match(/\.map$/); })
+					.filter(file => !file.match(/\.map$/))
 					.map(file => `<script src='${req.baseUrl}/client/${file}'></script>`)
 					.join('');
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -193,6 +193,7 @@ function get_route_handler(chunks: Record<string, string>, routes: RouteObject[]
 
 				let scripts = []
 					.concat(chunks.main) // chunks main might be an array. it might not! thanks, webpack
+					.filter(function (file) { return !file.match(/\.map$/); })
 					.map(file => `<script src='${req.baseUrl}/client/${file}'></script>`)
 					.join('');
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -77,6 +77,11 @@ export default function middleware({ routes, store }: {
 			cache_control: 'max-age=600'
 		}),
 
+		fs.existsSync(path.join(output, 'service-worker.js.map')) && serve({
+			pathname: '/service-worker.js.map',
+			cache_control: 'max-age=600'
+		}),
+
 		serve({
 			prefix: '/client/',
 			cache_control: 'max-age=31536000'

--- a/src/middleware/mime-types.md
+++ b/src/middleware/mime-types.md
@@ -29,7 +29,7 @@ application/java-archive			jar
 application/java-serialized-object		ser
 application/java-vm				class
 application/javascript				js
-application/json				json
+application/json				json map
 application/jsonml+json				jsonml
 application/lost+xml				lostxml
 application/mac-binhex40			hqx


### PR DESCRIPTION
For some apps I'd like to enable source maps in production. However this causes the following output for `%sapper.scripts%`:

```html
<script src='/client/<hash>/main.js'></script>
<script src='/client/<hash>/main.js.map'></script>
```

This PR fixes it so that Sapper outputs:

```html
<script src='/client/<hash>/main.js'></script>
```