### PR TITLE
Stable sort

### DIFF
--- a/src/core/create_routes.ts
+++ b/src/core/create_routes.ts
@@ -102,7 +102,10 @@ export default function create_routes({ files } = { files: glob.sync('**/*.*', {
 					}
 
 					if (!a_sub_part.dynamic && a_sub_part.content !== b_sub_part.content) {
-						return b_sub_part.content.length - a_sub_part.content.length;
+						return (
+							(b_sub_part.content.length - a_sub_part.content.length) ||
+							(a_sub_part.content < b_sub_part.content ? -1 : 1)
+						);
 					}
 				}
 			}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -356,6 +356,8 @@ function get_route_handler(chunks: Record<string, string>, routes: RouteObject[]
 		const rendered = route ? route.module.render({
 			status: statusCode,
 			error
+		}, {
+			store: store_getter && store_getter(req)
 		}) : { head: '', css: null, html: title };
 
 		const { head, css, html } = rendered;

--- a/test/unit/create_routes.test.js
+++ b/test/unit/create_routes.test.js
@@ -12,8 +12,8 @@ describe('create_routes', () => {
 			[
 				'index.html',
 				'about.html',
-				'post/foo.html',
 				'post/bar.html',
+				'post/foo.html',
 				'post/f[xx].html',
 				'post/[id].json.js',
 				'post/[id].html',
@@ -23,7 +23,7 @@ describe('create_routes', () => {
 	});
 
 	it('prefers index page to nested route', () => {
-		const routes = create_routes({
+		let routes = create_routes({
 			files: [
 				'api/examples/[slug].js',
 				'api/examples/index.js',
@@ -53,6 +53,45 @@ describe('create_routes', () => {
 				'api/examples/[slug].js',
 				'api/gists/index.js',
 				'api/gists/[id].js',
+			]
+		);
+
+		routes = create_routes({
+			files: [
+				'4xx.html',
+				'5xx.html',
+				'api/blog/[slug].js',
+				'api/blog/index.js',
+				'api/guide/contents.js',
+				'api/guide/index.js',
+				'blog/[slug].html',
+				'blog/index.html',
+				'blog/rss.xml.js',
+				'gist/[id].js',
+				'gist/create.js',
+				'guide/index.html',
+				'index.html',
+				'repl/index.html'
+			]
+		});
+
+		assert.deepEqual(
+			routes.map(r => r.file),
+			[
+				'4xx.html',
+				'5xx.html',
+				'index.html',
+				'guide/index.html',
+				'blog/index.html',
+				'blog/rss.xml.js',
+				'blog/[slug].html',
+				'gist/create.js',
+				'gist/[id].js',
+				'repl/index.html',
+				'api/guide/index.js',
+				'api/guide/contents.js',
+				'api/blog/index.js',
+				'api/blog/[slug].js',
 			]
 		);
 	});


### PR DESCRIPTION
Found a situation in which route sorting could be unstable, resulting in incorrect navigation. This fixes it. Also includes an unrelated commit I'd forgotten about, which binds `store` to error pages