### PR TITLE
[WIP] detect unused data on initial render

### DIFF
--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -224,11 +224,8 @@ class Watcher extends EventEmitter {
 					});
 
 					this.proc.on('message', message => {
-						if (message.__sapper__ && message.event === 'basepath') {
-							this.emit('basepath', {
-								basepath: message.basepath
-							});
-						}
+						if (!message.__sapper__) return;
+						this.emit(message.event, message);
 					});
 
 					this.proc.on('exit', emitFatal);

--- a/src/core/create_manifests.ts
+++ b/src/core/create_manifests.ts
@@ -156,6 +156,7 @@ function generate_server(
 
 							const props = [
 								`name: "${part.component.name}"`,
+								`file: "${part.component.file}"`,
 								`component: ${part.component.name}`
 							];
 

--- a/src/middleware/list_unused_properties.ts
+++ b/src/middleware/list_unused_properties.ts
@@ -1,0 +1,34 @@
+export function list_unused_properties(all: any, used: any) {
+	const props: string[] = [];
+
+	const seen = new Set();
+
+	function walk(keypath: string, a: any, b: any) {
+		if (seen.has(a)) return;
+		seen.add(a);
+
+		if (!a || typeof a !== 'object') return;
+
+		const is_array = Array.isArray(a);
+
+		for (const key in a) {
+			const child_keypath = keypath
+				? is_array ? `${keypath}[${key}]` : `${keypath}.${key}`
+				: key;
+
+			if (hasProp.call(b, key)) {
+				const a_child = a[key];
+				const b_child = b[key];
+
+				walk(child_keypath, a_child, b_child);
+			} else {
+				props.push(child_keypath);
+			}
+		}
+	}
+
+	walk(null, all, used);
+	return props;
+}
+
+const hasProp = Object.prototype.hasOwnProperty;

--- a/src/middleware/wrap_data.ts
+++ b/src/middleware/wrap_data.ts
@@ -1,0 +1,85 @@
+type Obj = Record<string, any>;
+
+export function wrap_data(data: any) {
+	const proxies = new Map();
+	const clones = new Map();
+
+	const handler = {
+		get(target: any, property: string): any {
+			const value = target[property];
+			const intercepted = intercept(value);
+
+			const target_clone = clones.get(target);
+			const child_clone = clones.get(value);
+
+			if (target_clone && target.hasOwnProperty(property)) {
+				target_clone[property] = child_clone || value;
+			}
+
+			return intercepted;
+		},
+	};
+
+	function get_or_create_proxy(obj: any) {
+		if (!proxies.has(obj)) {
+			proxies.set(obj, new Proxy(obj, handler));
+		}
+
+		return proxies.get(obj);
+	}
+
+	function intercept(obj: any) {
+		if (clones.has(obj)) return obj;
+
+		if (obj && typeof obj === 'object') {
+			if (Array.isArray(obj)) {
+				clones.set(obj, []);
+				return get_or_create_proxy(obj);
+			}
+
+			else if (isPlainObject(obj)) {
+				clones.set(obj, {});
+				return get_or_create_proxy(obj);
+			}
+		}
+
+		clones.set(obj, obj);
+		return obj;
+	}
+
+	return {
+		data: intercept(data),
+		unwrap: () => {
+			return clones.get(data);
+		}
+	};
+}
+
+const objectProtoOwnPropertyNames = Object.getOwnPropertyNames(Object.prototype).sort().join('\0')
+
+function isPlainObject(obj: any) {
+	const proto = Object.getPrototypeOf(obj);
+
+	if (
+		proto !== Object.prototype &&
+		proto !== null &&
+		Object.getOwnPropertyNames(proto).sort().join('\0') !== objectProtoOwnPropertyNames
+	) {
+		return false;
+	}
+
+	if (Object.getOwnPropertySymbols(obj).length > 0) {
+		return false;
+	}
+
+	return true;
+}
+
+
+function pick(obj: Obj, props: string[]) {
+	const picked: Obj = {};
+	props.forEach(prop => {
+		picked[prop] = obj[prop];
+	});
+	return picked;
+}


### PR DESCRIPTION
This is somewhat experimental. The idea is that if we can wrap preloaded data in proxies, we can detect which values are actually used in the initial render (including in computed properties etc), and print a warning if any data is *not* used, ideally prompting the developer to remove those properties from `preload` return values.

It also logs a message if the preloaded data is too large, regardless of whether that's because of unused properties.

Todo:

* [ ] add tests
* [ ] maybe support `Map` objects as well?
* [x] emit an event, don't just print to the console
* [ ] figure out how much preloaded data is 'too much'
* [ ] decide whether this is really a good idea