### PR TITLE
more robust cookies

### DIFF
--- a/templates/src/server/middleware/get_page_handler.ts
+++ b/templates/src/server/middleware/get_page_handler.ts
@@ -93,19 +93,21 @@ export function get_page_handler(
 					if (include_cookies) {
 						if (!opts.headers) opts.headers = {};
 
-						const str = []
-							.concat(
-								cookie.parse(req.headers.cookie || ''),
-								cookie.parse(opts.headers.cookie || ''),
-								cookie.parse(res.getHeader('Set-Cookie') || '')
-							)
-							.map(cookie => {
-								return Object.keys(cookie)
-									.map(name => `${name}=${encodeURIComponent(cookie[name])}`)
-									.join('; ');
-							})
-							.filter(Boolean)
-							.join(', ');
+						const cookies = Object.assign(
+							{},
+							cookie.parse(req.headers.cookie || ''),
+							cookie.parse(opts.headers.cookie || '')
+						);
+
+						const set_cookie = res.getHeader('Set-Cookie');
+						(Array.isArray(set_cookie) ? set_cookie : [set_cookie]).forEach(str => {
+							const match = /([^=]+)=([^;]+)/.exec(<string>str);
+							if (match) cookies[match[1]] = match[2];
+						});
+
+						const str = Object.keys(cookies)
+							.map(key => `${key}=${cookies[key]}`)
+							.join('; ');
 
 						opts.headers.cookie = str;
 					}

--- a/test/app/src/routes/credentials/test.json.js
+++ b/test/app/src/routes/credentials/test.json.js
@@ -1,20 +1,15 @@
-export function get(req, res) {
-	const cookies = req.headers.cookie
-		? req.headers.cookie.split(/,\s+/).reduce((cookies, cookie) => {
-			const [pair] = cookie.split('; ');
-			const [name, value] = pair.split('=');
-			cookies[name] = value;
-			return cookies;
-		}, {})
-		: {};
+import cookie from 'cookie';
 
-	if (cookies.test) {
+export function get(req, res) {
+	if (req.headers.cookie) {
+		const cookies = cookie.parse(req.headers.cookie);
+
 		res.writeHead(200, {
 			'Content-Type': 'application/json'
 		});
 
 		res.end(JSON.stringify({
-			message: cookies.test
+			message: `a: ${cookies.a}, b: ${cookies.b}, max-age: ${cookies['max-age']}`
 		}));
 	} else {
 		res.writeHead(403, {

--- a/test/app/src/server.js
+++ b/test/app/src/server.js
@@ -44,7 +44,7 @@ const middlewares = [
 
 	// set test cookie
 	(req, res, next) => {
-		res.setHeader('Set-Cookie', 'test=woohoo!; Max-Age=3600');
+		res.setHeader('Set-Cookie', ['a=1; Path=/', 'b=2; Path=/']);
 		next();
 	},
 

--- a/test/common/test.js
+++ b/test/common/test.js
@@ -623,7 +623,7 @@ function run({ mode, basepath = '' }) {
 				return nightmare.goto(`${base}/credentials?creds=include`)
 					.page.title()
 					.then(title => {
-						assert.equal(title, 'woohoo!');
+						assert.equal(title, 'a: 1, b: 2, max-age: undefined');
 					});
 			});
 
@@ -641,7 +641,7 @@ function run({ mode, basepath = '' }) {
 					.wait(100)
 					.page.title()
 					.then(title => {
-						assert.equal(title, 'woohoo!');
+						assert.equal(title, 'a: 1, b: 2, max-age: undefined');
 					});
 			});
 


### PR DESCRIPTION
Man, cookies suck. Took me a long time to figure the following out:

* The cookies that you send from server to client via a `Set-Cookie` header contain the key and value (`foo=bar`), but also a number of attributes (which could have values, like `Max-Age=3600`, but needn't, like `HttpOnly`). These are separated by a semi-colon. The order of attributes doesn't matter, but the key/value must go first
* You can set multiple cookies in a single response, by having multiple `Set-Cookie` headers (i.e. you can't set multiple cookies in a single header)
* You can't call `response.setHeader('Set-Cookie', '...')` multiple times. Instead you must pass an array as the second argument (`response.setHeader('Set-Cookie', ['a=1', 'b=2'])`). No error or warning will be given if you get this wrong
* If you need to get the header back later (which Sapper does), `res.getHeader('Set-Content')` could therefore return either a string or an array of strings
* The cookies that the client then sends back to the server only include the key/value. In a masterstroke of totally, 100% intuitive design, they come in the form of a single semi-colon-separated string, which looks ldentical to the `Set-Cookie` header except that it means something completely different (the semi-colon now separates cookies, *not* attributes)
* If you're using the `cookie` library, `cookie.parse` works with the cookies the client sends to the server but *not* the other way around

Anyway, Sapper was behaving incorrectly because I didn't understand all that until now. This PR fixes it.