### PR TITLE
Enable source maps by default in dev mode when using rollup

### DIFF
--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -30,7 +30,8 @@ export default {
 		output: () => {
 			return {
 				dir: locations.dest(),
-				format: 'cjs'
+				format: 'cjs',
+				sourcemap: dev()
 			};
 		}
 	},


### PR DESCRIPTION
Make debugging easier.