### PR TITLE
Add `ignore` option

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -73,9 +73,18 @@ interface Component {
 	preload: (data: any) => any | Promise<any>
 }
 
+const IGNORE = '__SAPPER__IGNORE__';
+function toIgnore(uri: string, val: any) {
+	if (Array.isArray(val)) return val.some(x => toIgnore(uri, x));
+	if (val instanceof RegExp) return val.test(uri);
+	if (typeof val === 'function') return val(uri);
+	return uri.startsWith(val.charCodeAt(0) === 47 ? val : `/${val}`);
+}
+
 export default function middleware(opts: {
 	manifest: Manifest,
 	store: (req: Req) => Store,
+	ignore?: any,
 	routes?: any // legacy
 }) {
 	if (opts.routes) {
@@ -84,12 +93,19 @@ export default function middleware(opts: {
 
 	const output = locations.dest();
 
-	const { manifest, store } = opts;
+	const { manifest, store, ignore } = opts;
 
 	let emitted_basepath = false;
 
 	const middleware = compose_handlers([
+		ignore && ((req: Req, res: ServerResponse, next: () => void) => {
+			req[IGNORE] = toIgnore(req.path, ignore);
+			next();
+		}),
+
 		(req: Req, res: ServerResponse, next: () => void) => {
+			if (req[IGNORE]) return next();
+
 			if (req.baseUrl === undefined) {
 				let { originalUrl } = req;
 				if (req.url === '/' && originalUrl[originalUrl.length - 1] !== '/') {
@@ -163,6 +179,8 @@ function serve({ prefix, pathname, cache_control }: {
 		: (file: string) => (cache.has(file) ? cache : cache.set(file, fs.readFileSync(path.resolve(output, file)))).get(file)
 
 	return (req: Req, res: ServerResponse, next: () => void) => {
+		if (req[IGNORE]) return next();
+
 		if (filter(req)) {
 			const type = lookup(req.path);
 
@@ -245,6 +263,8 @@ function get_server_route_handler(routes: ServerRoute[]) {
 	}
 
 	return function find_route(req: Req, res: ServerResponse, next: () => void) {
+		if (req[IGNORE]) return next();
+
 		for (const route of routes) {
 			if (route.pattern.test(req.path)) {
 				handle_route(route, req, res, next);
@@ -494,7 +514,9 @@ function get_page_handler(manifest: Manifest, store_getter: (req: Req) => Store)
 		});
 	}
 
-	return function find_route(req: Req, res: ServerResponse) {
+	return function find_route(req: Req, res: ServerResponse, next: () => void) {
+		if (req[IGNORE]) return next();
+
 		if (!server_routes.some(route => route.pattern.test(req.path))) {
 			for (const page of pages) {
 				if (page.pattern.test(req.path)) {

--- a/test/app/app/server.js
+++ b/test/app/app/server.js
@@ -91,8 +91,14 @@ const middlewares = [
 			return new Store({
 				title: 'Stored title'
 			});
-		}
-	})
+		},
+		ignore: [
+			/foo/i,
+			'/buzz',
+			'fizz',
+			x => x === '/hello'
+		]
+	}),
 ];
 
 if (BASEPATH) {
@@ -100,5 +106,9 @@ if (BASEPATH) {
 } else {
 	app.use(...middlewares);
 }
+
+['foobar', 'buzz', 'fizzer', 'hello'].forEach(uri => {
+	app.get('/'+uri, (req, res) => res.end(uri));
+});
 
 app.listen(PORT);

--- a/test/app/app/server.js
+++ b/test/app/app/server.js
@@ -93,7 +93,7 @@ const middlewares = [
 			});
 		},
 		ignore: [
-			/foo/i,
+			/foobar/i,
 			'/buzz',
 			'fizz',
 			x => x === '/hello'

--- a/test/common/test.js
+++ b/test/common/test.js
@@ -477,6 +477,42 @@ function run({ mode, basepath = '' }) {
 					});
 			});
 
+			// Ignores are meant for top-level escape.
+			// ~> Sapper **should** own the entire {basepath} when designated.
+			if (!basepath) {
+				it('respects `options.ignore` values (RegExp)', () => {
+					return nightmare.goto(`${base}/foobar`)
+						.evaluate(() => document.documentElement.textContent)
+						.then(text => {
+							assert.equal(text, 'foobar');
+						});
+				});
+
+				it('respects `options.ignore` values (String #1)', () => {
+					return nightmare.goto(`${base}/buzz`)
+						.evaluate(() => document.documentElement.textContent)
+						.then(text => {
+							assert.equal(text, 'buzz');
+						});
+				});
+
+				it('respects `options.ignore` values (String #2)', () => {
+					return nightmare.goto(`${base}/fizzer`)
+						.evaluate(() => document.documentElement.textContent)
+						.then(text => {
+							assert.equal(text, 'fizzer');
+						});
+				});
+
+				it('respects `options.ignore` values (Function)', () => {
+					return nightmare.goto(`${base}/hello`)
+						.evaluate(() => document.documentElement.textContent)
+						.then(text => {
+							assert.equal(text, 'hello');
+						});
+				});
+			}
+
 			it('does not attempt client-side navigation to server routes', () => {
 				return nightmare.goto(`${base}/blog/how-is-sapper-different-from-next`)
 					.init()


### PR DESCRIPTION
When Sapper runs as a top-level middleware, it (strongly) assumes it's the final handler for any/all requests on that domain. While this is 100% desired in most cases (and especially when relegated to a `basepath`), it does make it near-impossible to prevent this behavior in the 1-2% of cases where an escape hatch is needed.

More specifically, Polka users are forced to run _everything_ as a root-level middleware, even if a sub-application is meant to control its own basepath. This is currently the only work around in this case:

```js
polka()
  .use(
    compression(),
    // ...
    (req, res, next) => {
      if (req.path.startsWith('/users') {
        req.path = req.path.substring(6); // remove "/users"
        return users_sub_application(req, res, next);
      }
      next();
    },
    // ...
    sapper()
  )
```

With this feature, Polka (or any) users can bypass Sapper's routing and allow their legacy/sub/third-party/whatever apps to run on the same server, without worrying about middleware sequencing.

The `options.ignore` can be an instance of `RegExp`, `Function`, `String`, or an `Array` of any combination.

```js
sapper({
  store,
  manifest,
  ignore: [
    /foobar/i,
   'foobar', // leading slash will be added
    '/foobar', // identical
    uri => uri.startsWith('/foobar')
  ]
});
```

In the middleware composition, a new middleware is added only if/when the `options.ignore` is defined. The `req.__SAPPER__IGNORE__` boolean will be set & is used in the following middlewares to exit early, avoiding any sapper-related work that isn't desired for the current, incoming request. 