### PR TITLE
Remove unnecessary index.html file serve

### DIFF
--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -52,11 +52,6 @@ export default function middleware(opts: {
 			next();
 		},
 
-		fs.existsSync(path.join(build_dir, 'index.html')) && serve({
-			pathname: '/index.html',
-			cache_control: dev ? 'no-cache' : 'max-age=600'
-		}),
-
 		fs.existsSync(path.join(build_dir, 'service-worker.js')) && serve({
 			pathname: '/service-worker.js',
 			cache_control: 'no-cache, no-store, must-revalidate'


### PR DESCRIPTION
As far as I can tell, `/index.html` should no longer exist (outside of `sapper export`, which doesn't apply here). After #525 was merged, we're now using `/service-worker-index.html`, but that's handled by `get_page_handler.ts`, not here. So this code is doing nothing.