### PR TITLE
Blessed logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sapper",
-  "version": "0.19.0",
+  "version": "0.19.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,6 +9,15 @@
       "resolved": "https://registry.npmjs.org/@arr/every/-/every-1.0.0.tgz",
       "integrity": "sha1-MU+BaPUK5IoDLP2tX9tDb0ZKl6w=",
       "dev": true
+    },
+    "@types/blessed": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@types/blessed/-/blessed-0.1.10.tgz",
+      "integrity": "sha512-lCpkGnCq2lj9RBPwh/RH/ZJegYV6JdyyRHmURIW1DwMdtNhRRxYeHllqaMu8K6bDf6zhO7PpHsmEqlYMDPlmhw==",
+      "requires": {
+        "@types/events": "*",
+        "@types/node": "*"
+      }
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -19,8 +28,7 @@
     "@types/events": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
-      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
-      "dev": true
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
     },
     "@types/glob": {
       "version": "5.0.35",
@@ -57,8 +65,7 @@
     "@types/node": {
       "version": "10.9.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
-      "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw==",
-      "dev": true
+      "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw=="
     },
     "@types/rimraf": {
       "version": "2.0.2",
@@ -1009,6 +1016,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
+    },
+    "blessed": {
+      "version": "0.1.81",
+      "resolved": "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz",
+      "integrity": "sha1-+WLWh+wsNpVwrnGvhDJW5tDKESk="
     },
     "bluebird": {
       "version": "3.5.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "test": "test"
   },
   "dependencies": {
+    "@types/blessed": "^0.1.10",
+    "blessed": "^0.1.81",
     "html-minifier": "^3.5.16",
     "shimport": "^0.0.10",
     "source-map-support": "^0.5.6",

--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -200,6 +200,8 @@ class Watcher extends EventEmitter {
 			handle_result: (result: CompileResult) => {
 				deferred.promise.then(() => {
 					const restart = () => {
+						this.emit('restart');
+
 						log = '';
 						this.crashed = false;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,13 +15,15 @@ prog.command('dev')
 	.option('--hot', 'Use hot module replacement (requires webpack)', true)
 	.option('--live', 'Reload on changes if not using --hot', true)
 	.option('--bundler', 'Specify a bundler (rollup or webpack)')
+	.option('--stream', 'Stream logs, inside of boxing them', false)
 	.action(async (opts: {
 		port: number,
 		open: boolean,
 		'dev-port': number,
 		live: boolean,
 		hot: boolean,
-		bundler?: string
+		bundler?: string,
+		stream: boolean
 	}) => {
 		const { dev } = await import('./cli/dev');
 		dev(opts);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ prog.command('dev')
 	.option('--hot', 'Use hot module replacement (requires webpack)', true)
 	.option('--live', 'Reload on changes if not using --hot', true)
 	.option('--bundler', 'Specify a bundler (rollup or webpack)')
-	.option('--stream', 'Stream logs, inside of boxing them', false)
+	.option('--stream', 'Stream logs, instead of boxing them', false)
 	.action(async (opts: {
 		port: number,
 		open: boolean,

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -1,11 +1,78 @@
 import * as path from 'path';
 import colors from 'kleur';
 import * as child_process from 'child_process';
+import * as blessed from 'blessed';
 import prettyMs from 'pretty-ms';
 import { dev as _dev } from '../api/dev';
 import * as events from '../api/interfaces';
 
 export function dev(opts: { port: number, open: boolean, bundler?: string }) {
+	const screen = blessed.screen({
+		smartCSR: true
+	});
+
+	const status_box = blessed.box({
+		width: '100%',
+		height: '50%',
+		scrollable: true
+	});
+
+	let mouse_is_down = false;
+	let dragging = false;
+
+	screen.on('mousedown', data => {
+		if (mouse_is_down) {
+			if (dragging) {
+				divider.top = data.y;
+				status_box.height = data.y;
+				log_box.height = screen.height - (data.y + 1);
+				screen.render();
+			}
+		} else {
+			if (data.y === divider.top) {
+				dragging = true;
+			}
+
+			mouse_is_down = true;
+		}
+	});
+
+	screen.on('mouseup', data => {
+		mouse_is_down = false;
+	});
+
+	const log_box = blessed.box({
+		bottom: '0',
+		width: '100%',
+		height: '50%',
+		scrollable: true
+	});
+
+	const divider = blessed.line({
+		top: '50%',
+		orientation: 'horizontal'
+	});
+
+	screen.append(status_box);
+	screen.append(log_box);
+	screen.append(divider);
+	screen.render();
+
+	screen.key(['escape', 'q', 'C-c'], function(ch, key) {
+		return process.exit(0);
+	});
+
+	const append_log = data => {
+		log_box.setContent(log_box.getContent() + data);
+		screen.render();
+	};
+
+	const append_status = line => {
+		const lines = status_box.getLines();
+		status_box.insertLine(lines.length, line);
+		screen.render();
+	};
+
 	try {
 		const watcher = _dev(opts);
 
@@ -13,68 +80,62 @@ export function dev(opts: { port: number, open: boolean, bundler?: string }) {
 
 		watcher.on('ready', (event: events.ReadyEvent) => {
 			if (first) {
-				console.log(colors.bold.cyan(`> Listening on http://localhost:${event.port}`));
+				append_status(colors.bold.cyan(`> Listening on http://localhost:${event.port}`));
 				if (opts.open) child_process.exec(`open http://localhost:${event.port}`);
 				first = false;
 			}
 
-			// TODO clear screen?
-
-			event.process.stdout.on('data', data => {
-				process.stdout.write(data);
-			});
-
-			event.process.stderr.on('data', data => {
-				process.stderr.write(data);
-			});
+			event.process.stdout.on('data', append_log);
+			event.process.stderr.on('data', append_log);
 		});
 
 		watcher.on('invalid', (event: events.InvalidEvent) => {
 			const changed = event.changed.map(filename => path.relative(process.cwd(), filename)).join(', ');
-			console.log(`\n${colors.bold.cyan(changed)} changed. rebuilding...`);
+			status_box.setContent('');
+			append_status(`\n${colors.bold.cyan(changed)} changed. rebuilding...`);
 		});
 
 		watcher.on('error', (event: events.ErrorEvent) => {
-			console.log(colors.red(`✗ ${event.type}`));
-			console.log(colors.red(event.message));
+			append_status(colors.red(`✗ ${event.type}`));
+			append_status(colors.red(event.message));
 		});
 
 		watcher.on('fatal', (event: events.FatalEvent) => {
-			console.log(colors.bold.red(`> ${event.message}`));
-			if (event.log) console.log(event.log);
+			append_status(colors.bold.red(`> ${event.message}`));
+			if (event.log) append_status(event.log);
 		});
 
 		watcher.on('build', (event: events.BuildEvent) => {
 			if (event.errors.length) {
-				console.log(colors.bold.red(`✗ ${event.type}`));
+				append_status(colors.bold.red(`✗ ${event.type}`));
 
 				event.errors.filter(e => !e.duplicate).forEach(error => {
-					if (error.file) console.log(colors.bold(error.file));
-					console.log(error.message);
+					if (error.file) append_status(colors.bold(error.file));
+					append_status(error.message);
 				});
 
 				const hidden = event.errors.filter(e => e.duplicate).length;
 				if (hidden > 0) {
-					console.log(`${hidden} duplicate ${hidden === 1 ? 'error' : 'errors'} hidden\n`);
+					append_status(`${hidden} duplicate ${hidden === 1 ? 'error' : 'errors'} hidden\n`);
 				}
 			} else if (event.warnings.length) {
-				console.log(colors.bold.yellow(`• ${event.type}`));
+				append_status(colors.bold.yellow(`• ${event.type}`));
 
 				event.warnings.filter(e => !e.duplicate).forEach(warning => {
-					if (warning.file) console.log(colors.bold(warning.file));
-					console.log(warning.message);
+					if (warning.file) append_status(colors.bold(warning.file));
+					append_status(warning.message);
 				});
 
 				const hidden = event.warnings.filter(e => e.duplicate).length;
 				if (hidden > 0) {
-					console.log(`${hidden} duplicate ${hidden === 1 ? 'warning' : 'warnings'} hidden\n`);
+					append_status(`${hidden} duplicate ${hidden === 1 ? 'warning' : 'warnings'} hidden\n`);
 				}
 			} else {
-				console.log(`${colors.bold.green(`✔ ${event.type}`)} ${colors.gray(`(${prettyMs(event.duration)})`)}`);
+				append_status(`${colors.bold.green(`✔ ${event.type}`)} ${colors.gray(`(${prettyMs(event.duration)})`)}`);
 			}
 		});
 	} catch (err) {
-		console.log(colors.bold.red(`> ${err.message}`));
+		append_status(colors.bold.red(`> ${err.message}`));
 		process.exit(1);
 	}
 }

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -118,6 +118,8 @@ function boxed_output() {
 	screen.append(horizontal_divider);
 	screen.append(vertical_divider);
 
+	update_split(process.stdout.columns >> 1, process.stdout.rows >> 1);
+
 	screen.key(['escape', 'q', 'C-c'], function(ch, key) {
 		return process.exit(0);
 	});

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -6,15 +6,25 @@ import prettyMs from 'pretty-ms';
 import { dev as _dev } from '../api/dev';
 import * as events from '../api/interfaces';
 
-export function dev(opts: { port: number, open: boolean, bundler?: string }) {
+function boxed_output() {
 	const screen = blessed.screen({
 		smartCSR: true
 	});
 
-	const status_box = blessed.box({
+	const status_box = blessed.log({
 		width: '100%',
 		height: '50%',
-		scrollable: true
+		scrollable: true,
+		style: {
+			scrollbar: {
+				bg: 'black'
+			}
+		},
+		scrollbar: {},
+		input: true,
+		mouse: true,
+		keys: true,
+		scrollOnInput: false
 	});
 
 	let mouse_is_down = false;
@@ -39,13 +49,24 @@ export function dev(opts: { port: number, open: boolean, bundler?: string }) {
 
 	screen.on('mouseup', data => {
 		mouse_is_down = false;
+		dragging = false;
 	});
 
-	const log_box = blessed.box({
+	const log_box = blessed.log({
 		bottom: '0',
 		width: '100%',
 		height: '50%',
-		scrollable: true
+		scrollable: true,
+		style: {
+			scrollbar: {
+				bg: 'black'
+			}
+		},
+		scrollbar: {},
+		input: true,
+		mouse: true,
+		keys: true,
+		scrollOnInput: false
 	});
 
 	const divider = blessed.line({
@@ -56,22 +77,70 @@ export function dev(opts: { port: number, open: boolean, bundler?: string }) {
 	screen.append(status_box);
 	screen.append(log_box);
 	screen.append(divider);
-	screen.render();
 
 	screen.key(['escape', 'q', 'C-c'], function(ch, key) {
 		return process.exit(0);
 	});
 
-	const append_log = data => {
-		log_box.setContent(log_box.getContent() + data);
+	const append_log = (data: Buffer | string) => {
+		log_box.setContent(log_box.content + data);
 		screen.render();
 	};
 
-	const append_status = line => {
-		const lines = status_box.getLines();
-		status_box.insertLine(lines.length, line);
+	const append_status = (data: Buffer | string) => {
+		status_box.setContent(status_box.content + data);
 		screen.render();
 	};
+
+	return {
+		stdout: append_log,
+
+		stderr: append_log,
+
+		clear_logs: () => {
+			log_box.setContent(`${colors.inverse(` server log • ${new Date().toISOString()}\n`)} \n`);
+			screen.render();
+		},
+
+		log: (line: string) => {
+			append_status(line + '\n');
+		},
+
+		append: append_status,
+
+		clear: () => {
+			status_box.setContent(`${colors.inverse(` build log • ${new Date().toISOString()}\n`)} \n`);
+			screen.render();
+		}
+	};
+}
+
+function streamed_output() {
+	return {
+		stdout: process.stdout.write.bind(process.stdout),
+
+		stderr: process.stderr.write.bind(process.stderr),
+
+		clear_logs: () => {},
+
+		log: (line: string) => {
+			console.log(line);
+		},
+
+		append: (data: Buffer | string) => {
+			process.stdout.write(data);
+		},
+
+		clear: () => {}
+	};
+}
+
+export function dev(opts: { port: number, open: boolean, bundler?: string, stream: boolean }) {
+	const output = opts.stream
+		? streamed_output()
+		: boxed_output();
+
+	output.clear();
 
 	try {
 		const watcher = _dev(opts);
@@ -79,63 +148,66 @@ export function dev(opts: { port: number, open: boolean, bundler?: string }) {
 		let first = true;
 
 		watcher.on('ready', (event: events.ReadyEvent) => {
+			output.log(colors.bold.cyan(`> Listening on http://localhost:${event.port}`));
+
 			if (first) {
-				append_status(colors.bold.cyan(`> Listening on http://localhost:${event.port}`));
 				if (opts.open) child_process.exec(`open http://localhost:${event.port}`);
 				first = false;
 			}
-
-			event.process.stdout.on('data', append_log);
-			event.process.stderr.on('data', append_log);
 		});
+
+		watcher.on('restart', output.clear_logs);
+		watcher.on('stdout', output.stdout);
+		watcher.on('stderr', output.stderr);
 
 		watcher.on('invalid', (event: events.InvalidEvent) => {
 			const changed = event.changed.map(filename => path.relative(process.cwd(), filename)).join(', ');
-			status_box.setContent('');
-			append_status(`\n${colors.bold.cyan(changed)} changed. rebuilding...`);
+
+			output.clear();
+			output.log(`${colors.bold.cyan(changed)} changed. rebuilding...`);
 		});
 
 		watcher.on('error', (event: events.ErrorEvent) => {
-			append_status(colors.red(`✗ ${event.type}`));
-			append_status(colors.red(event.message));
+			output.log(colors.red(`✗ ${event.type}`));
+			output.log(colors.red(event.message));
 		});
 
 		watcher.on('fatal', (event: events.FatalEvent) => {
-			append_status(colors.bold.red(`> ${event.message}`));
-			if (event.log) append_status(event.log);
+			output.log(colors.bold.red(`> ${event.message}`));
+			if (event.log) output.log(event.log);
 		});
 
 		watcher.on('build', (event: events.BuildEvent) => {
 			if (event.errors.length) {
-				append_status(colors.bold.red(`✗ ${event.type}`));
+				output.log(colors.bold.red(`✗ ${event.type}`));
 
 				event.errors.filter(e => !e.duplicate).forEach(error => {
-					if (error.file) append_status(colors.bold(error.file));
-					append_status(error.message);
+					if (error.file) output.log(colors.bold(error.file));
+					output.log(error.message);
 				});
 
 				const hidden = event.errors.filter(e => e.duplicate).length;
 				if (hidden > 0) {
-					append_status(`${hidden} duplicate ${hidden === 1 ? 'error' : 'errors'} hidden\n`);
+					output.log(`${hidden} duplicate ${hidden === 1 ? 'error' : 'errors'} hidden\n`);
 				}
 			} else if (event.warnings.length) {
-				append_status(colors.bold.yellow(`• ${event.type}`));
+				output.log(colors.bold.yellow(`• ${event.type}`));
 
 				event.warnings.filter(e => !e.duplicate).forEach(warning => {
-					if (warning.file) append_status(colors.bold(warning.file));
-					append_status(warning.message);
+					if (warning.file) output.log(colors.bold(warning.file));
+					output.log(warning.message);
 				});
 
 				const hidden = event.warnings.filter(e => e.duplicate).length;
 				if (hidden > 0) {
-					append_status(`${hidden} duplicate ${hidden === 1 ? 'warning' : 'warnings'} hidden\n`);
+					output.log(`${hidden} duplicate ${hidden === 1 ? 'warning' : 'warnings'} hidden\n`);
 				}
 			} else {
-				append_status(`${colors.bold.green(`✔ ${event.type}`)} ${colors.gray(`(${prettyMs(event.duration)})`)}`);
+				output.log(`${colors.bold.green(`✔ ${event.type}`)} ${colors.gray(`(${prettyMs(event.duration)})`)}`);
 			}
 		});
 	} catch (err) {
-		append_status(colors.bold.red(`> ${err.message}`));
+		output.log(colors.bold.red(`> ${err.message}`));
 		process.exit(1);
 	}
 }


### PR DESCRIPTION
This improves (I think) dev mode logging by separating build logs from server logs, instead of interleaving them as is currently the case. It looks like this:

<img width="1553" alt="screen shot 2018-09-03 at 5 29 35 pm" src="https://user-images.githubusercontent.com/1162160/45001883-23cb7f80-af9f-11e8-84d4-510c90367526.png">

The terminal is on the right hand side, split into a top half and a bottom half. The top half contains build logs (including warnings, such as the unused style notice), while the bottom half contains whatever your server logs out. Invalidating the build clears the top half; if the server successfully restarts, the bottom half is cleared.

For terminals that are wider than they are tall, you can toggle between horizontal and vertical splits by clicking on the divider, which is also draggable.

Also fixed in this PR: #305.

To get the old behaviour back, do `sapper dev --stream`. 