### PR TITLE
Allow scripts to contain a CSP nonce

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -525,11 +525,11 @@ function get_page_handler(
 			}
 
 			// users can set a CSP nonce using res.locals.nonce
-			const nonceAttr = (res.locals && res.locals.nonce) ? ` nonce="${res.locals.nonce}"` : '';
+			const nonce_attr = (res.locals && res.locals.nonce) ? ` nonce="${res.locals.nonce}"` : '';
 
 			const body = template()
 				.replace('%sapper.base%', () => `<base href="${req.baseUrl}/">`)
-				.replace('%sapper.scripts%', () => `<script${nonceAttr}>${script}</script>`)
+				.replace('%sapper.scripts%', () => `<script${nonce_attr}>${script}</script>`)
 				.replace('%sapper.html%', () => html)
 				.replace('%sapper.head%', () => `<noscript id='sapper-head-start'></noscript>${head}<noscript id='sapper-head-end'></noscript>`)
 				.replace('%sapper.styles%', () => styles);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -524,9 +524,12 @@ function get_page_handler(
 				styles = (css && css.code ? `<style>${css.code}</style>` : '');
 			}
 
+			// users can set a CSP nonce using res.locals.nonce
+			const nonceAttr = (res.locals && res.locals.nonce) ? ` nonce="${res.locals.nonce}"` : '';
+
 			const body = template()
 				.replace('%sapper.base%', () => `<base href="${req.baseUrl}/">`)
-				.replace('%sapper.scripts%', () => `<script>${script}</script>`)
+				.replace('%sapper.scripts%', () => `<script${nonceAttr}>${script}</script>`)
 				.replace('%sapper.html%', () => html)
 				.replace('%sapper.head%', () => `<noscript id='sapper-head-start'></noscript>${head}<noscript id='sapper-head-end'></noscript>`)
 				.replace('%sapper.styles%', () => styles);


### PR DESCRIPTION
This PR allows Sapper to use a [nonce](https://www.troyhunt.com/locking-down-your-website-scripts-with-csp-hashes-nonces-and-report-uri/) for inline scripts, using the [Express and Helmet convention of `res.locals.nonce`](https://helmetjs.github.io/docs/csp/#generating-nonces).

CSP is a key feature for Pinafore because it's a webapp that can talk to multiple third-party servers (Mastodon instances), none of which may trust each other. The app also injects arbitrary HTML from these servers. This HTML is expected to be sanitized, but a malicious instance could inject inline `<script>`s to read data from other instances. To prevent this, Pinafore uses [Helmet](http://helmetjs.github.io/) with CSP.

Unfortunately Sapper now injects inline `<script>`s, which are blocked by CSP. This PR would allow a Sapper app to use nonces instead, allowing Sapper to function correctly while still blocking arbitrary inline scripts.