### PR TITLE
Prevent client to rerender page over SSR error - fixes #710

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -366,23 +366,18 @@ function try_serialize(data: any, fail?: (err) => void) {
 	}
 }
 
-// Try to serialize the given error, and ensure to return something truthy.
-// Otherwise, the client will think that it got preloaded data with no error
-// and rerender the page component over the error.
-// 
-// See: https://github.com/sveltejs/sapper/issues/710
-// 
-function serialize_error(error: Error|{message: string}) {
-	if (!error) return null
-	let serialized = try_serialize(error)
+// Ensure we return something truthy so the client will not re-render the page over the error
+function serialize_error(error: Error | { message: string }) {
+	if (!error) return null;
+	let serialized = try_serialize(error);
 	if (!serialized) {
-		const {name, message, stack} = error as Error
-		serialized = try_serialize({name, message, stack})
+		const { name, message, stack } = error as Error;
+		serialized = try_serialize({ name, message, stack });
 	}
 	if (!serialized) {
-		serialized = '{}'
+		serialized = '{}';
 	}
-	return serialized
+	return serialized;
 }
 
 function escape_html(html: string) {

--- a/test/apps/errors/src/routes/index.svelte
+++ b/test/apps/errors/src/routes/index.svelte
@@ -3,3 +3,4 @@
 <a href="nope">nope</a>
 <a href="blog/nope">blog/nope</a>
 <a href="throw">throw</a>
+<a href="preload-reject">preload-reject</a>

--- a/test/apps/errors/src/routes/preload-reject.svelte
+++ b/test/apps/errors/src/routes/preload-reject.svelte
@@ -1,0 +1,7 @@
+<script context="module">
+	export function preload() {
+    return Promise.reject(new Error('boom'))
+	}
+</script>
+
+<h1>Test has failed</h1>

--- a/test/apps/errors/src/routes/preload-reject.svelte
+++ b/test/apps/errors/src/routes/preload-reject.svelte
@@ -1,6 +1,6 @@
 <script context="module">
 	export function preload() {
-    return Promise.reject(new Error('boom'))
+		return Promise.reject(new Error('boom'))
 	}
 </script>
 

--- a/test/apps/errors/test.ts
+++ b/test/apps/errors/test.ts
@@ -85,6 +85,28 @@ describe('errors', function() {
 		);
 	});
 
+	// https://github.com/sveltejs/sapper/issues/710
+	// 
+	// In reported issue, error elements disappear, which is not the case in
+	// our test case. This is because the default layout `<slot/>` does not
+	// try to reclaim anything. Reporter probably has a custom `_layout.svelte`
+	// with some divs etc., and those will clear the existing DOM (if they
+	// don't find their element?).
+	// 
+	// Here we're not testing that the error is still here, but that the page 
+	// component has not been rendered (since only error page should be rendered 
+	// here). So we don't need a custom layout.
+	// 
+	it('does not replace server side rendered error', async () => {
+		await r.load('/preload-reject');
+		await r.sapper.start();
+
+		assert.equal(
+			await r.text('h1'),
+			'500'
+		);
+	});
+
 	it('does not serve error page for explicit non-page errors', async () => {
 		await r.load('/nope.json');
 

--- a/test/apps/errors/test.ts
+++ b/test/apps/errors/test.ts
@@ -85,18 +85,6 @@ describe('errors', function() {
 		);
 	});
 
-	// https://github.com/sveltejs/sapper/issues/710
-	// 
-	// In reported issue, error elements disappear, which is not the case in
-	// our test case. This is because the default layout `<slot/>` does not
-	// try to reclaim anything. Reporter probably has a custom `_layout.svelte`
-	// with some divs etc., and those will clear the existing DOM (if they
-	// don't find their element?).
-	// 
-	// Here we're not testing that the error is still here, but that the page 
-	// component has not been rendered (since only error page should be rendered 
-	// here). So we don't need a custom layout.
-	// 
 	it('does not replace server side rendered error', async () => {
 		await r.load('/preload-reject');
 		await r.sapper.start();


### PR DESCRIPTION
The preload error was serialized to `null` in preloaded data, so the client thought it got error free preloaded data and rendered the page over the error.

That what's caused the error to disappear (coupled with custom `_layout.svelte`).

But to make things worse, the client doesn't even have data to render at this point.