### PR TITLE
Include process.env in exporter server options

### DIFF
--- a/src/cli/export.ts
+++ b/src/cli/export.ts
@@ -35,12 +35,12 @@ export async function exporter(export_dir: string, { basepath = '' }) {
 
 	const proc = child_process.fork(path.resolve(`${build_dir}/server.js`), [], {
 		cwd: process.cwd(),
-		env: Object.assign({}, process.env, {
+		env: Object.assign({
 			PORT: port,
 			NODE_ENV: 'production',
 			SAPPER_DEST: build_dir,
 			SAPPER_EXPORT: 'true'
-		})
+		}, process.env)
 	});
 
 	const seen = new Set();

--- a/src/cli/export.ts
+++ b/src/cli/export.ts
@@ -35,12 +35,12 @@ export async function exporter(export_dir: string, { basepath = '' }) {
 
 	const proc = child_process.fork(path.resolve(`${build_dir}/server.js`), [], {
 		cwd: process.cwd(),
-		env: {
+		env: Object.assign({}, process.env, {
 			PORT: port,
 			NODE_ENV: 'production',
 			SAPPER_DEST: build_dir,
 			SAPPER_EXPORT: 'true'
-		}
+		})
 	});
 
 	const seen = new Set();


### PR DESCRIPTION
I ran into a problem deploying with up where having access to an environment variable for flow control would make solving the problem easy. I think it would useful in other environments or for other reasons also; and not needing to `if (!process.env.MISSING) ...` to ensure the export won't fail when things still run fine in development.