### PR TITLE
Repair regexp routes

### DIFF
--- a/src/core/create_manifest_data.ts
+++ b/src/core/create_manifest_data.ts
@@ -5,7 +5,7 @@ import { Page, PageComponent, ServerRoute, ManifestData } from '../interfaces';
 import { posixify, reserved_words } from '../utils';
 
 export default function create_manifest_data(cwd: string, extensions: string = '.svelte .html'): ManifestData {
-	
+
 	const component_extensions = extensions.split(' ');
 
 	// TODO remove in a future version
@@ -335,7 +335,7 @@ function get_pattern(segments: Part[][], add_trailing_slash: boolean) {
 	const path = segments.map(segment => {
 		return segment.map(part => {
 			return part.dynamic
-				? part.qualifier || part.spread ? '(.+)' : '([^\\/]+?)'
+				? part.qualifier || (part.spread ? '(.+)' : '([^\\/]+?)')
 				: encodeURI(part.content.normalize())
 					.replace(/\?/g, '%3F')
 					.replace(/#/g, '%23')

--- a/test/apps/basics/src/routes/[id([0-9]+)].svelte
+++ b/test/apps/basics/src/routes/[id([0-9]+)].svelte
@@ -3,6 +3,6 @@
 	const { page } = stores();
 </script>
 
-<h1>{$page.params.slug}</h1>
+<h1>Regexp page {$page.params.id}</h1>
 
-<a href="234">regexp route</a>
+<a href="regexp/234">nested regexp route</a>

--- a/test/apps/basics/src/routes/regexp/[id([0-9]+)].svelte
+++ b/test/apps/basics/src/routes/regexp/[id([0-9]+)].svelte
@@ -3,6 +3,4 @@
 	const { page } = stores();
 </script>
 
-<h1>{$page.params.slug}</h1>
-
-<a href="234">regexp route</a>
+<h1>Nested regexp page {$page.params.id}</h1>

--- a/test/apps/basics/test.ts
+++ b/test/apps/basics/test.ts
@@ -82,7 +82,7 @@ describe('basics', function() {
 
 		assert.equal(
 			await r.text('h1'),
-			'TEST-SLUG'
+			'test-slug'
 		);
 	});
 
@@ -314,6 +314,22 @@ describe('basics', function() {
 		await r.page.click('[href="dirs/foo/xyz"]');
 		await r.wait();
 		assert.equal(await r.text('h1'), 'B page');
+	});
+
+	it('find regexp routes', async () => {
+		await r.load('/qwe');
+		await r.sapper.start();
+
+		assert.equal(await r.text('h1'), 'qwe');
+
+		await r.page.click('[href="234"]');
+		await r.wait();
+
+		assert.equal(await r.text('h1'), 'Regexp page 234');
+
+		await r.page.click('[href="regexp/234"]');
+		await r.wait();
+		assert.equal(await r.text('h1'), 'Nested regexp page 234');
 	});
 
 	it('runs server route handlers before page handlers, if they match', async () => {

--- a/test/unit/create_manifest_data/test.ts
+++ b/test/unit/create_manifest_data/test.ts
@@ -95,16 +95,15 @@ describe('manifest_data', () => {
 		]);
 	});
 
-	// this test broken
-	// it('allows regex qualifiers', () => {
-	// 	const { pages } = create_manifest_data(path.join(__dirname, 'samples/qualifiers'));
-	//
-	// 	assert.deepEqual(pages.map(p => p.pattern), [
-	// 		/^\/([0-9-a-z]{3,})\/?$/,
-	// 		/^\/([a-z]{2})\/?$/,
-	// 		/^\/([^\/]+?)\/?$/
-	// 	]);
-	// });
+	it('allows regex qualifiers', () => {
+		const { pages } = create_manifest_data(path.join(__dirname, 'samples/qualifiers'));
+
+		assert.deepEqual(pages.map(p => p.pattern), [
+			/^\/([0-9-a-z]{3,})\/?$/,
+			/^\/([a-z]{2})\/?$/,
+			/^\/([^\/]+?)\/?$/
+		]);
+	});
 
 	it('sorts routes correctly', () => {
 		const { pages } = create_manifest_data(path.join(__dirname, 'samples/sorting'));


### PR DESCRIPTION
After implement spread routes, looks like regexp routes was broken. Fixed. Added more tests for that case. Related #707