### PR TITLE
fix: fix "sapper export" with a custom PORT

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -60,7 +60,8 @@ async function _export({
 		sander.copyFileSync(build_dir, 'service-worker.js.map').to(export_dir, 'service-worker.js.map');
 	}
 
-	const port = await ports.find(3000);
+	const defaultPort = process.env.PORT ? parseInt(process.env.PORT) : 3000;
+	const port = await ports.find(defaultPort);
 
 	const protocol = 'http:';
 	const host = `localhost:${port}`;


### PR DESCRIPTION
Fixes #565

Without this PR, `PORT=1337 npx sapper export` would fail. With this PR, it succeeds:

```
> Crawling http://localhost:1337/
listening on port 1337
```