### PR TITLE
fix path for component css when using a baseUrl

### DIFF
--- a/templates/src/client/app.ts
+++ b/templates/src/client/app.ts
@@ -340,7 +340,7 @@ export function prepare_page(target: Target): Promise<{
 }
 
 function load_css(chunk: string) {
-	const href = `${initial_data.baseUrl}client/${chunk}`;
+	const href = `${initial_data.baseUrl}/client/${chunk}`;
 	if (document.querySelector(`link[href="${href}"]`)) return;
 
 	return new Promise((fulfil, reject) => {


### PR DESCRIPTION
Fixes a `500` from the missing "/" before "client" when loading a component's css
> Refused to apply style from 'http://localhost:3000/custom/pathclient/chunk.8d05bbb2.css' because its MIME type ('text/html') is not a supported stylesheet MIME type, and strict MIME checking is enabled.

Let me know if I should push my sapper-template fork that reproduces the original error! I think this only happens when using express and a basepath.