### PR TITLE
ensure CSS placeholders are overwritten

### DIFF
--- a/src/core/create_compilers/extract_css.ts
+++ b/src/core/create_compilers/extract_css.ts
@@ -205,11 +205,15 @@ export default function extract_css(client_result: CompileResult, components: Pa
 		result.chunks[component.file] = files;
 	});
 
-	const replaced = entry.replace(/["']__SAPPER_CSS_PLACEHOLDER:(.+?)__["']/g, (m, route) => {
-		return JSON.stringify(replacements.get(route));
-	});
+	fs.readdirSync(`${dirs.dest}/client`).forEach(file => {
+		const source = fs.readFileSync(`${dirs.dest}/client/${file}`, 'utf-8');
 
-	fs.writeFileSync(`${dirs.dest}/client/${main}`, replaced);
+		const replaced = source.replace(/["']__SAPPER_CSS_PLACEHOLDER:(.+?)__["']/g, (m, route) => {
+			return JSON.stringify(replacements.get(route));
+		});
+
+		fs.writeFileSync(`${dirs.dest}/client/${file}`, replaced);
+	});
 
 	const leftover = get_css_from_modules(Array.from(unaccounted_for));
 	if (leftover) {


### PR DESCRIPTION
After #453, CSS started weirding out in Rollup apps, because the chunking algorithm was putting the manifest in a non-entry chunk. Specifically, CSS for pages that are navigated to after the initial load is not fetched.

This fixes it in an admittedly brute-force way. A neater solution would look something like https://github.com/rollup/rollup/issues/2447, but for now this is probably the most appropriate step to take.

(Also, this underscores the need to get some Rollup tests into the test suite — soon, when I'm less busy)