### PR TITLE
Don't create fallback routes

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -21,6 +21,7 @@ export type Store = {
 };
 
 export type PageComponent = {
+	missing?: boolean;
 	name: string;
 	file: string;
 };


### PR DESCRIPTION
Am in two minds about this one. In #308, if you have something like `routes/foo/bar/baz.html` but *don't* have (say) `routes/foo/index.html`, Sapper will import a fallback component that looks like this:

```html
<svelte:component this={child.component} {...child.props}/>
```

Since `routes/foo/index.html` would probably look like that *anyway*, we can a) save the developer some typing, b) avoid cluttering `routes`, and c) prevent the situation where you have multiple components that look like that, duplicated unnecessarily, which is good for file size. You'd then only need to create an intermediate `index.html` file if you needed specific markup or behaviour.

However, it's less explicit, and it's possible to create a webpack config that breaks it, by only compiling components inside `routes`.

So for now I'm just going to leave it here as a PR to the original PR.