### PR TITLE
Allow disabling live reload

### DIFF
--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -206,14 +206,18 @@ class Watcher extends EventEmitter {
 						});
 					}
 				}
-			),
-
-			fs.watch(`${src}/template.html`, () => {
-				this.dev_server.send({
-					action: 'reload'
-				});
-			})
+			)
 		);
+
+		if (this.live) {
+			this.filewatchers.push(
+				fs.watch(`${src}/template.html`, () => {
+					this.dev_server.send({
+						action: 'reload'
+					});
+				})
+			);
+		}
 
 		let deferred = new Deferred();
 
@@ -252,7 +256,7 @@ class Watcher extends EventEmitter {
 									this.dev_server.send({
 										status: 'completed'
 									});
-								} else {
+								} else if (this.live) {
 									this.dev_server.send({
 										action: 'reload'
 									});


### PR DESCRIPTION
The sapper CLI has a `--live` flag for live reload that is enabled by default and currently cannot be disabled.

With this PR, `sapper dev --live=false` will not send reload events to the browser.