### PR TITLE
Fixed tests for node 6

### DIFF
--- a/test/apps/redirects/test.ts
+++ b/test/apps/redirects/test.ts
@@ -21,7 +21,19 @@ describe('redirects', function() {
 		await build({ cwd: __dirname });
 
 		runner = new AppRunner(__dirname, '__sapper__/build/server/server.js');
-		({ base, page, start, prefetchRoutes, title } = await runner.start());
+		({ base, page, start, prefetchRoutes, title } = await runner.start({
+			requestInterceptor: (interceptedRequest) => {
+				if (/example\.com/.test(interceptedRequest.url())) {
+					interceptedRequest.respond({
+						status: 200,
+						contentType: 'text/html',
+						body: `<h1>external</h1>`
+					});
+				} else {
+					interceptedRequest.continue();
+				}
+			}
+		}));
 	});
 
 	after(() => runner.end());


### PR DESCRIPTION
Well, after hours of investigation the "prefetches programmatically" test failure I noticed several things:

- the test passes when run in isolation or run in head of sequence
- the test passes when page's `requestInterception` is disabled
- sapper does prefetching (I've checked promise resolution result in [AppRunner.capture](https://github.com/sveltejs/sapper/blob/master/test/apps/AppRunner.ts#L117) and it's ok)

I guess that the real issue is in puppeteer.

So, my solution is to isolate `setRequestInterception` and deal with it only where needed more exactly in "redirects" tests.