### PR TITLE
Failing test for #558 - preload on query param change

### DIFF
--- a/test/apps/preloading/src/routes/query.svelte
+++ b/test/apps/preloading/src/routes/query.svelte
@@ -1,0 +1,13 @@
+<script context="module">
+	export function preload({query}) {
+		return { text: query.text };
+	}
+</script>
+
+<script>
+export let text
+</script>
+
+<h1>{text}</h1>
+
+<a href="query?text=Second">Second</a>

--- a/test/apps/preloading/test.ts
+++ b/test/apps/preloading/test.ts
@@ -108,4 +108,16 @@ describe('preloading', function() {
 			'prefetch'
 		);
 	});
+
+	it('runs preload on query parameter change', async () => {
+		await page.goto(`${base}/query?text=First`);
+		assert.equal(await title(), 'First');
+
+		await start();
+
+		await page.click('a[href="query?text=Second"]');
+		await wait(50);
+
+		assert.equal(await title(),	'Second');
+	});
 });


### PR DESCRIPTION
Here is a failing test for Issue #558.

As stated in that issue, there is a line of code in `runtime/App.ts` which skips the preload stuff when it detects the route segments haven't changed.  This prevents a query parameter change from triggering the route's preload function.

```js
function hydrate_target(...) {
 //.....
    if (!session_dirty && current_branch[i] && current_branch[i].segment === segment) return current_branch[i];
```

The query param issue can be fixed by removing this line, but then you get a different test failing about un-necessarily recreating components:
```
 1) layout
       only recreates components when necessary:
```

Another option could be detecting when only the query string changed in the link click handler, and calling the preload function(s) directly, since the dynamic imports are already done? 