### PR TITLE
Tidy a few things up

### DIFF
--- a/runtime/src/server/constants.js
+++ b/runtime/src/server/constants.js
@@ -1,1 +1,0 @@
-export const IGNORE = '__SAPPER__IGNORE__';

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -5,7 +5,6 @@ import cookie from 'cookie';
 import devalue from 'devalue';
 import fetch from 'node-fetch';
 import URL from 'url';
-import { IGNORE } from '../constants';
 import { Manifest, Page, Props, Req, Res } from './types';
 import { build_dir, dev, src_dir } from '@sapper/internal/manifest-server';
 import { stores } from '@sapper/internal/shared';
@@ -328,8 +327,6 @@ export function get_page_handler(
 	}
 
 	return function find_route(req: Req, res: Res, next: () => void) {
-		if (req[IGNORE]) return next();
-
 		if (req.path === '/service-worker-index.html') {
 			const homePage = pages.find(page => page.pattern.test('/'));
 			handle_page(homePage, req, res);

--- a/runtime/src/server/middleware/get_server_route_handler.ts
+++ b/runtime/src/server/middleware/get_server_route_handler.ts
@@ -1,4 +1,3 @@
-import { IGNORE } from '../constants';
 import { Req, Res, ServerRoute } from './types';
 
 export function get_server_route_handler(routes: ServerRoute[]) {
@@ -64,8 +63,6 @@ export function get_server_route_handler(routes: ServerRoute[]) {
 	}
 
 	return function find_route(req: Req, res: Res, next: () => void) {
-		if (req[IGNORE]) return next();
-
 		for (const route of routes) {
 			if (route.pattern.test(req.path)) {
 				handle_route(route, req, res, next);

--- a/src/core/create_manifest_data.ts
+++ b/src/core/create_manifest_data.ts
@@ -249,7 +249,7 @@ type Part = {
 	spread?: boolean;
 };
 
-function is_spead(path: string) {
+function is_spread(path: string) {
 	const spread_pattern = /\[\.{3}/g;
 	return spread_pattern.test(path)
 }
@@ -259,9 +259,9 @@ function comparator(
 	b: { basename: string, parts: Part[], file: string, is_index: boolean }
 ) {
 	if (a.is_index !== b.is_index) {
-		if (a.is_index) return is_spead(a.file) ? 1 : -1;
+		if (a.is_index) return is_spread(a.file) ? 1 : -1;
 
-		return is_spead(b.file) ? -1 : 1;
+		return is_spread(b.file) ? -1 : 1;
 	}
 
 	const max = Math.max(a.parts.length, b.parts.length);

--- a/src/core/create_manifest_data.ts
+++ b/src/core/create_manifest_data.ts
@@ -74,6 +74,9 @@ export default function create_manifest_data(cwd: string): ManifestData {
 				const is_dir = fs.statSync(resolved).isDirectory();
 
 				const ext = path.extname(basename);
+
+				if (basename[0] === '_') return null;
+				if (basename[0] === '.' && basename !== '.well-known') return null;
 				if (!is_dir && !/^\.[a-z]+$/i.test(ext)) return null; // filter out tmp files etc
 
 				const segment = is_dir
@@ -108,22 +111,17 @@ export default function create_manifest_data(cwd: string): ManifestData {
 			.sort(comparator);
 
 		items.forEach(item => {
-			if (item.basename[0] === '_') return;
-
-			if (item.basename[0] === '.') {
-				if (item.file !== '.well-known') return;
-			}
-
 			const segments = parent_segments.slice();
 
 			if (item.is_index && segments.length > 0) {
-				const last_segment = segments[segments.length - 1].slice();
 				const suffix = item.basename
 					.slice(0, -item.ext.length)
 					.replace('index', '');
 
 				if (suffix) {
+					const last_segment = segments[segments.length - 1].slice();
 					const last_part = last_segment[last_segment.length - 1];
+
 					if (last_part.dynamic) {
 						last_segment.push({ dynamic: false, content: suffix });
 					} else {


### PR DESCRIPTION
Note:
- Removes the `req[IGNORE]` trick
- Speeds up `compose_handlers` by avoiding an extra closure and moving `ignore` test outside request handlers