### PR TITLE
only save the bits of client_info we need

### DIFF
--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -35,7 +35,9 @@ export async function build() {
 	const client_stats = await compile(client);
 	console.log(`${clorox.inverse(`\nbuilt client`)}`);
 	console.log(client_stats.toString({ colors: true }));
-	fs.writeFileSync(path.join(output, 'client_info.json'), JSON.stringify(client_stats.toJson()));
+	fs.writeFileSync(path.join(output, 'client_info.json'), JSON.stringify({
+		assets: client_stats.toJson().assetsByChunkName
+	}));
 
 	const server_stats = await compile(server);
 	console.log(`${clorox.inverse(`\nbuilt server`)}`);

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -263,7 +263,9 @@ export async function dev(opts: { port: number, open: boolean }) {
 		},
 
 		result: info => {
-			fs.writeFileSync(path.join(dir, 'client_info.json'), JSON.stringify(info, null, '  '));
+			fs.writeFileSync(path.join(dir, 'client_info.json'), JSON.stringify({
+				assets: info.assetsByChunkName
+			}, null, '  '));
 			deferreds.client.fulfil();
 
 			const client_files = info.assets.map((chunk: { name: string }) => `client/${chunk.name}`);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -90,7 +90,7 @@ export default function middleware({ routes, store }: {
 			cache_control: 'max-age=31536000'
 		}),
 
-		get_route_handler(client_info.assetsByChunkName, routes, store)
+		get_route_handler(client_info.assets, routes, store)
 	].filter(Boolean));
 
 	return middleware;


### PR DESCRIPTION
For many apps — certainly for svelte.technology — the `client_info.json` file is the largest file, taking up a lot of unnecessary space. With this PR, it just extracts the parts we're actually using in the middleware.