### PR TITLE
Ensure deepest layout is always refreshed on goto

### DIFF
--- a/templates/src/client/app.ts
+++ b/templates/src/client/app.ts
@@ -217,6 +217,10 @@ export function prepare_page(target: Target): Promise<{
 		segments[changed_from] === new_segments[changed_from]
 	) changed_from += 1;
 
+	if (changed_from === new_segments.length) {
+		changed_from -= 1;
+	}
+
 	let redirect: Redirect = null;
 	let error: { statusCode: number, message: Error | string } = null;
 


### PR DESCRIPTION
See: #349, #483's ps.

This PR just forces the deepest page component to refresh on `goto`, even if that's `goto(currentPage)`. This ensures that a change to a query param triggers a navigation.

One might argue that `goto(currentPage)` should be a noop, but I'd argue otherwise for two reasons:

1. Plain old regular links to the current page aren't noop, and thus users' expectation is that the page will refresh. If you're on hackernews' homepage and click its logo, would you expect it not to refresh revealing the freshest pile of nonsense?

2. `navigate(currentPage)` could be implemented as user code to be noop or not on top of a `goto` that always navigates. The opposite isn't true: if `goto(currentPage)` is a noop, we can't have a userland `navigate` that works differently.

This should probably still be polished (especially if #483 is something we'd like to do), but I think it should work for a temporary fix.