### PR TITLE
Fix base-path with service-worker-index.html - fixes #579

### DIFF
--- a/src/core/create_app.ts
+++ b/src/core/create_app.ts
@@ -44,7 +44,7 @@ export function create_serviceworker_manifest({ manifest_data, output, client_fi
 	client_files: string[];
 	static_files: string;
 }) {
-	let files: string[] = ['/service-worker-index.html'];
+	let files: string[] = ['service-worker-index.html'];
 
 	if (fs.existsSync(static_files)) {
 		files = files.concat(walk(static_files));


### PR DESCRIPTION
The very same than #615 but without the typo in the title.

Tested on v0.25.0 with a Sapper app ([here](https://github.com/Legilibre/archeo-lex.fr/tree/next)), but I was not able to test with the master version of Sapper+Svelte (`__sapper__` was renamed to `src/node_modules/@sapper` if I understand correctly, I didn’t make the change for now).