### PR TITLE
Fix Preload's Redirect

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -336,6 +336,7 @@ function get_page_handler(manifest: Manifest, store_getter: (req: Req) => Store)
 				if (redirect && (redirect.statusCode !== statusCode || redirect.location !== location)) {
 					throw new Error(`Conflicting redirects`);
 				}
+				location = location.replace(/^\//g, ''); // leading slash (only)
 				redirect = { statusCode, location };
 			},
 			error: (statusCode: number, message: Error | string) => {

--- a/test/app/routes/index.html
+++ b/test/app/routes/index.html
@@ -8,6 +8,7 @@
 <a href='about'>about</a>
 <a href='slow-preload'>slow preload</a>
 <a href='redirect-from'>redirect</a>
+<a href='redirect-root'>redirect (root)</a>
 <a href='blog/nope'>broken link</a>
 <a href='blog/throw-an-error'>error link</a>
 <a href='credentials?creds=include'>credentials</a>

--- a/test/app/routes/redirect-root.html
+++ b/test/app/routes/redirect-root.html
@@ -1,0 +1,7 @@
+<script>
+	export default {
+		preload() {
+			this.redirect(301, '/');
+		}
+	};
+</script>

--- a/test/common/test.js
+++ b/test/common/test.js
@@ -436,6 +436,33 @@ function run({ mode, basepath = '' }) {
 					});
 			});
 
+			it('redirects on server (root)', () => {
+				return nightmare.goto(`${base}/redirect-root`)
+					.path()
+					.then(path => {
+						assert.equal(path, `${basepath}/`);
+					})
+					.then(() => nightmare.page.title())
+					.then(title => {
+						assert.equal(title, 'Great success!');
+					});
+			});
+
+			it('redirects in client (root)', () => {
+				return nightmare.goto(base)
+					.wait('[href="redirect-root"]')
+					.click('[href="redirect-root"]')
+					.wait(200)
+					.path()
+					.then(path => {
+						assert.equal(path, `${basepath}/`);
+					})
+					.then(() => nightmare.page.title())
+					.then(title => {
+						assert.equal(title, 'Great success!');
+					});
+			});
+
 			it('handles 4xx error on server', () => {
 				return nightmare.goto(`${base}/blog/nope`)
 					.path()


### PR DESCRIPTION
Strips the leading slash within `this.redirect(code, path)` calls. Because it's done whenever the `redirect` object is set, the equality check still passes.

Also chose to strip because of this line: https://github.com/sveltejs/sapper/blob/master/src/middleware.ts#L405

Lastly, the idea of relative redirects was mentioned in the issue. I personally don't think that should happen, but am open to implementing it if majority rules.

_Closes #291_