### PR TITLE
Fix base-path with server-worker-index.html - fixes #579

### DIFF
--- a/src/core/create_app.ts
+++ b/src/core/create_app.ts
@@ -44,7 +44,7 @@ export function create_serviceworker_manifest({ manifest_data, output, client_fi
 	client_files: string[];
 	static_files: string;
 }) {
-	let files: string[] = ['/service-worker-index.html'];
+	let files: string[] = ['service-worker-index.html'];
 
 	if (fs.existsSync(static_files)) {
 		files = files.concat(walk(static_files));


### PR DESCRIPTION
Tested on v0.25.0 with a Sapper app, but I was not able to test with the master version of Sapper+Svelte.