### PR TITLE
allow process.env.NODE_ENV to be overridden when building

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ prog.command('build [dest]')
 	.action(async (dest = 'build') => {
 		console.log(`> Building...`);
 
-		process.env.NODE_ENV = 'production';
+		process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 		process.env.SAPPER_DEST = dest;
 
 		const start = Date.now();


### PR DESCRIPTION
fixes #241 