### PR TITLE
Set service-worker max-age to 0

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -141,12 +141,12 @@ export default function middleware(opts: {
 
 		fs.existsSync(path.join(output, 'service-worker.js')) && serve({
 			pathname: '/service-worker.js',
-			cache_control: 'max-age=600'
+			cache_control: 'max-age=0'
 		}),
 
 		fs.existsSync(path.join(output, 'service-worker.js.map')) && serve({
 			pathname: '/service-worker.js.map',
-			cache_control: 'max-age=600'
+			cache_control: 'max-age=0'
 		}),
 
 		serve({


### PR DESCRIPTION
As of Chrome 68 and Firefox 57 (and Edge and Safari), service workers are always revalidated regardless of the `cache-control` directive. So it's recommended to use `cache-control: max-age=0`, since it aligns older browsers with the newer behavior and also makes it clear to developers what's going on.

For the service worker sourcemap file I don't think it really matters what we do, since it's a request that is only made when DevTools are open, but I'd say align it with `service-worker.js` just in case the two get out of sync somehow.

Sources:

- https://developers.google.com/web/updates/2018/06/fresher-sw
- https://stackoverflow.com/a/38854905