### PR TITLE
feature(service-worker): Allow disabling service-worker with DISABLE_SERVICE_WORKER environment variable

### DIFF
--- a/src/core/create_compilers.ts
+++ b/src/core/create_compilers.ts
@@ -4,7 +4,7 @@ import relative from 'require-relative';
 export default function create_compilers() {
 	const webpack = relative('webpack', process.cwd());
 
-	const serviceworker_config = try_require(path.resolve('webpack/service-worker.config.js'));
+	const serviceworker_config = !process.env.DISABLE_SERVICE_WORKER && try_require(path.resolve('webpack/service-worker.config.js'));
 
 	return {
 		client: webpack(


### PR DESCRIPTION
feature(service-worker): Allow disabling service-worker with `DISABLE_SERVICE_WORKER` environment variable.

This feature allows to disable service workers, when starting sapper. e.g. `DISABLE_SERVICE_WORKER=true sapper dev`

This can make sense if you're developing and unreliable cache invalidation breaks your development experience, since service workers can break the refresh button: https://redfin.engineering/service-workers-break-the-browsers-refresh-button-by-default-here-s-why-56f9417694

I know this does not solve the problem, but might be useful if you don't want to hassle with the refreshing behavior of your browser.

@Rich-Harris If you think this deserves to be set in a different way, let me know and I'll change it.