### PR TITLE
Use consistent cache-control:max-age=600 for HTML pages

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -136,7 +136,7 @@ export default function middleware(opts: {
 
 		fs.existsSync(path.join(output, 'index.html')) && serve({
 			pathname: '/index.html',
-			cache_control: 'max-age=600'
+			cache_control: dev() ? 'no-cache' : 'max-age=600'
 		}),
 
 		fs.existsSync(path.join(output, 'service-worker.js')) && serve({
@@ -532,6 +532,7 @@ function get_page_handler(
 				.replace('%sapper.styles%', () => styles);
 
 			res.statusCode = status;
+			res.setHeader('Cache-Control', dev() ? 'no-cache' : 'max-age=600');
 			res.end(body);
 		}).catch(err => {
 			if (error) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -312,6 +312,7 @@ function get_page_handler(
 		 } = get_build_info();
 
 		res.setHeader('Content-Type', 'text/html');
+		res.setHeader('Cache-Control', dev() ? 'no-cache' : 'max-age=600');
 
 		// preload main.js and current route
 		// TODO detect other stuff we can preload? images, CSS, fonts?
@@ -532,7 +533,6 @@ function get_page_handler(
 				.replace('%sapper.styles%', () => styles);
 
 			res.statusCode = status;
-			res.setHeader('Cache-Control', dev() ? 'no-cache' : 'max-age=600');
 			res.end(body);
 		}).catch(err => {
 			if (error) {

--- a/test/common/test.js
+++ b/test/common/test.js
@@ -5,6 +5,7 @@ const Nightmare = require('nightmare');
 const walkSync = require('walk-sync');
 const rimraf = require('rimraf');
 const ports = require('port-authority');
+const fetch = require('node-fetch');
 
 Nightmare.action('page', {
 	title(done) {
@@ -800,13 +801,18 @@ function run({ mode, basepath = '' }) {
 		});
 
 		describe('headers', () => {
-			it('sets Content-Type and Link...preload headers', () => {
-				return capture(() => nightmare.goto(base)).then(requests => {
-					const { headers } = requests[0];
+			it('sets Content-Type, Link...preload, and Cache-Control headers', () => {
+				return capture(() => fetch(base)).then(responses => {
+					const { headers } = responses[0];
 
 					assert.equal(
 						headers['content-type'],
 						'text/html'
+					);
+
+					assert.equal(
+						headers['cache-control'],
+						'max-age=600'
 					);
 
 					const str = ['main', '.+?\\.\\d+']


### PR DESCRIPTION
Currently there is a `cache-control:max-age=600` set for `index.html`, but no `cache-control` header set for the HTML pages served from routes. This PR makes both of them consistently use `max-age:600` in production and `no-cache` in development.

In a future PR, I would like to make all of these cache-control headers configurable:

- immutable assets (`'max-age=31536000, immutable'` by default)
- routes, `index.html` (`'max-age=600'` by default)
- service worker (`'max-age=0'` by default, see #428)

But for now I would settle for making them consistent. :)