### PR TITLE
fix child.segment bug

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -233,7 +233,7 @@ function prepare_page(target: Target): Promise<{
 			path,
 			preloading: false,
 			child: Object.assign({}, root_props.child, {
-				segment: new_segments[0]
+				segment: segments[0]
 			})
 		};
 		if (changed(query, root_props.query)) data.query = query;
@@ -260,12 +260,11 @@ function prepare_page(target: Target): Promise<{
 					params: get_params(target.match),
 				}, results[i].preloaded);
 
-				level.props.child = {
-					segment: new_segments[i + 1]
-				};
+				level.props.child = {};
 			}
 
 			level = level.props.child;
+			level.segment = segments[i + 1];
 		}
 
 		return { data, nullable_depth };

--- a/test/app/routes/[x]/[y]/_layout.html
+++ b/test/app/routes/[x]/[y]/_layout.html
@@ -1,6 +1,8 @@
 <span>y: {segment} {count}</span>
 <svelte:component this={child.component} {...child.props}/>
 
+<span>child segment: {child.segment}</span>
+
 <script>
 	import counts from '../_counts.js';
 

--- a/test/common/test.js
+++ b/test/common/test.js
@@ -630,7 +630,8 @@ function run({ mode, basepath = '' }) {
 					.then(text => {
 						assert.deepEqual(text.split('\n').filter(Boolean), [
 							'y: bar 1',
-							'z: baz 1'
+							'z: baz 1',
+							'child segment: baz'
 						]);
 
 						return nightmare.click(`a`)
@@ -642,7 +643,8 @@ function run({ mode, basepath = '' }) {
 					.then(text => {
 						assert.deepEqual(text.split('\n').filter(Boolean), [
 							'y: bar 1',
-							'z: qux 2'
+							'z: qux 2',
+							'child segment: qux'
 						]);
 					});
 			});


### PR DESCRIPTION
Ensures that `child.segment` is correctly updated even for levels that are unchanged