### PR TITLE
Support async method in session middleware option

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -11,7 +11,7 @@ import App from '@sapper/internal/App.svelte';
 
 export function get_page_handler(
 	manifest: Manifest,
-	session_getter: (req: Req, res: Res) => any
+	session_getter: (req: Req, res: Res) => Promise<any>
 ) {
 	const get_build_info = dev
 		? () => JSON.parse(fs.readFileSync(path.join(build_dir, 'build.json'), 'utf-8'))
@@ -88,7 +88,7 @@ export function get_page_handler(
 			res.setHeader('Link', link);
 		}
 
-		const session = session_getter(req, res);
+		const session = await session_getter(req, res);
 
 		let redirect: { statusCode: number, location: string };
 		let preload_error: { statusCode: number, message: Error | string };

--- a/test/apps/session/src/server.js
+++ b/test/apps/session/src/server.js
@@ -11,7 +11,7 @@ const app = polka()
 	})
 	.use(
 		sapper.middleware({
-			session: (req, res) => ({
+			session: async (req, res) => await Promise.resolve({
 				title: `${req.hello} ${res.locals.name}`
 			})
 		})


### PR DESCRIPTION
Fixes #740

You can now run async operation in session option.

```javascript
const app = polka()
  .use(
    sapper.middleware({
      session: async (req, res) => {
        return await async_operation();
      }
    })
);
```