### PR TITLE
Don't crash if preload return empty

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -225,7 +225,7 @@ export function get_page_handler(
 
 					props[`level${l++}`] = {
 						component: part.component,
-						props: preloaded[i + 1],
+						props: preloaded[i + 1] || {},
 						segment: segments[i]
 					};
 				}

--- a/test/apps/preloading/src/routes/preload-nothing/index.svelte
+++ b/test/apps/preloading/src/routes/preload-nothing/index.svelte
@@ -1,0 +1,5 @@
+<script context="module">
+	export function preload() {}
+</script>
+
+<h1>Page loaded</h1>

--- a/test/apps/preloading/test.ts
+++ b/test/apps/preloading/test.ts
@@ -37,6 +37,15 @@ describe('preloading', function() {
 		assert.equal(await title(), 'true');
 	});
 
+	it('prevent crash if preload return nothing', async () => {
+		await page.goto(`${base}/preload-nothing`);
+
+		await start();
+		await wait(50);
+
+		assert.equal(await title(), 'Page loaded');
+	});
+
 	it('bails on custom classes returned from preload', async () => {
 		await page.goto(`${base}/preload-values/custom-class`);
 


### PR DESCRIPTION
fix for #587