### PR TITLE
avoid mutating `opts.headers` in `this.fetch` (#528)

### DIFF
--- a/templates/src/server/middleware/get_page_handler.ts
+++ b/templates/src/server/middleware/get_page_handler.ts
@@ -104,7 +104,7 @@ export function get_page_handler(
 					);
 
 					if (include_cookies) {
-						if (!opts.headers) opts.headers = {};
+						opts.headers = Object.assign({}, opts.headers);
 
 						const cookies = Object.assign(
 							{},


### PR DESCRIPTION
Noticed that I never actually submitted a PR for this fix for #528. No tests, because that sounds like more of a pain than I'd like to deal with at the moment.