### PR TITLE
leave anchor scrolling on initial load to browser

### DIFF
--- a/runtime/src/app/start/index.ts
+++ b/runtime/src/app/start/index.ts
@@ -40,7 +40,7 @@ export default function start(opts: {
 		if (initial_data.error) return handle_error(url);
 
 		const target = select_target(url);
-		if (target) return navigate(target, uid, false, hash);
+		if (target) return navigate(target, uid, true, hash);
 	});
 }
 


### PR DESCRIPTION
Fixes #331 hopefully without breaking anything else. This just sets noscroll to true during the initialization of the client-side app, so that wherever the browser decided to scroll to because of anchor fragments will be left untouched.

I don't really know what to test for this.