### PR TITLE
Fix export race condition (bonus windows support for dev)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "pretty-bytes": "^5.1.0",
     "puppeteer": "^1.12.0",
     "require-relative": "^0.8.7",
+    "rimraf": "^2.6.3",
     "rollup": "^1.1.2",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-json": "^3.1.0",
@@ -66,7 +67,7 @@
   "scripts": {
     "test": "mocha --opts mocha.opts",
     "pretest": "npm run build",
-    "build": "rm -rf dist && rollup -c",
+    "build": "rimraf dist && rollup -c",
     "prepare": "npm run build",
     "dev": "rollup -cw",
     "prepublishOnly": "npm test",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "pretty-bytes": "^5.1.0",
     "puppeteer": "^1.12.0",
     "require-relative": "^0.8.7",
-    "rimraf": "^2.6.3",
     "rollup": "^1.1.2",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-json": "^3.1.0",
@@ -67,7 +66,7 @@
   "scripts": {
     "test": "mocha --opts mocha.opts",
     "pretest": "npm run build",
-    "build": "rimraf dist && rollup -c",
+    "build": "rm -rf dist && rollup -c",
     "prepare": "npm run build",
     "dev": "rollup -cw",
     "prepublishOnly": "npm test",

--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -163,7 +163,6 @@ async function _export({
 					const cleaned = clean_html(body);
 
 					const q = yootils.queue(8);
-					let promise;
 
 					const base_match = /<base ([\s\S]+?)>/m.exec(cleaned);
 					const base_href = base_match && get_href(base_match[1]);
@@ -180,12 +179,12 @@ async function _export({
 							const url = resolve(base.href, href);
 
 							if (url.protocol === protocol && url.host === host) {
-								promise = q.add(() => handle(url));
+								q.add(() => handle(url));
 							}
 						}
 					}
 
-					await promise;
+					await q.close();
 				}
 			}
 		}


### PR DESCRIPTION
Export was firing off up to 8 requests, but only waiting for the last one to complete before killing the server.js process. This uses the q.close() method that seems to be designed to wait for all queued promises to complete.