### PR TITLE
update to node stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: node_js
 
 node_js:
-  - "11"
+  - "stable"
 
 env:
   global:


### PR DESCRIPTION
For some reason, the `export-webpack` test fails in Node 12. I get the same result running `sapper export` on a webpack project; it exports fine, but then doesn't exit. Works fine with Rollup, works fine with Node 11. Not sure what's happening — for now I've just pinned the Travis config to use Node 11.