### PR TITLE
Emit basepath event

### DIFF
--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -6,7 +6,6 @@ import * as ports from 'port-authority';
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
 import format_messages from 'webpack-format-messages';
-import prettyMs from 'pretty-ms';
 import { locations } from '../config';
 import { EventEmitter } from 'events';
 import { create_routes, create_main_manifests, create_compilers, create_serviceworker_manifest } from '../core';
@@ -171,6 +170,14 @@ class Watcher extends EventEmitter {
 							PORT: this.port
 						}, process.env),
 						stdio: ['ipc']
+					});
+
+					this.proc.on('message', message => {
+						if (message.__sapper__ && message.event === 'basepath') {
+							this.emit('basepath', {
+								basepath: message.basepath
+							});
+						}
 					});
 				});
 			}

--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -66,7 +66,7 @@ async function execute(emitter: EventEmitter, {
 	const saved = new Set();
 
 	proc.on('message', message => {
-		if (!message.__sapper__) return;
+		if (!message.__sapper__ || message.event !== 'file') return;
 
 		let file = new URL(message.url, origin).pathname.slice(1);
 		let { body } = message;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,15 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { resolve, URL } from 'url';
+import { URL } from 'url';
 import { ClientRequest, ServerResponse } from 'http';
 import cookie from 'cookie';
-import mkdirp from 'mkdirp';
-import rimraf from 'rimraf';
 import devalue from 'devalue';
 import fetch from 'node-fetch';
 import { lookup } from './middleware/mime';
 import { locations, dev } from './config';
-import { Route, Template } from './interfaces';
 import sourceMapSupport from 'source-map-support';
 
 sourceMapSupport.install();
@@ -138,8 +135,6 @@ function serve({ prefix, pathname, cache_control }: {
 		}
 	};
 }
-
-const resolved = Promise.resolve();
 
 function get_route_handler(chunks: Record<string, string>, App: Component, routes: RouteObject[], store_getter: (req: Req) => Store) {
 	const template = dev()
@@ -449,10 +444,6 @@ function compose_handlers(handlers: Handler[]) {
 
 		go();
 	};
-}
-
-function read_json(file: string) {
-	return JSON.parse(fs.readFileSync(file, 'utf-8'));
 }
 
 function try_serialize(data: any) {

--- a/test/common/test.js
+++ b/test/common/test.js
@@ -133,6 +133,7 @@ function run({ mode, basepath = '' }) {
 		let capture;
 
 		let base;
+		let captured_basepath;
 
 		const nightmare = new Nightmare();
 
@@ -179,7 +180,13 @@ function run({ mode, basepath = '' }) {
 				let handler;
 
 				proc.on('message', message => {
-					if (message.__sapper__) return;
+					if (message.__sapper__) {
+						if (message.event === 'basepath') {
+							captured_basepath = basepath;
+						}
+						return;
+					}
+
 					if (handler) handler(message);
 				});
 
@@ -596,6 +603,10 @@ function run({ mode, basepath = '' }) {
 					.then(hasProgressIndicator => {
 						assert.ok(!hasProgressIndicator);
 					});
+			});
+
+			it('emits a basepath', () => {
+				assert.equal(captured_basepath, basepath);
 			});
 		});
 


### PR DESCRIPTION
This change allows tooling (i.e. Sapper Studio) to be aware of a project's custom basepath, which is necessary for some functionality — in particular, editing the page currently being viewed