### PR TITLE
Remove basepath from deferred urls and add trailing slash to root 

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -71,8 +71,9 @@ async function execute(emitter: EventEmitter, {
 	const deferreds = new Map();
 
 	function get_deferred(pathname: string) {
+		pathname = pathname.replace(`/${basepath}`, '')
 		if (!deferreds.has(pathname)) {
-			deferreds.set(pathname, new Deferred())	;
+			deferreds.set(pathname, new Deferred());
 		}
 
 		return deferreds.get(pathname);
@@ -138,6 +139,13 @@ async function execute(emitter: EventEmitter, {
 	}
 
 	return ports.wait(port)
-		.then(() => handle(new URL(`/${basepath}`, origin))) // TODO all static routes
+		.then(() => {
+			// TODO all static routes
+			if (basepath) {
+				return handle(new URL(`/${basepath}/`, origin));
+			} else {
+				return handle(new URL('/', origin));
+			}
+		})
 		.then(() => proc.kill());
 }


### PR DESCRIPTION
The `pathname` that comes back from the request is missing the `basepath`. I thought maybe it's easier to always strip them off. Also the root request is missing the trailing slash, my fix is kinda ugly, I'm sure you have a more elegant solution.

Fixes #342 