### PR TITLE
Fix rollup input paths on Windows

### DIFF
--- a/src/core/create_compilers/RollupResult.ts
+++ b/src/core/create_compilers/RollupResult.ts
@@ -38,11 +38,18 @@ export default class RollupResult implements CompileResult {
 		// webpack, but we can have a route -> [chunk] map or something
 		this.assets = {};
 
-		compiler.chunks.forEach(chunk => {
-			if (compiler.input in chunk.modules) {
-				this.assets.main = chunk.fileName;
+		if (typeof compiler.input === 'string') {
+			compiler.chunks.forEach(chunk => {
+				if (compiler.input in chunk.modules) {
+					this.assets.main = chunk.fileName;
+				}
+			});
+		} else {
+			for (const name in compiler.input) {
+				const file = compiler.input[name];
+				this.assets[name] = compiler.chunks.find(chunk => file in chunk.modules).fileName;
 			}
-		});
+		}
 
 		this.summary = compiler.chunks.map(chunk => {
 			const size_color = chunk.code.length > 150000 ? colors.bold.red : chunk.code.length > 50000 ? colors.bold.yellow : colors.bold.white;

--- a/src/core/create_compilers/index.ts
+++ b/src/core/create_compilers/index.ts
@@ -15,6 +15,13 @@ export default async function create_compilers(bundler: 'rollup' | 'webpack'): P
 		const config = await RollupCompiler.load_config();
 		validate_config(config, 'rollup');
 
+		normalize_rollup_config(config.client);
+		normalize_rollup_config(config.server);
+
+		if (config.serviceworker) {
+			normalize_rollup_config(config.serviceworker);
+		}
+
 		return {
 			client: new RollupCompiler(config.client),
 			server: new RollupCompiler(config.server),
@@ -40,5 +47,15 @@ export default async function create_compilers(bundler: 'rollup' | 'webpack'): P
 function validate_config(config: any, bundler: 'rollup' | 'webpack') {
 	if (!config.client || !config.server) {
 		throw new Error(`${bundler}.config.js must export a { client, server, serviceworker? } object`);
+	}
+}
+
+function normalize_rollup_config(config: any) {
+	if (typeof config.input === 'string') {
+		config.input = path.normalize(config.input);
+	} else {
+		for (const name in config.input) {
+			config.input[name] = path.normalize(config.input[name]);
+		}
 	}
 }


### PR DESCRIPTION
Normalizes input paths so they match rollup's `chunk.modules`.