### PR TITLE
Allow to have middleware for the path same with a HTML page

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -329,12 +329,10 @@ export function get_page_handler(
 			return;
 		}
 
-		if (!server_routes.some(route => route.pattern.test(req.path))) {
-			for (const page of pages) {
-				if (page.pattern.test(req.path)) {
-					handle_page(page, req, res);
-					return;
-				}
+		for (const page of pages) {
+			if (page.pattern.test(req.path)) {
+				handle_page(page, req, res);
+				return;
 			}
 		}
 


### PR DESCRIPTION
The feature was introduced with 9e2d0a7fbca10034d9ed83df03200fd549174f73, but regressed with commit 8dc52a04e4bb3e358834442c6125a1989fa2ea4e.