### PR TITLE
Update colors dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "test": "test"
   },
   "dependencies": {
+    "ansi-colors": "^2.0.1",
     "cheerio": "^1.0.0-rc.2",
     "chokidar": "^2.0.3",
-    "clorox": "^1.0.3",
     "cookie": "^0.3.1",
     "devalue": "^1.0.1",
     "glob": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "source-map-support": "^0.5.5",
     "tslib": "^1.9.0",
     "url-parse": "^1.2.0",
-    "webpack-format-messages": "^1.0.2"
+    "webpack-format-messages": "^2.0.1"
   },
   "devDependencies": {
     "@types/glob": "^5.0.34",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as child_process from 'child_process';
 import sade from 'sade';
-import * as clorox from 'clorox';
+import * as colors from 'ansi-colors';
 import prettyMs from 'pretty-ms';
 // import upgrade from './cli/upgrade';
 import * as ports from 'port-authority';
@@ -47,7 +47,7 @@ prog.command('build [dest]')
 				require('./server.js');
 			`.replace(/^\t+/gm, '').trim());
 
-			console.error(`\n> Finished in ${elapsed(start)}. Type ${clorox.bold.cyan(`node ${dest}`)} to run the app.`);
+			console.error(`\n> Finished in ${elapsed(start)}. Type ${colors.bold.cyan(`node ${dest}`)} to run the app.`);
 		} catch (err) {
 			console.error(err ? err.details || err.stack || err.message || err : 'Unknown error');
 			process.exit(1);
@@ -81,7 +81,7 @@ prog.command('export [dest]')
 
 			const { exporter } = await import('./cli/export');
 			await exporter(dest, opts);
-			console.error(`\n> Finished in ${elapsed(start)}. Type ${clorox.bold.cyan(`npx serve ${dest}`)} to run the app.`);
+			console.error(`\n> Finished in ${elapsed(start)}. Type ${colors.bold.cyan(`npx serve ${dest}`)} to run the app.`);
 		} catch (err) {
 			console.error(err ? err.details || err.stack || err.message || err : 'Unknown error');
 			process.exit(1);

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as clorox from 'clorox';
+import * as colors from 'ansi-colors';
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
 import { minify_html } from './utils/minify_html';
@@ -19,7 +19,7 @@ export async function build() {
 
 	// remove this in a future version
 	if (template.indexOf('%sapper.base%') === -1) {
-		console.log(`${clorox.bold.red(`> As of Sapper v0.10, your template.html file must include %sapper.base% in the <head>`)}`);
+		console.log(`${colors.bold.red(`> As of Sapper v0.10, your template.html file must include %sapper.base% in the <head>`)}`);
 		process.exit(1);
 	}
 
@@ -33,14 +33,14 @@ export async function build() {
 	const { client, server, serviceworker } = create_compilers();
 
 	const client_stats = await compile(client);
-	console.log(`${clorox.inverse(`\nbuilt client`)}`);
+	console.log(`${colors.inverse(`\nbuilt client`)}`);
 	console.log(client_stats.toString({ colors: true }));
 	fs.writeFileSync(path.join(output, 'client_info.json'), JSON.stringify({
 		assets: client_stats.toJson().assetsByChunkName
 	}));
 
 	const server_stats = await compile(server);
-	console.log(`${clorox.inverse(`\nbuilt server`)}`);
+	console.log(`${colors.inverse(`\nbuilt server`)}`);
 	console.log(server_stats.toString({ colors: true }));
 
 	let serviceworker_stats;
@@ -52,7 +52,7 @@ export async function build() {
 		});
 
 		serviceworker_stats = await compile(serviceworker);
-		console.log(`${clorox.inverse(`\nbuilt service worker`)}`);
+		console.log(`${colors.inverse(`\nbuilt service worker`)}`);
 		console.log(serviceworker_stats.toString({ colors: true }));
 	}
 }

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as net from 'net';
-import * as clorox from 'clorox';
+import * as colors from 'ansi-colors';
 import * as child_process from 'child_process';
 import * as http from 'http';
 import mkdirp from 'mkdirp';
@@ -74,7 +74,7 @@ export async function dev(opts: { port: number, open: boolean }) {
 	// remove this in a future version
 	const template = fs.readFileSync(path.join(locations.app(), 'template.html'), 'utf-8');
 	if (template.indexOf('%sapper.base%') === -1) {
-		console.log(`${clorox.bold.red(`> As of Sapper v0.10, your template.html file must include %sapper.base% in the <head>`)}`);
+		console.log(`${colors.bold.red(`> As of Sapper v0.10, your template.html file must include %sapper.base% in the <head>`)}`);
 		process.exit(1);
 	}
 
@@ -84,7 +84,7 @@ export async function dev(opts: { port: number, open: boolean }) {
 
 	if (port) {
 		if (!await ports.check(port)) {
-			console.log(`${clorox.bold.red(`> Port ${port} is unavailable`)}`);
+			console.log(`${colors.bold.red(`> Port ${port} is unavailable`)}`);
 			return;
 		}
 	} else {
@@ -144,7 +144,7 @@ export async function dev(opts: { port: number, open: boolean }) {
 			restarting = false;
 		});
 
-		console.log(`\n${clorox.bold.cyan(path.relative(process.cwd(), filename))} changed. rebuilding...`);
+		console.log(`\n${colors.bold.cyan(path.relative(process.cwd(), filename))} changed. rebuilding...`);
 	}
 
 	// TODO watch the configs themselves?
@@ -162,15 +162,15 @@ export async function dev(opts: { port: number, open: boolean }) {
 
 		compiler.watch({}, (err: Error, stats: any) => {
 			if (err) {
-				console.log(`${clorox.red(`✗ ${name}`)}`);
-				console.log(`${clorox.red(err.message)}`);
+				console.log(`${colors.red(`✗ ${name}`)}`);
+				console.log(`${colors.red(err.message)}`);
 				error(err);
 			} else {
 				const messages = format_messages(stats);
 				const info = stats.toJson();
 
 				if (messages.errors.length > 0) {
-					console.log(`${clorox.bold.red(`✗ ${name}`)}`);
+					console.log(`${colors.bold.red(`✗ ${name}`)}`);
 
 					const filtered = messages.errors.filter((message: string) => {
 						return !build.unique_errors.has(message);
@@ -187,7 +187,7 @@ export async function dev(opts: { port: number, open: boolean }) {
 					}
 				} else {
 					if (messages.warnings.length > 0) {
-						console.log(`${clorox.bold.yellow(`• ${name}`)}`);
+						console.log(`${colors.bold.yellow(`• ${name}`)}`);
 
 						const filtered = messages.warnings.filter((message: string) => {
 							return !build.unique_warnings.has(message);
@@ -203,7 +203,7 @@ export async function dev(opts: { port: number, open: boolean }) {
 							console.log(`${hidden} duplicate ${hidden === 1 ? 'warning' : 'warnings'} hidden\n`);
 						}
 					} else {
-						console.log(`${clorox.bold.green(`✔ ${name}`)} ${clorox.gray(`(${prettyMs(info.time)})`)}`);
+						console.log(`${colors.bold.green(`✔ ${name}`)} ${colors.gray(`(${prettyMs(info.time)})`)}`);
 					}
 
 					result(info);
@@ -277,7 +277,7 @@ export async function dev(opts: { port: number, open: boolean }) {
 
 				if (first) {
 					first = false;
-					console.log(`${clorox.bold.cyan(`> Listening on http://localhost:${port}`)}`);
+					console.log(`${colors.bold.cyan(`> Listening on http://localhost:${port}`)}`);
 					if (opts.open) child_process.exec(`open http://localhost:${port}`);
 				}
 			});

