### PR TITLE
switch license to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,7 @@
-Copyright (c) 2017 [these people](https://github.com/sveltejs/sapper/graphs/contributors).
+Copyright (c) 2016-19 [these people](https://github.com/sveltejs/sapper/graphs/contributors)
 
-Permission is hereby granted by the authors of this software, to any person, to use the software for any purpose, free of charge, including the rights to run, read, copy, change, distribute and sell it, and including usage rights to any patents the authors may hold on it, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-This license, or a link to its text, must be included with all copies of the software and any derivative works.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-Any modification to the software submitted to the authors may be incorporated into the software under the terms of this license.
-
-The software is provided "as is", without warranty of any kind, including but not limited to the warranties of title, fitness, merchantability and non-infringement. The authors have no obligation to provide support or updates for the software, and may not be held liable for any damages, claims or other liability arising from its use.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "express"
   ],
   "author": "Rich Harris",
-  "license": "LIL",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/sveltejs/sapper/issues"
   },


### PR DESCRIPTION
I was hoping the LIL license would catch on, but it clearly hasn't... I'm pretty sure switching to MIT is legally sound since they're essentially identical (by design), but if any contributors have objections, please make them known