### PR TITLE
replace magic env vars with documented CLI flags

### DIFF
--- a/src/api/build.ts
+++ b/src/api/build.ts
@@ -16,25 +16,33 @@ type Opts = {
 	routes?: string;
 	dest?: string;
 	output?: string;
-	static_files?: string;
+	static?: string;
 	legacy?: boolean;
 	bundler?: 'rollup' | 'webpack';
 	oncompile?: ({ type, result }: { type: string, result: CompileResult }) => void;
 };
 
 export async function build({
-	cwd = process.cwd(),
-	src = path.join(cwd, 'src'),
-	routes = path.join(cwd, 'src/routes'),
-	output = path.join(cwd, '__sapper__'),
-	static_files = path.join(cwd, 'static'),
-	dest = path.join(cwd, '__sapper__/build'),
+	cwd,
+	src = 'src',
+	routes = 'src/routes',
+	output = '__sapper__',
+	static: static_files = 'static',
+	dest = '__sapper__/build',
 
 	bundler,
 	legacy = false,
 	oncompile = noop
 }: Opts = {}) {
 	bundler = validate_bundler(bundler);
+
+	cwd = path.resolve(cwd);
+	src = path.resolve(cwd, src);
+	dest = path.resolve(cwd, dest);
+	routes = path.resolve(cwd, routes);
+	output = path.resolve(cwd, output);
+	static_files = path.resolve(cwd, static_files);
+	dest = path.resolve(cwd, dest);
 
 	if (legacy && bundler === 'webpack') {
 		throw new Error(`Legacy builds are not supported for projects using webpack`);

--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -22,7 +22,7 @@ type Opts = {
 	dest?: string,
 	routes?: string,
 	output?: string,
-	static_files?: string,
+	static?: string,
 	'dev-port'?: number,
 	live?: boolean,
 	hot?: boolean,
@@ -43,7 +43,7 @@ class Watcher extends EventEmitter {
 		dest: string;
 		routes: string;
 		output: string;
-		static_files: string;
+		static: string;
 	}
 	port: number;
 	closed: boolean;
@@ -69,12 +69,12 @@ class Watcher extends EventEmitter {
 	}
 
 	constructor({
-		cwd = process.cwd(),
-		src = path.join(cwd, 'src'),
-		routes = path.join(cwd, 'src/routes'),
-		output = path.join(cwd, '__sapper__'),
-		static_files = path.join(cwd, 'static'),
-		dest = path.join(cwd, '__sapper__/dev'),
+		cwd = '.',
+		src = 'src',
+		routes = 'src/routes',
+		output = '__sapper__',
+		static: static_files = 'static',
+		dest = '__sapper__/dev',
 		'dev-port': dev_port,
 		live,
 		hot,
@@ -84,8 +84,18 @@ class Watcher extends EventEmitter {
 	}: Opts) {
 		super();
 
+		cwd = path.resolve(cwd);
+
 		this.bundler = validate_bundler(bundler);
-		this.dirs = { cwd, src, dest, routes, output, static_files };
+		this.dirs = {
+			cwd,
+			src: path.resolve(cwd, src),
+			dest: path.resolve(cwd, dest),
+			routes: path.resolve(cwd, routes),
+			output: path.resolve(cwd, output),
+			static: path.resolve(cwd, static_files)
+		};
+
 		this.port = port;
 		this.closed = false;
 
@@ -133,7 +143,7 @@ class Watcher extends EventEmitter {
 			this.port = await ports.find(3000);
 		}
 
-		const { cwd, src, dest, routes, output, static_files } = this.dirs;
+		const { cwd, src, dest, routes, output, static: static_files } = this.dirs;
 		rimraf.sync(dest);
 		mkdirp.sync(`${dest}/client`);
 		if (this.bundler === 'rollup') copy_shimport(dest);

--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -29,15 +29,20 @@ type URL = url.UrlWithStringQuery;
 export { _export as export };
 
 async function _export({
-	cwd = process.cwd(),
-	static: static_files = path.join(cwd, 'static'),
-	build_dir = path.join(cwd, '__sapper__/build'),
+	cwd,
+	static: static_files = 'static',
+	build_dir = '__sapper__/build',
+	export_dir = '__sapper__/export',
 	basepath = '',
-	export_dir = path.join(cwd, '__sapper__/export', basepath),
 	timeout = 5000,
 	oninfo = noop,
 	onfile = noop
 }: Opts = {}) {
+	cwd = path.resolve(cwd);
+	static_files = path.resolve(cwd, static_files);
+	build_dir = path.resolve(cwd, build_dir);
+	export_dir = path.resolve(cwd, export_dir, basepath);
+
 	// Prep output directory
 	sander.rimrafSync(export_dir);
 


### PR DESCRIPTION
Follow-up to https://github.com/sveltejs/sapper/pull/468. The locations of various files are now entirely configurable via the CLI, in the rare cases that's necessary, rather than via undocumented environment variables.

cc @lukeed 