### PR TITLE
Harden tests (...a bit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,7 @@ yarn.lock
 yarn-error.log
 node_modules
 cypress/screenshots
-test/app/.sapper
-test/app/src/manifest
 __sapper__
-test/app/export
-test/app/build
 sapper
 runtime.js
 dist

--- a/test/apps/basics/src/server.js
+++ b/test/apps/basics/src/server.js
@@ -1,8 +1,9 @@
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT } = process.env;
+import { start } from '../../common.js';
 
-polka()
+const app = polka()
 	.use(sapper.middleware())
-	.listen(PORT);
+
+start(app);

--- a/test/apps/common.js
+++ b/test/apps/common.js
@@ -1,0 +1,42 @@
+const { NODE_ENV, PORT } = process.env;
+
+export const dev = NODE_ENV === 'development';
+
+export function start(app) {
+	const port = parseInt(PORT) || 0;
+
+	app.listen(port, () => {
+		const address = app.server.address();
+
+		process.env.PORT = address.port;
+
+		send({
+			__sapper__: true,
+			event: 'listening',
+			address
+		});
+	});
+}
+
+const properties = ['name', 'message', 'stack', 'code', 'lineNumber', 'fileName'];
+
+function send(message) {
+	process.send && process.send(message);
+}
+
+function send_error(error) {
+	send({
+		__sapper__: true,
+		event: 'error',
+		error: properties.reduce((object, key) => ({...object, [key]: error[key]}), {})
+	})
+}
+
+process.on('unhandledRejection', (reason, p) => {
+	send_error(reason);
+});
+
+process.on('uncaughtException', err => {
+	send_error(err);
+	process.exitCode = 1;
+});

--- a/test/apps/credentials/src/server.js
+++ b/test/apps/credentials/src/server.js
@@ -1,13 +1,14 @@
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT } = process.env;
+import { start } from '../../common.js';
 
-polka()
+const app = polka()
 	.use((req, res, next) => {
 		// set test cookie
 		res.setHeader('Set-Cookie', ['a=1; Max-Age=3600', 'b=2; Max-Age=3600']);
 		next();
 	})
 	.use(sapper.middleware())
-	.listen(PORT);
+
+start(app);

--- a/test/apps/css/src/server.js
+++ b/test/apps/css/src/server.js
@@ -1,8 +1,9 @@
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT } = process.env;
+import { start } from '../../common.js';
 
-polka()
-	.use(sapper.middleware())
-	.listen(PORT);
+const app = polka()
+	.use(sapper.middleware());
+
+start(app);

--- a/test/apps/encoding/src/server.js
+++ b/test/apps/encoding/src/server.js
@@ -1,8 +1,9 @@
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT } = process.env;
+import { start } from '../../common.js';
 
-polka()
-	.use(sapper.middleware())
-	.listen(PORT);
+const app = polka()
+	.use(sapper.middleware());
+
+start(app);

--- a/test/apps/errors/src/server.js
+++ b/test/apps/errors/src/server.js
@@ -1,8 +1,9 @@
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT } = process.env;
+import { start } from '../../common.js';
 
-polka()
-	.use(sapper.middleware())
-	.listen(PORT);
+const app = polka()
+	.use(sapper.middleware());
+
+start(app);

--- a/test/apps/export-webpack/src/server.js
+++ b/test/apps/export-webpack/src/server.js
@@ -2,14 +2,12 @@ import sirv from 'sirv';
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT, NODE_ENV } = process.env;
-const dev = NODE_ENV === 'development';
+import { start, dev } from '../../common.js';
 
-polka()
+const app = polka()
 	.use(
 		sirv('static', { dev }),
 		sapper.middleware()
-	)
-	.listen(PORT, err => {
-		if (err) console.log('error', err);
-	});
+	);
+
+start(app);

--- a/test/apps/export-webpack/test.ts
+++ b/test/apps/export-webpack/test.ts
@@ -6,14 +6,12 @@ describe('export-webpack', function() {
 	this.timeout(10000);
 
 	// hooks
-	before(async () => {
-		await api.build({ cwd: __dirname, bundler: 'webpack' });
-		await api.export({ cwd: __dirname, bundler: 'webpack' });
-	});
+	before('build app', () => api.build({ cwd: __dirname, bundler: 'webpack' }));
+	before('export app', () => api.export({ cwd: __dirname }));
 
+	// tests
 	it('injects <link rel=preload> tags', () => {
 		const index = fs.readFileSync(`${__dirname}/__sapper__/export/index.html`, 'utf8');
 		assert.ok(/rel=preload/.test(index));
 	});
-
 });

--- a/test/apps/export/src/server.js
+++ b/test/apps/export/src/server.js
@@ -2,14 +2,12 @@ import sirv from 'sirv';
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT, NODE_ENV } = process.env;
-const dev = NODE_ENV === 'development';
+import { start, dev } from '../../common.js';
 
