### PR TITLE
add service-worker-index.html

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -94,7 +94,9 @@ async function _export({
 		const is_html = type === 'text/html';
 
 		if (is_html) {
-			file = file === '' ? 'index.html' : `${file}/index.html`;
+			if (pathname !== '/service-worker-index.html') {
+				file = file === '' ? 'index.html' : `${file}/index.html`;
+			}
 			body = minify_html(body);
 		}
 
@@ -113,7 +115,10 @@ async function _export({
 	});
 
 	async function handle(url: URL) {
-		const pathname = (url.pathname.replace(root.pathname, '') || '/');
+		let pathname = url.pathname;
+		if (pathname !== '/service-worker-index.html') {
+		  pathname = pathname.replace(root.pathname, '') || '/'
+		}
 
 		if (seen.has(pathname)) return;
 		seen.add(pathname);
@@ -138,7 +143,7 @@ async function _export({
 		const range = ~~(r.status / 100);
 
 		if (range === 2) {
-			if (type === 'text/html') {
+			if (type === 'text/html' && pathname !== '/service-worker-index.html') {
 				const urls: URL[] = [];
 
 				const cleaned = clean_html(body);
@@ -181,6 +186,7 @@ async function _export({
 
 	return ports.wait(port)
 		.then(() => handle(root))
+		.then(() => handle(resolve(root.href, 'service-worker-index.html')))
 		.then(() => proc.kill())
 		.catch(err => {
 			proc.kill();

--- a/src/core/create_manifests.ts
+++ b/src/core/create_manifests.ts
@@ -45,17 +45,15 @@ export function create_serviceworker_manifest({ manifest_data, output, client_fi
 	client_files: string[];
 	static_files: string;
 }) {
-	let files: string[];
+	let files: string[] = ['/service-worker-index.html'];
 
 	if (fs.existsSync(static_files)) {
-		files = walk(static_files);
+		files = files.concat(walk(static_files));
 	} else {
 		// TODO remove in a future version
 		if (fs.existsSync('assets')) {
 			throw new Error(`As of Sapper 0.21, the assets/ directory should become static/`);
 		}
-
-		files = [];
 	}
 
 	let code = `

--- a/templates/src/server/middleware/get_page_handler.ts
+++ b/templates/src/server/middleware/get_page_handler.ts
@@ -34,6 +34,7 @@ export function get_page_handler(
 	}
 
 	async function handle_page(page: Page, req: Req, res: Res, status = 200, error: Error | string = null) {
+		const isSWIndexHtml = req.path === '/service-worker-index.html';
 		const build_info: {
 			bundler: 'rollup' | 'webpack',
 			shimport: string | null,
@@ -47,7 +48,7 @@ export function get_page_handler(
 		// preload main.js and current route
 		// TODO detect other stuff we can preload? images, CSS, fonts?
 		let preloaded_chunks = Array.isArray(build_info.assets.main) ? build_info.assets.main : [build_info.assets.main];
-		if (!error) {
+		if (!error && !isSWIndexHtml) {
 			page.parts.forEach(part => {
 				if (!part) return;
 
@@ -145,17 +146,22 @@ export function get_page_handler(
 
 			match = error ? null : page.pattern.exec(req.path);
 
-			preloaded = await Promise.all([root_preloaded].concat(page.parts.map(part => {
-				if (!part) return null;
+			let toPreload = [root_preloaded];
+			if (!isSWIndexHtml) {
+				toPreload = toPreload.concat(page.parts.map(part => {
+					if (!part) return null;
 
-				return part.component.preload
-					? part.component.preload.call(preload_context, {
-						path: req.path,
-						query: req.query,
-						params: part.params ? part.params(match) : {}
-					})
-					: {};
-			})));
+					return part.component.preload
+						? part.component.preload.call(preload_context, {
+							path: req.path,
+							query: req.query,
+							params: part.params ? part.params(match) : {}
+						})
+						: {};
+				}))
+			}
+
+			preloaded = await Promise.all(toPreload);
 		} catch (err) {
 			preload_error = { statusCode: 500, message: err };
 			preloaded = []; // appease TypeScript
@@ -204,23 +210,29 @@ export function get_page_handler(
 			});
 
 			let level = data.child;
-			for (let i = 0; i < page.parts.length; i += 1) {
-				const part = page.parts[i];
-				if (!part) continue;
+			if (isSWIndexHtml) {
+				level.props = Object.assign({}, props, {
+					params: {}
+				})
+			} else {
+				for (let i = 0; i < page.parts.length; i += 1) {
+					const part = page.parts[i];
+					if (!part) continue;
 
-				const get_params = part.params || (() => ({}));
+					const get_params = part.params || (() => ({}));
 
-				Object.assign(level, {
-					component: part.component,
-					props: Object.assign({}, props, {
-						params: get_params(match)
-					}, preloaded[i + 1])
-				});
+					Object.assign(level, {
+						component: part.component,
+						props: Object.assign({}, props, {
+							params: get_params(match)
+						}, preloaded[i + 1])
+					});
 
-				level.props.child = <Props["child"]>{
-					segment: segments[i + 1]
-				};
-				level = level.props.child;
+					level.props.child = <Props["child"]>{
+						segment: segments[i + 1]
+					};
+					level = level.props.child;
+				}
 			}
 
 			const { html, head, css } = manifest.root.render(data, {
@@ -302,6 +314,12 @@ export function get_page_handler(
 
 	return function find_route(req: Req, res: Res, next: () => void) {
 		if (req[IGNORE]) return next();
+
+		if (req.path === '/service-worker-index.html') {
+			const homePage = pages.find(page => page.pattern.test('/'));
+			handle_page(homePage, req, res);
+			return;
+		}
 
 		if (!server_routes.some(route => route.pattern.test(req.path))) {
 			for (const page of pages) {

--- a/test/apps/export/test.ts
+++ b/test/apps/export/test.ts
@@ -30,6 +30,7 @@ describe('export', function() {
 			'blog/index.html',
 			'global.css',
 			'index.html',
+			'service-worker-index.html',
 			'service-worker.js'
 		]);
 	});

--- a/test/apps/with-basepath/test.ts
+++ b/test/apps/with-basepath/test.ts
@@ -56,6 +56,7 @@ describe('with-basepath', function() {
 		assert.deepEqual(non_client_assets, [
 			'custom-basepath/global.css',
 			'custom-basepath/index.html',
+			'custom-basepath/service-worker-index.html',
 			'custom-basepath/service-worker.js'
 		]);
 	});


### PR DESCRIPTION
This fixes #422 by outputting a new `/service-worker-index.html` file which can be cached by the service worker and served in offline use cases.

The reason I went with `service-worker-index.html` rather than the old `index.html` is that the latter breaks `sapper export`, since the service worker-targeted `index.html` conflicts with the base route. Since `index.html` is kind of an imprecise name for it anyway, I figured renaming to `service-worker-index.html` made the most sense.

The only change that users will have to make in order to get this to work is to use the commented code from `sapper-template` defined [here](https://github.com/sveltejs/sapper-template/blob/1234971da512d37a6453cfebbf8e47a023f547be/src/service-worker.js#L51-L59). We'll probably want to update that commented code anyway, since it hasn't worked for about a year.

I have tested this with `sapper-template` and it works.

To test, you just `npm link` this PR to `sapper-template`, then in `sapper-template`, do `npm run build && npm start` and then navigate to the base URL, then put the Dev Tools in offline mode, uncomment the commented-out service worker code, then refresh. At this point, the new page should be served by the service worker using `service-worker-index.html`.