### PR TITLE
Added css build info for webpack apps

### DIFF
--- a/src/core/create_compilers/WebpackResult.ts
+++ b/src/core/create_compilers/WebpackResult.ts
@@ -55,14 +55,25 @@ export default class WebpackResult implements CompileResult {
 	}
 
 	to_json(manifest_data: ManifestData, dirs: Dirs): BuildInfo {
+		const extract_css = (assets: string[] | string) => {
+			assets = Array.isArray(assets) ? assets : [assets];
+			return assets.find(asset => /\.css$/.test(asset));
+		};
+
 		return {
 			bundler: 'webpack',
 			shimport: null, // webpack has its own loader
 			assets: this.assets,
 			css: {
-				// TODO
-				main: null,
-				chunks: {}
+				main: extract_css(this.assets.main),
+				chunks: Object
+					.keys(this.assets)
+					.filter(chunkName => chunkName !== 'main')
+					.reduce((chunks: { [key: string]: string }, chukName) => {
+						const assets = this.assets[chukName];
+						chunks[chukName] = extract_css(assets);
+						return chunks;
+					}, {})
 			}
 		};
 	}


### PR DESCRIPTION
Currently sapper is not filling out a `css` field in `build.json` info file when used with `mini-css-extract-plugin`. Therefore [critical css injected by sapper](https://github.com/sveltejs/sapper/blob/master/templates/src/server/middleware/get_page_handler.ts#L273) is duplicated by chunks injected by the plugin.

The PR is going to solve the issue.