### PR TITLE
put server assets in subfolder

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -71,7 +71,7 @@ async function execute(emitter: EventEmitter, opts: Opts) {
 		message: `Crawling ${root.href}`
 	});
 
-	const proc = child_process.fork(path.resolve(`${opts.build}/server.js`), [], {
+	const proc = child_process.fork(path.resolve(`${opts.build}/server/server.js`), [], {
 		cwd: process.cwd(),
 		env: Object.assign({
 			PORT: port,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,7 +58,7 @@ prog.command('build [dest]')
 				process.env.PORT = process.env.PORT || ${opts.port || 3000};
 
 				console.log('Starting server on port ' + process.env.PORT);
-				require('./server');
+				require('./server/server.js');
 			`.replace(/^\t+/gm, '').trim());
 
 			console.error(`\n> Finished in ${elapsed(start)}. Type ${colors.bold.cyan(`node ${dest}`)} to run the app.`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,7 +58,7 @@ prog.command('build [dest]')
 				process.env.PORT = process.env.PORT || ${opts.port || 3000};
 
 				console.log('Starting server on port ' + process.env.PORT);
-				require('./server.js');
+				require('./server');
 			`.replace(/^\t+/gm, '').trim());
 
 			console.error(`\n> Finished in ${elapsed(start)}. Type ${colors.bold.cyan(`node ${dest}`)} to run the app.`);

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -25,7 +25,7 @@ export default {
 	server: {
 		input: () => {
 			return {
-				index: `${locations.src()}/server.js`
+				server: `${locations.src()}/server.js`
 			};
 		},
 

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -24,12 +24,14 @@ export default {
 
 	server: {
 		input: () => {
-			return `${locations.src()}/server.js`
+			return {
+				index: `${locations.src()}/server.js`
+			};
 		},
 
 		output: () => {
 			return {
-				dir: locations.dest(),
+				dir: `${locations.dest()}/server`,
 				format: 'cjs',
 				sourcemap: dev()
 			};

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -23,13 +23,13 @@ export default {
 	server: {
 		entry: () => {
 			return {
-				server: `${locations.src()}/server`
+				index: `${locations.src()}/server`
 			};
 		},
 
 		output: () => {
 			return {
-				path: locations.dest(),
+				path: `${locations.dest()}/server`,
 				filename: '[name].js',
 				chunkFilename: '[hash]/[name].[id].js',
 				libraryTarget: 'commonjs2'

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -23,7 +23,7 @@ export default {
 	server: {
 		entry: () => {
 			return {
-				index: `${locations.src()}/server`
+				server: `${locations.src()}/server`
 			};
 		},
 

--- a/test/common/test.js
+++ b/test/common/test.js
@@ -184,7 +184,7 @@ function run({ mode, basepath = '' }) {
 					assert.ok(fs.existsSync('__sapper__/build/index.js'));
 				}
 
-				proc = require('child_process').fork(`${dir}/server.js`, {
+				proc = require('child_process').fork(`${dir}/server/server.js`, {
 					cwd: process.cwd(),
 					env: {
 						NODE_ENV: mode,


### PR DESCRIPTION
Just ran into a case where the production build wasn't behaving correctly because the launcher `index.js` was overwriting the file corresponding to `src/routes/index.html`. This eliminates that possibility