### PR TITLE
Build rollup config: Don't add hashes to files in dist

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -52,7 +52,8 @@ export default [
 		output: {
 			dir: 'dist',
 			format: 'cjs',
-			sourcemap: true
+			sourcemap: true,
+			chunkFileNames: '[name].js'
 		},
 		external,
 		plugins: [


### PR DESCRIPTION
I tried this on a lark. No difference in passing tests.

If there's a technical reason for delivering the Sapper dist hashed, feel free to close this immediately.