### PR TITLE
don't minify JS when minifying HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cheerio": "^1.0.0-rc.2",
     "chokidar": "^2.0.3",
     "cookie": "^0.3.1",
-    "devalue": "^1.0.1",
+    "devalue": "^1.0.4",
     "glob": "^7.1.2",
     "html-minifier": "^3.5.16",
     "mkdirp": "^0.5.1",

--- a/src/api/utils/minify_html.ts
+++ b/src/api/utils/minify_html.ts
@@ -8,7 +8,7 @@ export function minify_html(html: string) {
 		decodeEntities: true,
 		html5: true,
 		minifyCSS: true,
-		minifyJS: true,
+		minifyJS: false,
 		removeAttributeQuotes: true,
 		removeComments: true,
 		removeOptionalTags: true,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -452,9 +452,9 @@ function get_page_handler(manifest: Manifest, store_getter: (req: Req) => Store)
 
 			let inline_script = `__SAPPER__={${[
 				error && `error:1`,
-				`baseUrl: "${req.baseUrl}"`,
-				serialized.preloaded && `preloaded: ${serialized.preloaded}`,
-				serialized.store && `store: ${serialized.store}`
+				`baseUrl:"${req.baseUrl}"`,
+				serialized.preloaded && `preloaded:${serialized.preloaded}`,
+				serialized.store && `store:${serialized.store}`
 			].filter(Boolean).join(',')}};`;
 
 			const has_service_worker = fs.existsSync(path.join(locations.dest(), 'service-worker.js'));


### PR DESCRIPTION
When exporting, Sapper minifies the resulting HTML. It will also minify any inline JavaScript (i.e. preloaded data), which is slow.

This PR upgrades devalue to a version that produces smaller output in the first place (https://github.com/Rich-Harris/devalue/pull/10), rendering JS minification unnecessary.