### PR TITLE
Fix nested routes navigates

### DIFF
--- a/templates/src/client/app.ts
+++ b/templates/src/client/app.ts
@@ -36,7 +36,7 @@ const root_props: RootProps = {
 
 export let prefetching: {
 	href: string;
-	promise: Promise<{ redirect?: Redirect, data?: any, nullable_depth?: number }>;
+	promise: Promise<{ redirect?: Redirect, data?: any, nullable_depth?: number, new_segments?: any }>;
 } = null;
 export function set_prefetching(href, promise) {
 	prefetching = { href, promise };
@@ -137,9 +137,12 @@ export function navigate(target: Target, id: number, noscroll?: boolean, hash?: 
 
 	const token = current_token = {};
 
-	return loaded.then(({ redirect, data, nullable_depth }) => {
+	return loaded.then(({ redirect, data, nullable_depth, new_segments }) => {
 		if (redirect) {
 			return goto(redirect.location, { replaceState: true });
+		}
+		if (new_segments) {
+			segments = new_segments;
 		}
 		render(data, nullable_depth, scroll_history[id], noscroll, hash, token);
 		if (document.activeElement) document.activeElement.blur();
@@ -285,10 +288,8 @@ export function prepare_page(target: Target): Promise<{
 		}
 	}).then(results => {
 		if (redirect) {
-			return { redirect };
+			return { redirect, new_segments };
 		}
-
-		segments = new_segments;
 
 		const get_params = page.parts[page.parts.length - 1].params || (() => ({}));
 		const params = get_params(target.match);
@@ -303,6 +304,7 @@ export function prepare_page(target: Target): Promise<{
 			};
 
 			return {
+				new_segments,
 				data: Object.assign({}, props, {
 					preloading: false,
 					child: {
@@ -318,7 +320,7 @@ export function prepare_page(target: Target): Promise<{
 			path,
 			preloading: false,
 			child: Object.assign({}, root_props.child, {
-				segment: segments[0]
+				segment: new_segments[0]
 			})
 		};
 		if (changed(query, root_props.query)) data.query = query;
@@ -349,10 +351,10 @@ export function prepare_page(target: Target): Promise<{
 			}
 
 			level = level.props.child;
-			level.segment = segments[i + 1];
+			level.segment = new_segments[i + 1];
 		}
 
-		return { data, nullable_depth };
+		return { data, nullable_depth, new_segments };
 	});
 }
 

--- a/test/apps/preloading/src/routes/index.html
+++ b/test/apps/preloading/src/routes/index.html
@@ -2,3 +2,5 @@
 
 <a href="slow-preload">slow preload</a>
 <a href="foo">foo</a>
+<a href="prefetch/qwe" rel=prefetch>prefetch qwe</a>
+<a href="prefetch/xyz" rel=prefetch>prefetch xyz</a>

--- a/test/apps/preloading/src/routes/prefetch/[slug]/index.html
+++ b/test/apps/preloading/src/routes/prefetch/[slug]/index.html
@@ -1,0 +1,1 @@
+<h1>{params.slug}</h1>

--- a/test/apps/preloading/src/routes/prefetch/_layout.html
+++ b/test/apps/preloading/src/routes/prefetch/_layout.html
@@ -1,0 +1,1 @@
+<svelte:component this={child.component} {...child.props}/>

--- a/test/apps/preloading/src/routes/prefetch/index.html
+++ b/test/apps/preloading/src/routes/prefetch/index.html
@@ -1,0 +1,1 @@
+<h1>prefetch</h1>

--- a/test/apps/preloading/test.ts
+++ b/test/apps/preloading/test.ts
@@ -83,4 +83,31 @@ describe('preloading', function() {
 		assert.equal(page.url(), `${base}/foo`);
 		assert.equal(await title(), 'foo');
 	});
+
+	it('navigates to prefetched urls', async () => {
+		await page.goto(base);
+		await start();
+		await prefetchRoutes();
+
+		await page.hover('a[href="prefetch/qwe"]');
+		await wait(100);
+		await page.hover('a[href="prefetch/xyz"]');
+		await wait(100);
+
+		await page.click('a[href="prefetch/qwe"]');
+		await wait(50);
+
+		assert.equal(
+			await title(),
+			'qwe'
+		);
+
+		await page.goto(`${base}/prefetch`);
+		await wait(50);
+
+		assert.equal(
+			await title(),
+			'prefetch'
+		);
+	});
 });


### PR DESCRIPTION
This PR repair error with transition between routes, in the case when we use prefetching for nested paths.

The problem occurs when you have several nested links on a page with rel=prefetch. If you move mouse between them and then click on any of these links, there is no transition between the pages.

This is due to the nullable_depth is overwritten for prefetched route

Now we are set new segments at the moment, when navigation takes place between the routes and not at the time of prefetching page.

Reference to this issue #532