### PR TITLE
Implement differential bundling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sapper",
-  "version": "0.18.3",
+  "version": "0.18.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -55,9 +55,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.3.tgz",
-      "integrity": "sha512-DOzWZKUnmFYG0KUOs+9HEBju2QhBU6oM2zeluunQNt0vnJvnkHvtDNlQPZDkTrkC5pZrNx1TPqeL137zciXZMQ==",
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
+      "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw==",
       "dev": true
     },
     "@types/rimraf": {
@@ -1154,7 +1154,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -1594,7 +1594,7 @@
     },
     "compare-versions": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-2.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/compare-versions/-/compare-versions-2.0.1.tgz",
       "integrity": "sha1-Htwfk2h/2XoyXFn1XkWgfbEGrKY=",
       "dev": true
     },
@@ -2071,9 +2071,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.28",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.28.tgz",
-          "integrity": "sha512-iHsAzDg3OLH7JP+wipniUULHoDSWLgEDYOvsar6/mpAkTJd9/n23Ap8ikruMlvRTqMv/LXrflH9v/AfiEqaBGg==",
+          "version": "8.10.29",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.29.tgz",
+          "integrity": "sha512-zbteaWZ2mdduacm0byELwtRyhYE40aK+pAanQk415gr1eRuu67x7QGOLmn8jz5zI8LDK7d0WI/oT6r5Trz4rzQ==",
           "dev": true
         }
       }
@@ -2097,7 +2097,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -2538,7 +2538,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -4270,9 +4270,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
-      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
     },
     "mamacro": {
@@ -4397,7 +4397,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -4537,7 +4537,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -4991,7 +4991,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -5682,7 +5682,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -6287,9 +6287,9 @@
       }
     },
     "shimport": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/shimport/-/shimport-0.0.9.tgz",
-      "integrity": "sha512-y0DHz5ffBuz+iXUQgkqjT3yJRuegeyhHeDdqVdDMVDCeuS0Ex6AFPLFNV228EfPQmkDumraLsN9HBcT1qyLxHw=="
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/shimport/-/shimport-0.0.10.tgz",
+      "integrity": "sha512-3xPFDLmcLj87sx0OwA60qbloMQUsu6VGF97IG4RqxTf91sGeiaaXOPxM1PoQHbaTm4TOhH8zosokqLAZtuNGnA=="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -7009,7 +7009,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -7074,9 +7074,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.8.tgz",
-      "integrity": "sha512-WatYTD84gP/867bELqI2F/2xC9PQBETn/L+7RGq9MQOA/7yFBNvY1UwXqvtILeE6n0ITwBXxp34M0/o70dzj6A==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "requires": {
         "commander": "~2.17.1",
         "source-map": "~0.6.1"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "html-minifier": "^3.5.16",
-    "shimport": "^0.0.9",
+    "shimport": "^0.0.10",
     "source-map-support": "^0.5.6",
     "tslib": "^1.9.1"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,8 +31,13 @@ prog.command('build [dest]')
 	.describe('Create a production-ready version of your app')
 	.option('-p, --port', 'Default of process.env.PORT', '3000')
 	.option('--bundler', 'Specify a bundler (rollup or webpack, blank for auto)')
+	.option('--legacy', 'Create separate legacy build')
 	.example(`build custom-dir -p 4567`)
-	.action(async (dest = 'build', opts: { port: string, bundler?: string }) => {
+	.action(async (dest = 'build', opts: {
+		port: string,
+		legacy: boolean,
+		bundler?: string
+	}) => {
 		console.log(`> Building...`);
 
 		process.env.NODE_ENV = process.env.NODE_ENV || 'production';
@@ -78,9 +83,11 @@ prog.command('export [dest]')
 	.option('--build-dir', 'Specify a custom temporary build directory', '.sapper/prod')
 	.option('--basepath', 'Specify a base path')
 	.option('--timeout', 'Milliseconds to wait for a page (--no-timeout to disable)', 5000)
+	.option('--legacy', 'Create separate legacy build')
 	.option('--bundler', 'Specify a bundler (rollup or webpack, blank for auto)')
 	.action(async (dest = 'export', opts: {
 		build: boolean,
+		legacy: boolean,
 		bundler?: string,
 		'build-dir': string,
 		basepath?: string,

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -4,8 +4,12 @@ import { locations } from '../config';
 import validate_bundler from './utils/validate_bundler';
 import { repeat } from '../utils';
 
-export function build(opts: { bundler?: string }) {
+export function build(opts: { bundler?: string, legacy?: boolean }) {
 	const bundler = validate_bundler(opts.bundler);
+
+	if (opts.legacy && bundler === 'webpack') {
+		throw new Error(`Legacy builds are not supported for projects using webpack`);
+	}
 
 	return new Promise((fulfil, reject) => {
 		try {
@@ -13,6 +17,7 @@ export function build(opts: { bundler?: string }) {
 				dest: locations.dest(),
 				app: locations.app(),
 				routes: locations.routes(),
+				legacy: opts.legacy,
 				bundler,
 				webpack: 'webpack',
 				rollup: 'rollup'

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -9,8 +9,11 @@ export default {
 		},
 
 		output: () => {
+			let dir = `${locations.dest()}/client`;
+			if (process.env.SAPPER_LEGACY_BUILD) dir += `/legacy`;
+
 			return {
-				dir: `${locations.dest()}/client`,
+				dir,
 				entryFileNames: '[name].[hash].js',
 				chunkFileNames: '[name].[hash].js',
 				format: 'esm'


### PR DESCRIPTION
First stab at #280. This adds a `--legacy` flag to `sapper build` and `sapper export`.

When the flag is set, Sapper creates two builds, by running your client config twice — once normally, and once with `process.env.SAPPER_LEGACY_BUILD === 'true'`. It has no opinion about *how* exactly you define a legacy build, but it's easy to do in a Rollup config file. The regular build goes in `client`, the legacy build goes in `client/legacy`.

Later, when the middleware renders the page, it includes a block of code like this (except minified):

```html
<script>
  (function(){
    try{
      eval("async function x(){}");
      var main="${main}"k
    } catch (e) {
      main="${legacy_main}"k
    };

    try{
      new Function("import('"+main+"')")();
    } catch (e) {
      var s = document.createElement("script");
      s.src="${req.baseUrl}/client/shimport@${build_info.shimport}.js";
      s.setAttribute("data-main",main);
      document.head.appendChild(s);
    }
  }());
</script>
```

In other words, it selects between `client/client.xyz123,js` and `client/legacy/client.abc234.js` based on whether the `async` keyword is supported. This is [the same way Meteor defines](https://blog.meteor.com/meteor-1-7-and-the-evergreen-dream-a8c1270b0901) 'modern browser'.

The thinking is that you would add the Babel plugin to your Rollup config and only run it if the env var was set. You can see what that looks like here: https://github.com/sveltejs/sapper-template-rollup/blob/babel/rollup/client.config.js (the app is deployed [here](https://sapper-template-rollup-babel.now.sh/), if anyone fancies verifying that it does in fact work in e.g. IE11, since I haven't had the chance to do that yet).

Does this seem like the right approach?