### PR TITLE
Add cache-control:immutable for immutable assets

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -151,7 +151,7 @@ export default function middleware(opts: {
 
 		serve({
 			prefix: '/client/',
-			cache_control: dev() ? 'no-cache' : 'max-age=31536000'
+			cache_control: dev() ? 'no-cache' : 'max-age=31536000, immutable'
 		}),
 
 		get_server_route_handler(manifest.server_routes),


### PR DESCRIPTION
Since the `client/` assets are immutable and uniq'ed by a checksum, we can add [immutable caching](https://hacks.mozilla.org/2017/01/using-immutable-caching-to-speed-up-the-web/) headers to allow browsers that support it (Firefox, Edge currently) to avoid unnecessary revalidation requests.

The way Chrome currently works is that it uses heuristics based on the `max-age` rather than `immutable`, so this will also work for Chrome. Not sure about Safari.