### PR TITLE
Use most current manifest_data

### DIFF
--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -48,7 +48,7 @@ class Watcher extends EventEmitter {
 	}
 	port: number;
 	closed: boolean;
-	
+
 	dev_port: number;
 	live: boolean;
 	hot: boolean;
@@ -82,7 +82,7 @@ class Watcher extends EventEmitter {
 		hot,
 		'devtools-port': devtools_port,
 		bundler,
-		port = +process.env.PORT, 
+		port = +process.env.PORT,
 		ext
 	}: Opts) {
 		super();
@@ -192,16 +192,14 @@ class Watcher extends EventEmitter {
 				},
 				() => {
 					try {
-						const new_manifest_data = create_manifest_data(routes, this.ext);
+						manifest_data = create_manifest_data(routes, this.ext);
 						create_app({
 							bundler: this.bundler,
-							manifest_data, // TODO is this right? not new_manifest_data?
+							manifest_data,
 							dev: true,
 							dev_port: this.dev_port,
 							cwd, src, dest, routes, output
 						});
-
-						manifest_data = new_manifest_data;
 					} catch (error) {
 						this.emit('error', <ErrorEvent>{
 							type: 'manifest',


### PR DESCRIPTION
Sapper build seemed one step behind changes, this PR intends to fix it.

Example of trouble experienced:

```bash
$ touch src/routes/xyz.svelte
$ ls __sapper__/dev/client/xyz*
ls: __sapper__/dev/client/xyz*: No such file or directory

$ touch src/routes/xyz2.svelte
$ ls __sapper__/dev/client/xyz*
__sapper__/dev/client/xyz.a25908c7.js

$ touch src/routes/xyz3.svelte
$ ls __sapper__/dev/client/xyz*
__sapper__/dev/client/xyz.a25908c7.js
__sapper__/dev/client/xyz2.02d1ee4f.js
```