### PR TITLE
always re-run preload functions when query string changes

### DIFF
--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -22,6 +22,7 @@ let root_component: Component;
 let current_token: {};
 let root_preloaded: Promise<any>;
 let current_branch = [];
+let current_query = '{}';
 
 const stores = {
 	page: writable({}),
@@ -250,11 +251,17 @@ async function render(redirect: Redirect, branch: any[], props: any, page: Page)
 	}
 
 	current_branch = branch;
+	current_query = JSON.stringify(page.query);
 	ready = true;
 	session_dirty = false;
 }
 
-function part_changed(i, segment, match) {
+function part_changed(i, segment, match, stringified_query) {
+	// TODO only check query string changes for preload functions
+	// that do in fact depend on it (using static analysis or
+	// runtime instrumentation)
+	if (stringified_query !== current_query) return true;
+
 	const previous = current_branch[i];
 
 	if (!previous) return false;
@@ -304,12 +311,15 @@ export async function hydrate_target(target: Target): Promise<{
 	let l = 1;
 
 	try {
+		const stringified_query = JSON.stringify(page.query);
 		const match = route.pattern.exec(page.path);
+
 		let segment_dirty = false;
+
 		branch = await Promise.all(route.parts.map(async (part, i) => {
 			const segment = segments[i];
 
-			if (part_changed(i, segment, match)) segment_dirty = true;
+			if (part_changed(i, segment, match, stringified_query)) segment_dirty = true;
 
 			props.segments[l] = segments[i + 1]; // TODO make this less confusing
 			if (!part) return { segment };

--- a/test/apps/preloading/src/routes/echo/index.svelte
+++ b/test/apps/preloading/src/routes/echo/index.svelte
@@ -1,0 +1,17 @@
+<script context="module">
+	export function preload(page) {
+		return {
+			query: page.query
+		};
+	}
+</script>
+
+<script>
+	export let query;
+</script>
+
+<pre>{JSON.stringify(query)}</pre>
+
+<a href="echo?foo=1">foo=1</a>
+<a href="echo?foo=2">foo=2</a>
+<a href="echo?foo=3">foo=3</a>

--- a/test/apps/preloading/test.ts
+++ b/test/apps/preloading/test.ts
@@ -109,4 +109,23 @@ describe('preloading', function() {
 	it('survives the tests with no server errors', () => {
 		assert.deepEqual(r.errors, []);
 	});
+
+	it('re-runs preload when page.query changes', async () => {
+		await r.load('/echo?foo=1');
+		await r.sapper.start();
+		await r.sapper.prefetchRoutes();
+
+		assert.equal(
+			await r.text('pre'),
+			`{"foo":"1"}`
+		);
+
+		await r.page.click('a[href="echo?foo=2"]');
+		await r.wait();
+
+		assert.equal(
+			await r.text('pre'),
+			`{"foo":"2"}`
+		);
+	});
 });


### PR DESCRIPTION
fixes #701. Does this seem like a reasonable approach for now? We can reduce false positives later, most likely by using `Object.defineProperty` to detect when `page.query` is read