### PR TITLE
Feature: use regexp in routes

### DIFF
--- a/src/core/create_routes.ts
+++ b/src/core/create_routes.ts
@@ -4,171 +4,171 @@ import { locations } from '../config';
 import { Route } from '../interfaces';
 
 export default function create_routes({ files } = { files: glob.sync('**/*.*', { cwd: locations.routes(), dot: true, nodir: true }) }) {
-	const routes: Route[] = files
-		.filter((file: string) => !/(^|\/|\\)_/.test(file))
-		.map((file: string) => {
-			if (/(^|\/|\\)(_|\.(?!well-known))/.test(file)) return;
+    const routes: Route[] = files
+        .filter((file: string) => !/(^|\/|\\)_/.test(file))
+        .map((file: string) => {
+            if (/(^|\/|\\)(_|\.(?!well-known))/.test(file)) return;
 
-			if (/]\[/.test(file)) {
-				throw new Error(`Invalid route ${file} — parameters must be separated`);
-			}
+            if (/]\[/.test(file)) {
+                throw new Error(`Invalid route ${file} — parameters must be separated`);
+            }
 
-			const base = file.replace(/\.[^/.]+$/, '');
-			const parts = base.split('/'); // glob output is always posix-style
-			if (parts[parts.length - 1] === 'index') parts.pop();
+            const base = file.replace(/\.[^/.]+$/, '');
+            const parts = base.split('/'); // glob output is always posix-style
+            if (parts[parts.length - 1] === 'index') parts.pop();
 
-			return {
-				files: [file],
-				base,
-				parts
-			};
-		})
-		.filter(Boolean)
-		.filter((a, index, array) => {
-			const found = array.slice(index + 1).find(b => a.base === b.base);
-			if (found) found.files.push(...a.files);
-			return !found;
-		})
-		.sort((a, b) => {
-			if (a.parts[0] === '4xx' || a.parts[0] === '5xx') return -1;
-			if (b.parts[0] === '4xx' || b.parts[0] === '5xx') return 1;
+            return {
+                files: [file],
+                base,
+                parts
+            };
+        })
+        .filter(Boolean)
+        .filter((a, index, array) => {
+            const found = array.slice(index + 1).find(b => a.base === b.base);
+            if (found) found.files.push(...a.files);
+            return !found;
+        })
+        .sort((a, b) => {
+            if (a.parts[0] === '4xx' || a.parts[0] === '5xx') return -1;
+            if (b.parts[0] === '4xx' || b.parts[0] === '5xx') return 1;
 
-			const max = Math.max(a.parts.length, b.parts.length);
+            const max = Math.max(a.parts.length, b.parts.length);
 
-			for (let i = 0; i < max; i += 1) {
-				const a_part = a.parts[i];
-				const b_part = b.parts[i];
+            for (let i = 0; i < max; i += 1) {
+                const a_part = a.parts[i];
+                const b_part = b.parts[i];
 
-				if (!a_part) return -1;
-				if (!b_part) return 1;
+                if (!a_part) return -1;
+                if (!b_part) return 1;
 
-				const a_sub_parts = get_sub_parts(a_part);
-				const b_sub_parts = get_sub_parts(b_part);
-				const max = Math.max(a_sub_parts.length, b_sub_parts.length);
+                const a_sub_parts = get_sub_parts(a_part);
+                const b_sub_parts = get_sub_parts(b_part);
+                const max = Math.max(a_sub_parts.length, b_sub_parts.length);
 
-				for (let i = 0; i < max; i += 1) {
-					const a_sub_part = a_sub_parts[i];
-					const b_sub_part = b_sub_parts[i];
+                for (let i = 0; i < max; i += 1) {
+                    const a_sub_part = a_sub_parts[i];
+                    const b_sub_part = b_sub_parts[i];
 
-					if (!a_sub_part) return 1; // b is more specific, so goes first
-					if (!b_sub_part) return -1;
+                    if (!a_sub_part) return 1; // b is more specific, so goes first
+                    if (!b_sub_part) return -1;
 
-					if (a_sub_part.dynamic !== b_sub_part.dynamic) {
-						return a_sub_part.dynamic ? 1 : -1;
-					}
+                    if (a_sub_part.dynamic !== b_sub_part.dynamic) {
+                        return a_sub_part.dynamic ? 1 : -1;
+                    }
 
-					if (!a_sub_part.dynamic && a_sub_part.content !== b_sub_part.content) {
-						return (
-							(b_sub_part.content.length - a_sub_part.content.length) ||
-							(a_sub_part.content < b_sub_part.content ? -1 : 1)
-						);
-					}
-					// If both parts dynamic, check for regexp patterns
-	                if (a_sub_part.dynamic && b_sub_part.dynamic) {
-	                    const regexp_pattern = /\((.*?)\)/;
-	                    const a_match = regexp_pattern.exec(a_sub_part.content);
-	                    const b_match = regexp_pattern.exec(b_sub_part.content);
+                    if (!a_sub_part.dynamic && a_sub_part.content !== b_sub_part.content) {
+                        return (
+                            (b_sub_part.content.length - a_sub_part.content.length) ||
+                            (a_sub_part.content < b_sub_part.content ? -1 : 1)
+                        );
+                    }
+                    // If both parts dynamic, check for regexp patterns
+                    if (a_sub_part.dynamic && b_sub_part.dynamic) {
+                        const regexp_pattern = /\((.*?)\)/;
+                        const a_match = regexp_pattern.exec(a_sub_part.content);
+                        const b_match = regexp_pattern.exec(b_sub_part.content);
 
-	                    if (!a_match && b_match) {
-	                        return 1; // No regexp, so less specific than b
-	                    }
-	                    if (!b_match && a_match) {
-	                        return -1; 
-	                    }
-	                    if (a_match && b_match) {
-	                    	return b_match[1].length - a_match[1].length;
-	                    }
-	                }
-				}
-			}
+                        if (!a_match && b_match) {
+                            return 1; // No regexp, so less specific than b
+                        }
+                        if (!b_match && a_match) {
+                            return -1; 
+                        }
+                        if (a_match && b_match) {
+                            return b_match[1].length - a_match[1].length;
+                        }
+                    }
+                }
+            }
 
-			throw new Error(`The ${a.base} and ${b.base} routes clash`);
-		})
-		.map(({ files, base, parts }) => {
-			const id = (
-				parts.join('_').replace(/[[\]]/g, '$').replace(/^\d/, '_$&').replace(/[^a-zA-Z0-9_$]/g, '_')
-			 ) || '_';
+            throw new Error(`The ${a.base} and ${b.base} routes clash`);
+        })
+        .map(({ files, base, parts }) => {
+            const id = (
+                parts.join('_').replace(/[[\]]/g, '$').replace(/^\d/, '_$&').replace(/[^a-zA-Z0-9_$]/g, '_')
+             ) || '_';
 
-			const params: string[] = [];
-			const match_patterns: string[] = [];
-			const param_pattern = /\[([^\(]+)(?:\((.+?)\))?\]/g;
-			let match;
-			while (match = param_pattern.exec(base)) {
-				params.push(match[1]);
-				if (typeof match[2] !== 'undefined') {
-	                match_patterns.push(`(${match[2]}?)`);
-	            }
-			}
+            const params: string[] = [];
+            const match_patterns: string[] = [];
+            const param_pattern = /\[([^\(]+)(?:\((.+?)\))?\]/g;
+            let match;
+            while (match = param_pattern.exec(base)) {
+                params.push(match[1]);
+                if (typeof match[2] !== 'undefined') {
+                    match_patterns.push(`(${match[2]}?)`);
+                }
+            }
 
-			// TODO can we do all this with sub-parts? or does
-			// nesting make that impossible?
-			let pattern_string = '';
-			let i = parts.length;
-			let nested = true;
-			while (i--) {
-				const part = encodeURI(parts[i].normalize()).replace(/\?/g, '%3F').replace(/#/g, '%23').replace(/%5B/g, '[').replace(/%5D/g, ']');
-				const dynamic = ~part.indexOf('[');
+            // TODO can we do all this with sub-parts? or does
+            // nesting make that impossible?
+            let pattern_string = '';
+            let i = parts.length;
+            let nested = true;
+            while (i--) {
+                const part = encodeURI(parts[i].normalize()).replace(/\?/g, '%3F').replace(/#/g, '%23').replace(/%5B/g, '[').replace(/%5D/g, ']');
+                const dynamic = ~part.indexOf('[');
 
-				if (dynamic) {
-					const matcher = part.replace(param_pattern, match_patterns[i] || `([^/]+?)`);
-					pattern_string = nested ? `(?:\\/${matcher}${pattern_string})?` : `\\/${matcher}${pattern_string}`;
-				} else {
-					nested = false;
-					pattern_string = `\\/${part}${pattern_string}`;
-				}
-			}
+                if (dynamic) {
+                    const matcher = part.replace(param_pattern, match_patterns[i] || `([^/]+?)`);
+                    pattern_string = nested ? `(?:\\/${matcher}${pattern_string})?` : `\\/${matcher}${pattern_string}`;
+                } else {
+                    nested = false;
+                    pattern_string = `\\/${part}${pattern_string}`;
+                }
+            }
 
-			const pattern = new RegExp(`^${pattern_string}\\/?$`);
+            const pattern = new RegExp(`^${pattern_string}\\/?$`);
 
-			const test = (url: string) => pattern.test(url);
+            const test = (url: string) => pattern.test(url);
 
-			const exec = (url: string) => {
-				const match = pattern.exec(url);
-				if (!match) return;
+            const exec = (url: string) => {
+                const match = pattern.exec(url);
+                if (!match) return;
 
-				const result: Record<string, string> = {};
-				params.forEach((param, i) => {
-					result[param] = match[i + 1];
-				});
+                const result: Record<string, string> = {};
+                params.forEach((param, i) => {
+                    result[param] = match[i + 1];
+                });
 
-				return result;
-			};
+                return result;
+            };
 
-			return {
-				id,
-				handlers: files.map(file => ({
-					type: path.extname(file) === '.html' ? 'page' : 'route',
-					file
-				})).sort((a, b) => {
-					if (a.type === 'page' && b.type === 'route') {
-						return 1;
-					}
+            return {
+                id,
+                handlers: files.map(file => ({
+                    type: path.extname(file) === '.html' ? 'page' : 'route',
+                    file
+                })).sort((a, b) => {
+                    if (a.type === 'page' && b.type === 'route') {
+                        return 1;
+                    }
 
-					if (a.type === 'route' && b.type === 'page') {
-						return -1;
-					}
+                    if (a.type === 'route' && b.type === 'page') {
+                        return -1;
+                    }
 
-					return 0;
-				}),
-				pattern,
-				test,
-				exec,
-				parts,
-				params
-			};
-		});
+                    return 0;
+                }),
+                pattern,
+                test,
+                exec,
+                parts,
+                params
+            };
+        });
 
-	return routes;
+    return routes;
 }
 
 function get_sub_parts(part: string) {
-	return part.split(/\[(.+)\]/)
-		.map((content, i) => {
-			if (!content) return null;
-			return {
-				content,
-				dynamic: i % 2 === 1
-			};
-		})
-		.filter(Boolean);
+    return part.split(/\[(.+)\]/)
+        .map((content, i) => {
+            if (!content) return null;
+            return {
+                content,
+                dynamic: i % 2 === 1
+            };
+        })
+        .filter(Boolean);
 }

--- a/src/core/create_routes.ts
+++ b/src/core/create_routes.ts
@@ -4,184 +4,187 @@ import { locations } from '../config';
 import { Route } from '../interfaces';
 
 export default function create_routes({ files } = { files: glob.sync('**/*.*', { cwd: locations.routes(), dot: true, nodir: true }) }) {
-    const routes: Route[] = files
-        .filter((file: string) => !/(^|\/|\\)(_(?!error\.html)|\.(?!well-known))/.test(file))
-        .map((file: string) => {
-            if (/]\[/.test(file)) {
-                throw new Error(`Invalid route ${file} — parameters must be separated`);
-            }
+	const routes: Route[] = files
+		.filter((file: string) => !/(^|\/|\\)(_(?!error\.html)|\.(?!well-known))/.test(file))
+		.map((file: string) => {
+			if (/]\[/.test(file)) {
+				throw new Error(`Invalid route ${file} — parameters must be separated`);
+			}
 
-            if (file === '4xx.html' || file === '5xx.html') {
-                throw new Error('As of Sapper 0.14, 4xx.html and 5xx.html should be replaced with _error.html');
-            }
+			if (file === '4xx.html' || file === '5xx.html') {
+				throw new Error('As of Sapper 0.14, 4xx.html and 5xx.html should be replaced with _error.html');
+			}
 
-            const base = file.replace(/\.[^/.]+$/, '');
-            const parts = base.split('/'); // glob output is always posix-style
-            if (/^index(\..+)?/.test(parts[parts.length - 1])) {
-                const part = parts.pop();
-                if (parts.length > 0) parts[parts.length - 1] += part.slice(5);
-            }
+			const base = file.replace(/\.[^/.]+$/, '');
+			const parts = base.split('/'); // glob output is always posix-style
+			if (/^index(\..+)?/.test(parts[parts.length - 1])) {
+				const part = parts.pop();
+				if (parts.length > 0) parts[parts.length - 1] += part.slice(5);
+			}
 
-            return {
-                files: [file],
-                base,
-                parts
-            };
-        })
-        .filter(Boolean)
-        .filter((a, index, array) => {
-            const found = array.slice(index + 1).find(b => a.base === b.base);
-            if (found) found.files.push(...a.files);
-            return !found;
-        })
-        .sort((a, b) => {
-            if (a.parts[0] === '_error') return -1;
-            if (b.parts[0] === '_error') return 1;
+			return {
+				files: [file],
+				base,
+				parts
+			};
+		})
+		.filter(Boolean)
+		.filter((a, index, array) => {
+			const found = array.slice(index + 1).find(b => a.base === b.base);
+			if (found) found.files.push(...a.files);
+			return !found;
+		})
+		.sort((a, b) => {
+			if (a.parts[0] === '_error') return -1;
+			if (b.parts[0] === '_error') return 1;
 
-            const max = Math.max(a.parts.length, b.parts.length);
+			const max = Math.max(a.parts.length, b.parts.length);
 
-            for (let i = 0; i < max; i += 1) {
-                const a_part = a.parts[i];
-                const b_part = b.parts[i];
+			for (let i = 0; i < max; i += 1) {
+				const a_part = a.parts[i];
+				const b_part = b.parts[i];
 
-                if (!a_part) return -1;
-                if (!b_part) return 1;
+				if (!a_part) return -1;
+				if (!b_part) return 1;
 
-                const a_sub_parts = get_sub_parts(a_part);
-                const b_sub_parts = get_sub_parts(b_part);
-                const max = Math.max(a_sub_parts.length, b_sub_parts.length);
+				const a_sub_parts = get_sub_parts(a_part);
+				const b_sub_parts = get_sub_parts(b_part);
+				const max = Math.max(a_sub_parts.length, b_sub_parts.length);
 
-                for (let i = 0; i < max; i += 1) {
-                    const a_sub_part = a_sub_parts[i];
-                    const b_sub_part = b_sub_parts[i];
+				for (let i = 0; i < max; i += 1) {
+					const a_sub_part = a_sub_parts[i];
+					const b_sub_part = b_sub_parts[i];
 
-                    if (!a_sub_part) return 1; // b is more specific, so goes first
-                    if (!b_sub_part) return -1;
+					if (!a_sub_part) return 1; // b is more specific, so goes first
+					if (!b_sub_part) return -1;
 
-                    if (a_sub_part.dynamic !== b_sub_part.dynamic) {
-                        return a_sub_part.dynamic ? 1 : -1;
-                    }
+					if (a_sub_part.dynamic !== b_sub_part.dynamic) {
+						return a_sub_part.dynamic ? 1 : -1;
+					}
 
-                    if (!a_sub_part.dynamic && a_sub_part.content !== b_sub_part.content) {
-                        return (
-                            (b_sub_part.content.length - a_sub_part.content.length) ||
-                            (a_sub_part.content < b_sub_part.content ? -1 : 1)
-                        );
-                    }
+					if (!a_sub_part.dynamic && a_sub_part.content !== b_sub_part.content) {
+						return (
+							(b_sub_part.content.length - a_sub_part.content.length) ||
+							(a_sub_part.content < b_sub_part.content ? -1 : 1)
+						);
+					}
 
-                    // If both parts dynamic, check for regexp patterns
-                    if (a_sub_part.dynamic && b_sub_part.dynamic) {
-                        const regexp_pattern = /\((.*?)\)/;
-                        const a_match = regexp_pattern.exec(a_sub_part.content);
-                        const b_match = regexp_pattern.exec(b_sub_part.content);
+					// If both parts dynamic, check for regexp patterns
+					if (a_sub_part.dynamic && b_sub_part.dynamic) {
+						const regexp_pattern = /\((.*?)\)/;
+						const a_match = regexp_pattern.exec(a_sub_part.content);
+						const b_match = regexp_pattern.exec(b_sub_part.content);
 
-                        if (!a_match && b_match) {
-                            return 1; // No regexp, so less specific than b
-                        }
-                        if (!b_match && a_match) {
-                            return -1; 
-                        }
-                        if (a_match && b_match) {
-                            return b_match[1].length - a_match[1].length;
-                        }
-                    }
-                }
-            }
+						if (!a_match && b_match) {
+							return 1; // No regexp, so less specific than b
+						}
+						if (!b_match && a_match) {
+							return -1; 
+						}
+						if (a_match && b_match && a_match[1] !== b_match[1]) {
+							return b_match[1].length - a_match[1].length;
+						}
+					}
+				}
+			}
 
-            throw new Error(`The ${a.base} and ${b.base} routes clash`);
-        })
-        .map(({ files, base, parts }) => {
-            const id = (
-                parts.join('_').replace(/[[\]]/g, '$').replace(/^\d/, '_$&').replace(/[^a-zA-Z0-9_$]/g, '_')
-             ) || '_';
+			throw new Error(`The ${a.base} and ${b.base} routes clash`);
+		})
+		.map(({ files, base, parts }) => {
+			const id = (
+				parts.join('_').replace(/[[\]]/g, '$').replace(/^\d/, '_$&').replace(/[^a-zA-Z0-9_$]/g, '_')
+			 ) || '_';
 
-            const params: string[] = [];
-            const match_patterns: object = {};
-            const param_pattern = /\[([^\(\]]+)(?:\((.+?)\))?\]/g;
-            let match;
-            while (match = param_pattern.exec(base)) {
-                params.push(match[1]);
-                if (typeof match[2] !== 'undefined') {
-                    // Make a map of the regexp patterns
-                    match_patterns[match[1]] = `(${match[2]}?)`;
-                }
-            }
+			const params: string[] = [];
+			const match_patterns: object = {};
+			const param_pattern = /\[([^\(\]]+)(?:\((.+?)\))?\]/g;
+			let match;
+			while (match = param_pattern.exec(base)) {
+				params.push(match[1]);
+				if (typeof match[2] !== 'undefined') {
+					if (/[\(\)\?\:]/.exec(match[2])) {
+						throw new Error('Sapper does not allow (, ), ? or : in RegExp routes yet');
+					}
+					// Make a map of the regexp patterns
+					match_patterns[match[1]] = `(${match[2]}?)`;
+				}
+			}
 
-            // TODO can we do all this with sub-parts? or does
-            // nesting make that impossible?
-            let pattern_string = '';
-            let i = parts.length;
-            let nested = true;
-            while (i--) {
-                const part = encodeURI(parts[i].normalize()).replace(/\?/g, '%3F').replace(/#/g, '%23').replace(/%5B/g, '[').replace(/%5D/g, ']');
-                const dynamic = ~part.indexOf('[');
+			// TODO can we do all this with sub-parts? or does
+			// nesting make that impossible?
+			let pattern_string = '';
+			let i = parts.length;
+			let nested = true;
+			while (i--) {
+				const part = encodeURI(parts[i].normalize()).replace(/\?/g, '%3F').replace(/#/g, '%23').replace(/%5B/g, '[').replace(/%5D/g, ']');
+				const dynamic = ~part.indexOf('[');
 
-                if (dynamic) {
-                    // Get keys from part and replace with stored match patterns
-                    const keys = part.replace(/\(.*?\)/, '').split(/[\[\]]/).filter((x, i) => { if (i % 2) return x });
-                    let matcher = part;
-                    keys.forEach(k => {
-                        const key_pattern = new RegExp('\\[' + k + '(?:\\((.+?)\\))?\\]');
-                        matcher = matcher.replace(key_pattern, match_patterns[k] || `([^/]+?)`);
-                    })
-                    pattern_string = nested ? `(?:\\/${matcher}${pattern_string})?` : `\\/${matcher}${pattern_string}`;
-                } else {
-                    nested = false;
-                    pattern_string = `\\/${part}${pattern_string}`;
-                }
-            }
+				if (dynamic) {
+					// Get keys from part and replace with stored match patterns
+					const keys = part.replace(/\(.*?\)/, '').split(/[\[\]]/).filter((x, i) => { if (i % 2) return x });
+					let matcher = part;
+					keys.forEach(k => {
+						const key_pattern = new RegExp('\\[' + k + '(?:\\((.+?)\\))?\\]');
+						matcher = matcher.replace(key_pattern, match_patterns[k] || `([^/]+?)`);
+					})
+					pattern_string = nested ? `(?:\\/${matcher}${pattern_string})?` : `\\/${matcher}${pattern_string}`;
+				} else {
+					nested = false;
+					pattern_string = `\\/${part}${pattern_string}`;
+				}
+			}
 
-            const pattern = new RegExp(`^${pattern_string}\\/?$`);
+			const pattern = new RegExp(`^${pattern_string}\\/?$`);
 
-            const test = (url: string) => pattern.test(url);
+			const test = (url: string) => pattern.test(url);
 
-            const exec = (url: string) => {
-                const match = pattern.exec(url);
-                if (!match) return;
+			const exec = (url: string) => {
+				const match = pattern.exec(url);
+				if (!match) return;
 
-                const result: Record<string, string> = {};
-                params.forEach((param, i) => {
-                    result[param] = match[i + 1];
-                });
+				const result: Record<string, string> = {};
+				params.forEach((param, i) => {
+					result[param] = match[i + 1];
+				});
 
-                return result;
-            };
+				return result;
+			};
 
-            return {
-                id,
-                handlers: files.map(file => ({
-                    type: path.extname(file) === '.html' ? 'page' : 'route',
-                    file
-                })).sort((a, b) => {
-                    if (a.type === 'page' && b.type === 'route') {
-                        return 1;
-                    }
+			return {
+				id,
+				handlers: files.map(file => ({
+					type: path.extname(file) === '.html' ? 'page' : 'route',
+					file
+				})).sort((a, b) => {
+					if (a.type === 'page' && b.type === 'route') {
+						return 1;
+					}
 
-                    if (a.type === 'route' && b.type === 'page') {
-                        return -1;
-                    }
+					if (a.type === 'route' && b.type === 'page') {
+						return -1;
+					}
 
-                    return 0;
-                }),
-                pattern,
-                test,
-                exec,
-                parts,
-                params
-            };
-        });
+					return 0;
+				}),
+				pattern,
+				test,
+				exec,
+				parts,
+				params
+			};
+		});
 
-    return routes;
+	return routes;
 }
 
 function get_sub_parts(part: string) {
-    return part.split(/\[(.+)\]/)
-        .map((content, i) => {
-            if (!content) return null;
-            return {
-                content,
-                dynamic: i % 2 === 1
-            };
-        })
-        .filter(Boolean);
+	return part.split(/\[(.+)\]/)
+		.map((content, i) => {
+			if (!content) return null;
+			return {
+				content,
+				dynamic: i % 2 === 1
+			};
+		})
+		.filter(Boolean);
 }


### PR DESCRIPTION
Needed this feature for current project. Using regexp to distinguish routes that would otherwise be clashing. This makes it possible to have routes like so:

```
index.html
[page].html
[lang([a-z]{2})]/index.html
[lang([a-z]{2})]/[page].html
[category([a-z-]{3,})]/[page].html
```
Obvious caveat _(for now at least)_: it's not possible to use `/` or `\` in the regexp patterns as that would break the route path.