### PR TITLE
Fixed %sapper.styles% injection for webpack apps

### DIFF
--- a/src/core/create_compilers/WebpackResult.ts
+++ b/src/core/create_compilers/WebpackResult.ts
@@ -1,6 +1,6 @@
 import format_messages from 'webpack-format-messages';
 import { CompileResult, BuildInfo, CompileError, Chunk, CssFile } from './interfaces';
-import { ManifestData, Dirs } from '../../interfaces';
+import { ManifestData, Dirs, PageComponent } from '../../interfaces';
 
 const locPattern = /\((\d+):(\d+)\)$/;
 
@@ -66,14 +66,17 @@ export default class WebpackResult implements CompileResult {
 			assets: this.assets,
 			css: {
 				main: extract_css(this.assets.main),
-				chunks: Object
-					.keys(this.assets)
-					.filter(chunkName => chunkName !== 'main')
-					.reduce((chunks: { [key: string]: string }, chukName) => {
-						const assets = this.assets[chukName];
-						chunks[chukName] = extract_css(assets);
-						return chunks;
-					}, {})
+				chunks: manifest_data.components
+                    .reduce((chunks: Record<string, string[]>, component: PageComponent) => {
+                        const css_dependencies = [];
+                        const css = extract_css(this.assets[component.name]);
+
+                        if (css) css_dependencies.push(css);
+
+                        chunks[component.file] = css_dependencies;
+
+                        return chunks;
+                    }, {})
 			}
 		};
 	}

--- a/src/core/create_compilers/WebpackResult.ts
+++ b/src/core/create_compilers/WebpackResult.ts
@@ -67,16 +67,16 @@ export default class WebpackResult implements CompileResult {
 			css: {
 				main: extract_css(this.assets.main),
 				chunks: manifest_data.components
-                    .reduce((chunks: Record<string, string[]>, component: PageComponent) => {
-                        const css_dependencies = [];
-                        const css = extract_css(this.assets[component.name]);
+					.reduce((chunks: Record<string, string[]>, component: PageComponent) => {
+						const css_dependencies = [];
+						const css = extract_css(this.assets[component.name]);
 
-                        if (css) css_dependencies.push(css);
+						if (css) css_dependencies.push(css);
 
-                        chunks[component.file] = css_dependencies;
+						chunks[component.file] = css_dependencies;
 
-                        return chunks;
-                    }, {})
+						return chunks;
+					}, {})
 			}
 		};
 	}


### PR DESCRIPTION
Hi again!

Several month ago I've [added](https://github.com/sveltejs/sapper/pull/529) `css` field to `build.json` info file for webpack apps.
The `css` field had a shape like:
```typescript
{
  main: string,
  chunks: Record<WebpackChunkName, CSSFileName>
}
```

That time I didn't notice two things:

1. Page part styles [are retrieved](https://github.com/sveltejs/sapper/blob/master/runtime/src/server/middleware/get_page_handler.ts#L283) via `build_info.css[part.file]`. Because of the implementation described above used the `wepackChunkName` to form `ccs.chunks` keys the styles were never added to `%sapper.styles%`.
2. The `css.chunks` values should be arrays not strings

The PR fixes both of the issues described.