### PR TITLE
no need to use basepath in <link>

### DIFF
--- a/templates/src/client/app.ts
+++ b/templates/src/client/app.ts
@@ -342,7 +342,7 @@ export function prepare_page(target: Target): Promise<{
 }
 
 function load_css(chunk: string) {
-	const href = `${initial_data.baseUrl}client/${chunk}`;
+	const href = `client/${chunk}`;
 	if (document.querySelector(`link[href="${href}"]`)) return;
 
 	return new Promise((fulfil, reject) => {


### PR DESCRIPTION
supersedes #465 