### PR TITLE
support Rollup 1.0

### DIFF
--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -142,12 +142,14 @@ export default class RollupCompiler {
 
 		const bundle = await rollup.rollup({
 			input,
+			inlineDynamicImports: true,
 			external: (id: string) => {
 				return (id[0] !== '.' && !path.isAbsolute(id)) || id.slice(-5, id.length) === '.json';
 			}
 		});
 
-		const { code } = await bundle.generate({ format: 'cjs' });
+		const resp = await bundle.generate({ format: 'cjs' });
+		const { code } = resp.output ? resp.output[0] : resp;
 
 		// temporarily override require
 		const defaultLoader = require.extensions['.js'];


### PR DESCRIPTION
Support the `.generate` response from both Rollup 0.x and 1.0.

The `inlineDynamicImports` thing is something I'm really not sure about, I _think_ that makes sense, but it's a very big 'think'.