-polka()
+const app = polka()
 	.use(
 		sirv('static', { dev }),
 		sapper.middleware()
-	)
-	.listen(PORT, err => {
-		if (err) console.log('error', err);
-	});
+	);
+
+start(app);

--- a/test/apps/export/test.ts
+++ b/test/apps/export/test.ts
@@ -6,11 +6,10 @@ describe('export', function() {
 	this.timeout(10000);
 
 	// hooks
-	before(async () => {
-		await api.build({ cwd: __dirname });
-		await api.export({ cwd: __dirname });
-	});
+	before('build app', () => api.build({ cwd: __dirname }));
+	before('export app', () => api.export({ cwd: __dirname }));
 
+	// tests
 	it('crawls a site', () => {
 		const files = walk(`${__dirname}/__sapper__/export`);
 

--- a/test/apps/ignore/src/server.js
+++ b/test/apps/ignore/src/server.js
@@ -1,7 +1,7 @@
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT } = process.env;
+import { start } from '../../common.js';
 
 const app = polka().use(sapper.middleware({
 	ignore: [
@@ -16,4 +16,4 @@ const app = polka().use(sapper.middleware({
 	app.get('/'+uri, (req, res) => res.end(uri));
 });
 
-app.listen(PORT);
+start(app);

--- a/test/apps/ignore/test.ts
+++ b/test/apps/ignore/test.ts
@@ -1,58 +1,58 @@
 import * as assert from 'assert';
-import * as puppeteer from 'puppeteer';
 import { build } from '../../../api';
 import { AppRunner } from '../AppRunner';
 
 describe('ignore', function() {
 	this.timeout(10000);
 
-	let runner: AppRunner;
-	let page: puppeteer.Page;
-	let base: string;
+	let r: AppRunner;
 
 	// hooks
-	before(async () => {
-		await build({ cwd: __dirname });
-
-		runner = new AppRunner(__dirname, '__sapper__/build/server/server.js');
-		({ base, page } = await runner.start());
+	before('build app', () => build({ cwd: __dirname }));
+	before('start runner', async () => {
+		r = await new AppRunner().start(__dirname);
 	});
 
-	after(() => runner.end());
+	after(() => r && r.end());
 
+	// tests
 	it('respects `options.ignore` values (RegExp)', async () => {
-		await page.goto(`${base}/foobar`);
+		await r.load('/foobar');
 
 		assert.equal(
-			await page.evaluate(() => document.documentElement.textContent),
+			await r.text('body'),
 			'foobar'
 		);
 	});
 
 	it('respects `options.ignore` values (String #1)', async () => {
-		await page.goto(`${base}/buzz`);
+		await r.load('/buzz');
 
 		assert.equal(
-			await page.evaluate(() => document.documentElement.textContent),
+			await r.text('body'),
 			'buzz'
 		);
 	});
 
 	it('respects `options.ignore` values (String #2)', async () => {
-		await page.goto(`${base}/fizzer`);
+		await r.load('/fizzer');
 
 		assert.equal(
-			await page.evaluate(() => document.documentElement.textContent),
+			await r.text('body'),
 			'fizzer'
 		);
 	});
 
 	it('respects `options.ignore` values (Function)', async () => {
-		await page.goto(`${base}/hello`);
+		await r.load('/hello');
 
 		assert.equal(
-			await page.evaluate(() => document.documentElement.textContent),
+			await r.text('body'),
 			'hello'
 		);
+	});
+
+	it('survives the tests with no server errors', () => {
+		assert.deepEqual(r.errors, []);
 	});
 });

--- a/test/apps/layout/src/server.js
+++ b/test/apps/layout/src/server.js
@@ -1,8 +1,9 @@
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT } = process.env;
+import { start } from '../../common.js';
 
-polka()
-	.use(sapper.middleware())
-	.listen(PORT);
+const app = polka()
+	.use(sapper.middleware());
+
+start(app);

--- a/test/apps/preloading/src/server.js
+++ b/test/apps/preloading/src/server.js
@@ -1,8 +1,9 @@
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT } = process.env;
+import { start } from '../../common.js';
 
-polka()
-	.use(sapper.middleware())
-	.listen(PORT);
+const app = polka()
+	.use(sapper.middleware());
+
+start(app);

--- a/test/apps/redirects/src/server.js
+++ b/test/apps/redirects/src/server.js
@@ -1,8 +1,9 @@
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT } = process.env;
+import { start } from '../../common.js';
 
-polka()
-	.use(sapper.middleware())
-	.listen(PORT);
+const app = polka()
+	.use(sapper.middleware());
+
+start(app);

--- a/test/apps/scroll/src/server.js
+++ b/test/apps/scroll/src/server.js
@@ -1,8 +1,9 @@
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT } = process.env;
+import { start } from '../../common.js';
 
-polka()
-	.use(sapper.middleware())
-	.listen(PORT);
+const app = polka()
+	.use(sapper.middleware());
+
+start(app);

--- a/test/apps/session/src/server.js
+++ b/test/apps/session/src/server.js
@@ -1,9 +1,9 @@
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT } = process.env;
+import { start } from '../../common.js';
 
-polka()
+const app = polka()
 	.use((req, res, next) => {
 		req.hello = 'hello';
 		res.locals = { name: 'world' };
@@ -15,5 +15,6 @@ polka()
 				title: `${req.hello} ${res.locals.name}`
 			})
 		})
-	)
-	.listen(PORT);
+	);
+
+start(app);

--- a/test/apps/with-basepath/src/server.js
+++ b/test/apps/with-basepath/src/server.js
@@ -2,15 +2,14 @@ import sirv from 'sirv';
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT, NODE_ENV } = process.env;
-const dev = NODE_ENV === 'development';
+import { start, dev } from '../../common.js';
 
