### PR TITLE
Fixed rel="preload" `as` attribute for styles

### DIFF
--- a/templates/src/server/middleware/get_page_handler.ts
+++ b/templates/src/server/middleware/get_page_handler.ts
@@ -67,7 +67,10 @@ export function get_page_handler(
 		} else {
 			const link = preloaded_chunks
 				.filter(file => file && !file.match(/\.map$/))
-				.map(file => `<${req.baseUrl}/client/${file}>;rel="preload";as="script"`)
+				.map((file) => {
+					const as = /\.css$/.test(file) ? 'style' : 'script';
+					return `<${req.baseUrl}/client/${file}>;rel="preload";as="${as}"`;
+				})
 				.join(', ');
 
 			res.setHeader('Link', link);


### PR DESCRIPTION
The PR fixes a Chrome issue:
`
The resource http://localhost:3000/client/24f7444a3806f9c48fd7/main.css was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.
`

Probably images and fonts determination should be fixed too.