### PR TITLE
export should fail on timeouts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,7 +65,13 @@ prog.command('export [dest]')
 	.option('--build', '(Re)build app before exporting', true)
 	.option('--build-dir', 'Specify a custom temporary build directory', '.sapper/prod')
 	.option('--basepath', 'Specify a base path')
-	.action(async (dest = 'export', opts: { build: boolean, 'build-dir': string, basepath?: string }) => {
+	.option('--timeout', 'Milliseconds to wait for a page (--no-timeout to disable)', 5000)
+	.action(async (dest = 'export', opts: {
+		build: boolean,
+		'build-dir': string,
+		basepath?: string,
+		timeout: number | false
+	}) => {
 		process.env.NODE_ENV = 'production';
 		process.env.SAPPER_DEST = opts['build-dir'];
 
@@ -83,7 +89,7 @@ prog.command('export [dest]')
 			await exporter(dest, opts);
 			console.error(`\n> Finished in ${elapsed(start)}. Type ${colors.bold.cyan(`npx serve ${dest}`)} to run the app.`);
 		} catch (err) {
-			console.error(err ? err.details || err.stack || err.message || err : 'Unknown error');
+			console.error(colors.bold.red(`> ${err.message}`));
 			process.exit(1);
 		}
 	});

--- a/src/cli/export.ts
+++ b/src/cli/export.ts
@@ -8,13 +8,20 @@ function left_pad(str: string, len: number) {
 	return str;
 }
 
-export function exporter(export_dir: string, { basepath = '' }) {
+export function exporter(export_dir: string, {
+	basepath = '',
+	timeout
+}: {
+	basepath: string,
+	timeout: number | false
+}) {
 	return new Promise((fulfil, reject) => {
 		try {
 			const emitter = _exporter({
 				build: locations.dest(),
 				dest: export_dir,
-				basepath
+				basepath,
+				timeout
 			});
 
 			emitter.on('file', event => {


### PR DESCRIPTION
We were exporting in an environment where `preload` requests were never responding, and getting no feedback. With this PR, `sapper export` will fail if any page takes longer than 5,000ms (configurable with `--timeout`, and can be disabled with `--no-timeout`) to fetch.