-polka()
+const app = polka()
 	.use(
 		'custom-basepath',
 		sirv('static', { dev }),
 		sapper.middleware()
-	)
-	.listen(PORT, err => {
-		if (err) console.log('error', err);
-	});
+	);
+
+start(app);
+

--- a/test/apps/with-sourcemaps-webpack/src/server.js
+++ b/test/apps/with-sourcemaps-webpack/src/server.js
@@ -1,8 +1,9 @@
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT } = process.env;
+import { start } from '../../common.js';
 
-polka()
-	.use(sapper.middleware())
-	.listen(PORT);
+const app = polka()
+	.use(sapper.middleware());
+
+start(app);

--- a/test/apps/with-sourcemaps-webpack/test.ts
+++ b/test/apps/with-sourcemaps-webpack/test.ts
@@ -7,10 +7,9 @@ describe('with-sourcemaps-webpack', function() {
 	this.timeout(10000);
 
 	// hooks
-	before(async () => {
-		await build({ cwd: __dirname, bundler: 'webpack' });
-	});
+	before('build app', () => build({ cwd: __dirname, bundler: 'webpack' }));
 
+	// tests
 	it('does not put sourcemap files in service worker shell', async () => {
 		const service_worker_source = fs.readFileSync(`${__dirname}/src/node_modules/@sapper/service-worker.js`, 'utf-8');
 		const shell_source = /shell = (\[[\s\S]+?\])/.exec(service_worker_source)[1];

--- a/test/apps/with-sourcemaps/src/server.js
+++ b/test/apps/with-sourcemaps/src/server.js
@@ -1,8 +1,9 @@
 import polka from 'polka';
 import * as sapper from '@sapper/server';
 
-const { PORT } = process.env;
+import { start } from '../../common.js';
 
-polka()
-	.use(sapper.middleware())
-	.listen(PORT);
+const app = polka()
+	.use(sapper.middleware());
+
+start(app);

--- a/test/apps/with-sourcemaps/test.ts
+++ b/test/apps/with-sourcemaps/test.ts
@@ -7,10 +7,9 @@ describe('with-sourcemaps', function() {
 	this.timeout(10000);
 
 	// hooks
-	before(async () => {
-		await build({ cwd: __dirname });
-	});
+	before('build app', () => build({ cwd: __dirname }));
 
+	// tests
 	it('does not put sourcemap files in service worker shell', async () => {
 		const service_worker_source = fs.readFileSync(`${__dirname}/src/node_modules/@sapper/service-worker.js`, 'utf-8');
 		const shell_source = /shell = (\[[\s\S]+?\])/.exec(service_worker_source)[1];


### PR DESCRIPTION
Closes #666.

The main issue was that `AppRunner` didn't care much about the server and if for some reason it took a while to launch, we could get connection errors.

I started working on that and kept running upon completely unrelated issues in tests, so I ended up refactoring a bunch of other parts... So, sorry for the big PR. I didn't expect to make so many changes but I'm of course willing to work on it and split it all up if there's interest (feel free to reject this!).

- Made `AppRunner` aware of whether the server is running: fixes the main problem.
- Added `SAPPER_TEST_DELAY` environment variable:

    I'm not on a powerful machine, so I kept getting random errors due to `wait(50)` not being sufficient after clicks. I tried `waitForNavigation()` in addition to the wait, but it turns out Sapper's pushing the state change way too soon (I'll open an issue to discuss that), so I figured for now configuring the delay in a central location is enough.

- Added tests for server errors:

    At some point, I got an error to occur server-side but that was only logged to `stderr`. Added server error reporting and a single test to each group that fails if any errors happened during the other tests.

- Removed `port-authority` since as far as I'm aware, this shouldn't be necessary for running tests.

- Refactored the helper methods a bit... Sorry, this one's just opinionated.