### PR TITLE
Preload js assets - fixes #408

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -50,7 +50,8 @@ export function get_page_handler(
 			bundler: 'rollup' | 'webpack',
 			shimport: string | null,
 			assets: Record<string, string | string[]>,
-			legacy_assets?: Record<string, string>
+			legacy_assets?: Record<string, string>,
+			script_preloads?: Record<string, string[]>
 		 } = get_build_info();
 
 		res.setHeader('Content-Type', 'text/html');
@@ -67,6 +68,16 @@ export function get_page_handler(
 				preloaded_chunks = preloaded_chunks.concat(build_info.assets[part.name]);
 			});
 		}
+
+		page.parts.forEach((part) => {
+			if (build_info.script_preloads && part && build_info.script_preloads[part.file]) {
+				build_info.script_preloads[part.file].forEach((preloadFile) => {
+					if (preloaded_chunks.indexOf(preloadFile) === -1) {
+						preloaded_chunks.push(preloadFile)
+					}
+				})
+			}
+		})
 
 		if (build_info.bundler === 'rollup') {
 			// TODO add dependencies and CSS

--- a/runtime/src/server/middleware/types.ts
+++ b/runtime/src/server/middleware/types.ts
@@ -11,6 +11,7 @@ export type Page = {
 	parts: Array<{
 		name: string;
 		component: Component;
+		file?: string;
 		params?: (match: RegExpMatchArray) => Record<string, string>;
 		preload?: (data: any) => any | Promise<any>;
 	}>

--- a/src/api/build.ts
+++ b/src/api/build.ts
@@ -95,11 +95,13 @@ export async function build({
 	const build_info = client_result.to_json(manifest_data, { src, routes, dest });
 	build_info.legacy_assets = client_result.assets;
 	build_info.script_preloads = {};
-	Object.keys(client_result.script_preloads).forEach((facadeFileName) => {
-		// get relative filename, remove / or \ from the beginning of the string
-		const relativeFacedeFileName = facadeFileName.replace(routes, '').slice(1);
-		build_info.script_preloads[relativeFacedeFileName] = client_result.script_preloads[facadeFileName];
-	})
+	if (client_result.script_preloads) {
+		Object.keys(client_result.script_preloads).forEach((facadeFileName) => {
+			// get relative filename, remove / or \ from the beginning of the string
+			const relativeFacedeFileName = facadeFileName.replace(routes, '').slice(1);
+			build_info.script_preloads[relativeFacedeFileName] = client_result.script_preloads[facadeFileName];
+		})
+	}
 
 	if (legacy) {
 		process.env.SAPPER_LEGACY_BUILD = 'true';

--- a/src/api/build.ts
+++ b/src/api/build.ts
@@ -93,6 +93,13 @@ export async function build({
 	});
 
 	const build_info = client_result.to_json(manifest_data, { src, routes, dest });
+	build_info.legacy_assets = client_result.assets;
+	build_info.script_preloads = {};
+	Object.keys(client_result.script_preloads).forEach((facadeFileName) => {
+		// get relative filename, remove / or \ from the beginning of the string
+		const relativeFacedeFileName = facadeFileName.replace(routes, '').slice(1);
+		build_info.script_preloads[relativeFacedeFileName] = client_result.script_preloads[facadeFileName];
+	})
 
 	if (legacy) {
 		process.env.SAPPER_LEGACY_BUILD = 'true';

--- a/src/core/create_compilers/interfaces.ts
+++ b/src/core/create_compilers/interfaces.ts
@@ -23,6 +23,7 @@ export interface CompileResult {
 	chunks: Chunk[];
 	assets: Record<string, string>;
 	css_files: CssFile[];
+	script_preloads: Record<string, string[]>;
 
 	to_json: (manifest_data: ManifestData, dirs: Dirs) => BuildInfo
 }
@@ -32,6 +33,7 @@ export type BuildInfo = {
 	shimport: string;
 	assets: Record<string, string>;
 	legacy_assets?: Record<string, string>;
+	script_preloads: Record<string, string[]>;
 	css: {
 		main: string | null,
 		chunks: Record<string, string[]>


### PR DESCRIPTION
Alternative to #440, fixes #408.

Preloading scripts content is important to supply good Google site speed rate. The #440 PR looks outdated so I implemented an own solution.