### PR TITLE
cli: abort on unknown options

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -262,7 +262,7 @@ prog.command('export [dest]')
 		}
 	});
 
-prog.parse(process.argv);
+prog.parse(process.argv, { unknown: (arg: string) => `Unknown option: ${arg}` });
 
 
 async function _build(


### PR DESCRIPTION
Fixes #729. That issue mentioned a warning, but I think failing outright is a better idea. Made very simple to do thanks to new Sade/MRI features 🎉 