--- a/src/cli/export.ts
+++ b/src/cli/export.ts
@@ -1,7 +1,7 @@
 import * as child_process from 'child_process';
 import * as path from 'path';
 import * as sander from 'sander';
-import * as clorox from 'clorox';
+import * as colors from 'ansi-colors';
 import cheerio from 'cheerio';
 import URL from 'url-parse';
 import fetch from 'node-fetch';
@@ -62,7 +62,7 @@ export async function exporter(export_dir: string, { basepath = '' }) {
 			body = minify_html(body);
 		}
 
-		console.log(`${clorox.bold.cyan(file)} ${clorox.gray(`(${prettyBytes(body.length)})`)}`);
+		console.log(`${colors.bold.cyan(file)} ${colors.gray(`(${prettyBytes(body.length)})`)}`);
 
 		sander.writeFileSync(export_dir, file, body);
 	});
@@ -72,7 +72,7 @@ export async function exporter(export_dir: string, { basepath = '' }) {
 		const range = ~~(r.status / 100);
 
 		if (range >= 4) {
-			console.log(`${clorox.red(`> Received ${r.status} response when fetching ${url.pathname}`)}`);
+			console.log(`${colors.red(`> Received ${r.status} response when fetching ${url.pathname}`)}`);
 			return;
 		}
 

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as child_process from 'child_process';
-import * as clorox from 'clorox';
+import * as colors from 'ansi-colors';
 import * as ports from 'port-authority';
 
 export async function start(dir: string, opts: { port: number, open: boolean }) {
@@ -11,13 +11,13 @@ export async function start(dir: string, opts: { port: number, open: boolean }) 
 	const server = path.resolve(dir, 'server.js');
 
 	if (!fs.existsSync(server)) {
-		console.log(`${clorox.bold.red(`> ${dir}/server.js does not exist — type ${clorox.bold.cyan(dir === 'build' ? `npx sapper build` : `npx sapper build ${dir}`)} to create it`)}`);
+		console.log(`${colors.bold.red(`> ${dir}/server.js does not exist — type ${colors.bold.cyan(dir === 'build' ? `npx sapper build` : `npx sapper build ${dir}`)} to create it`)}`);
 		return;
 	}
 
 	if (port) {
 		if (!await ports.check(port)) {
-			console.log(`${clorox.bold.red(`> Port ${port} is unavailable`)}`);
+			console.log(`${colors.bold.red(`> Port ${port} is unavailable`)}`);
 			return;
 		}
 	} else {
@@ -34,6 +34,6 @@ export async function start(dir: string, opts: { port: number, open: boolean }) 
 	});
 
 	await ports.wait(port);
-	console.log(`${clorox.bold.cyan(`> Listening on http://localhost:${port}`)}`);
+	console.log(`${colors.bold.cyan(`> Listening on http://localhost:${port}`)}`);
 	if (opts.open) child_process.exec(`open http://localhost:${port}`);
 }

--- a/src/cli/upgrade.ts
+++ b/src/cli/upgrade.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import * as clorox from 'clorox';
+import * as colors from 'ansi-colors';
 
 export default async function upgrade() {
 	const upgraded = [
@@ -27,10 +27,10 @@ async function upgrade_sapper_main() {
 
 		if (/\%sapper\.main\%/.test(template)) {
 			if (!pattern.test(template)) {
-				console.log(`${clorox.red(`Could not replace %sapper.main% in ${file}`)}`);
+				console.log(`${colors.red(`Could not replace %sapper.main% in ${file}`)}`);
 			} else {
 				write(file, template.replace(pattern, `%sapper.scripts%`));
-				console.log(`${clorox.green(`Replaced %sapper.main% in ${file}`)}`);
+				console.log(`${colors.green(`Replaced %sapper.main% in ${file}`)}`);
 				replaced = true;
 			}
 		}


### PR DESCRIPTION
Step 1 of 3 on #267. Didn't have time for the others, sorry. 

There's room to update Sapper to use the `symbols` provided by `ansi-colors`, but I didn't touch that. Symbols are kind of a personal touch 😆 

Also, might as well keep using `glob` since webpack relies on it. Would be adding a new player in this case, rather than replacing one.