### PR TITLE
parallelize exports

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -118,9 +118,7 @@ async function execute(emitter: EventEmitter, {
 					}
 				});
 
-				for (const url of urls) {
-					await handle(url);
-				}
+				await Promise.all(urls.map(handle));
 			}
 		}
 	}


### PR DESCRIPTION
There isn't really a good reason not to fetch all URLs in parallel, as far as I can see. This should speed up exporting a bit