### PR TITLE
clear errors on successful render

### DIFF
--- a/templates/src/client/app.ts
+++ b/templates/src/client/app.ts
@@ -310,7 +310,7 @@ export function prepare_page(target: Target): Promise<{
 			};
 		}
 
-		const props = { path, query };
+		const props = { path, query, error: null, status: null };
 		const data = {
 			path,
 			preloading: false,

--- a/test/apps/AppRunner.ts
+++ b/test/apps/AppRunner.ts
@@ -58,7 +58,8 @@ export class AppRunner {
 			start: () => this.page.evaluate(() => start()),
 			prefetchRoutes: () => this.page.evaluate(() => prefetchRoutes()),
 			prefetch: (href: string) => this.page.evaluate((href: string) => prefetch(href), href),
-			goto: (href: string) => this.page.evaluate((href: string) => goto(href), href)
+			goto: (href: string) => this.page.evaluate((href: string) => goto(href), href),
+			title: () => this.page.$eval('h1', node => node.textContent)
 		};
 	}
 

--- a/test/apps/errors/src/routes/enhance-your-calm.html
+++ b/test/apps/errors/src/routes/enhance-your-calm.html
@@ -1,0 +1,7 @@
+<script>
+	export default {
+		preload() {
+			this.error(420, 'Enhance your calm');
+		}
+	};
+</script>

--- a/test/apps/errors/src/routes/no-error.html
+++ b/test/apps/errors/src/routes/no-error.html
@@ -1,0 +1,3 @@
+<h1>{error ? error.message : 'No error here'}</h1>
+
+<a href="enhance-your-calm">Enhance your calm</a>

--- a/test/apps/errors/test.ts
+++ b/test/apps/errors/test.ts
@@ -14,13 +14,14 @@ describe('errors', function() {
 	// helpers
 	let start: () => Promise<void>;
 	let prefetchRoutes: () => Promise<void>;
+	let title: () => Promise<string>;
 
 	// hooks
 	before(async () => {
 		await build({ cwd: __dirname });
 
 		runner = new AppRunner(__dirname, '__sapper__/build/server/server.js');
-		({ base, page, start, prefetchRoutes } = await runner.start());
+		({ base, page, start, prefetchRoutes, title } = await runner.start());
 	});
 
 	after(() => runner.end());
@@ -109,5 +110,17 @@ describe('errors', function() {
 			await page.evaluate(() => document.body.textContent),
 			'oops'
 		);
+	});
+
+	it('clears props.error on successful render', async () => {
+		await page.goto(`${base}/no-error`);
+		await start();
+		await prefetchRoutes();
+
+		await page.click('[href="enhance-your-calm"]');
+		assert.equal(await title(), '420');
+
+		await page.goBack();
+		assert.equal(await title(), 'No error here');
 	});
 });


### PR DESCRIPTION
Currently, if you navigate to a page that errors, then navigate to another page in your app, the `error` object will persist. So if you happen to have a property called `error` in a regular component, it will be incorrect.