### PR TITLE
[FIX] fix css sourcemaps

### DIFF
--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -61,6 +61,7 @@ export default class RollupCompiler {
 
 	async compile(): Promise<CompileResult> {
 		const config = await this._;
+		const sourcemap = config.output.sourcemap;
 
 		const start = Date.now();
 
@@ -68,7 +69,7 @@ export default class RollupCompiler {
 			const bundle = await rollup.rollup(config);
 			await bundle.write(config.output);
 
-			return new RollupResult(Date.now() - start, this);
+			return new RollupResult(Date.now() - start, this, sourcemap);
 		} catch (err) {
 			if (err.filename) {
 				// TODO this is a bit messy. Also, can
@@ -85,6 +86,7 @@ export default class RollupCompiler {
 
 	async watch(cb: (err?: Error, stats?: any) => void) {
 		const config = await this._;
+		const sourcemap = config.output.sourcemap;
 
 		const watcher = rollup.watch(config);
 
@@ -113,7 +115,7 @@ export default class RollupCompiler {
 
 				case 'ERROR':
 					this.errors.push(event.error);
-					cb(null, new RollupResult(Date.now() - this._start, this));
+					cb(null, new RollupResult(Date.now() - this._start, this, sourcemap));
 					break;
 
 				case 'START':
@@ -126,7 +128,7 @@ export default class RollupCompiler {
 					break;
 
 				case 'BUNDLE_END':
-					cb(null, new RollupResult(Date.now() - this._start, this));
+					cb(null, new RollupResult(Date.now() - this._start, this, sourcemap));
 					break;
 
 				default:

--- a/src/core/create_compilers/RollupResult.ts
+++ b/src/core/create_compilers/RollupResult.ts
@@ -18,10 +18,12 @@ export default class RollupResult implements CompileResult {
 		main: string,
 		chunks: Record<string, string[]>
 	};
+	sourcemap: boolean | 'inline';
 	summary: string;
 
-	constructor(duration: number, compiler: RollupCompiler) {
+	constructor(duration: number, compiler: RollupCompiler, sourcemap: boolean | 'inline') {
 		this.duration = duration;
+		this.sourcemap = sourcemap
 
 		this.errors = compiler.errors.map(munge_warning_or_error);
 		this.warnings = compiler.warnings.map(munge_warning_or_error); // TODO emit this as they happen
@@ -93,7 +95,7 @@ export default class RollupResult implements CompileResult {
 			bundler: 'rollup',
 			shimport: require('shimport/package.json').version,
 			assets: this.assets,
-			css: extract_css(this, manifest_data.components, dirs)
+			css: extract_css(this, manifest_data.components, dirs, this.sourcemap)
 		};
 	}
 

--- a/src/core/create_compilers/extract_css.ts
+++ b/src/core/create_compilers/extract_css.ts
@@ -46,7 +46,7 @@ type SourceMap = {
 	mappings: string;
 };
 
-function get_css_from_modules(modules: string[], css_map: Map<string, string>, dirs: Dirs) {
+function get_css_from_modules(modules: string[], css_map: Map<string, string>, asset_dir: string) {
 	const parts: string[] = [];
 	const mappings: number[][][] = [];
 
@@ -94,7 +94,7 @@ function get_css_from_modules(modules: string[], css_map: Map<string, string>, d
 	if (parts.length > 0) {
 		combined_map.mappings = codec.encode(mappings);
 
-		combined_map.sources = combined_map.sources.map(source => path.relative(`${dirs.dest}/client`, source));
+		combined_map.sources = combined_map.sources.map(source => path.relative(asset_dir, source).replace(/\\/g, '/'));
 
 		return {
 			code: parts.join('\n'),
@@ -138,16 +138,15 @@ export default function extract_css(client_result: CompileResult, components: Pa
 		const css_modules = chunk.modules.filter(m => css_map.has(m));
 		if (!css_modules.length) return;
 
-		const css = get_css_from_modules(css_modules, css_map, dirs);
+		const css = get_css_from_modules(css_modules, css_map, asset_dir);
 
 		const { code, map } = css;
 
 		const output_file_name = chunk.file.replace(/\.js$/, '.css');
 
 		map.file = output_file_name;
-		map.sources = map.sources.map(source => path.relative(`${asset_dir}`, source));
 
-		fs.writeFileSync(`${asset_dir}/${output_file_name}`, `${code}\n/* sourceMappingURL=./${output_file_name}.map */`);
+		fs.writeFileSync(`${asset_dir}/${output_file_name}`, `${code}\n/*# sourceMappingURL=${output_file_name}.map */`);
 		fs.writeFileSync(`${asset_dir}/${output_file_name}.map`, JSON.stringify(map, null, '  '));
 
 		chunks_with_css.add(chunk);
@@ -227,7 +226,7 @@ export default function extract_css(client_result: CompileResult, components: Pa
 		entry_css_modules.push(file);
 	});
 
-	const leftover = get_css_from_modules(entry_css_modules, css_map, dirs);
+	const leftover = get_css_from_modules(entry_css_modules, css_map, asset_dir);
 	if (leftover) {
 		const { code, map } = leftover;
 
@@ -236,9 +235,8 @@ export default function extract_css(client_result: CompileResult, components: Pa
 		const output_file_name = `main.${main_hash}.css`;
 
 		map.file = output_file_name;
-		map.sources = map.sources.map(source => path.relative(asset_dir, source));
 
-		fs.writeFileSync(`${asset_dir}/${output_file_name}`, `${code}\n/* sourceMappingURL=client/${output_file_name}.map */`);
+		fs.writeFileSync(`${asset_dir}/${output_file_name}`, `${code}\n/*# sourceMappingURL=client/${output_file_name}.map */`);
 		fs.writeFileSync(`${asset_dir}/${output_file_name}.map`, JSON.stringify(map, null, '  '));
 
 		result.main = output_file_name;


### PR DESCRIPTION
fixes #421
closes #537

There were 3 issues:

- `#` was missing from `/* sourceMappingURL=<URL> */`
- `sources` array was relatively mapped twice
- `sources` array would contain windows paths on a windows system

I have tested the PR in my own project and CSS sourcemaps work now.