### PR TITLE
[FEAT] make rollup sourcemap independent of env

### DIFF
--- a/src/config/rollup.ts
+++ b/src/config/rollup.ts
@@ -1,7 +1,7 @@
 import { dev, src, dest } from './env';
 import { InputOption, OutputOptions } from 'rollup';
 
-const defaultSourcemap = dev ? 'inline' : false;
+const sourcemap = dev ? 'inline' : false;
 
 export default {
 	dev,
@@ -11,7 +11,7 @@ export default {
 			return `${src}/client.js`
 		},
 
-		output: (sourcemap: boolean | 'inline' = defaultSourcemap): OutputOptions => {
+		output: (): OutputOptions => {
 			let dir = `${dest}/client`;
 			if (process.env.SAPPER_LEGACY_BUILD) dir += `/legacy`;
 
@@ -32,7 +32,7 @@ export default {
 			};
 		},
 
-		output: (sourcemap: boolean | 'inline' = defaultSourcemap): OutputOptions => {
+		output: (): OutputOptions => {
 			return {
 				dir: `${dest}/server`,
 				format: 'cjs',
@@ -46,7 +46,7 @@ export default {
 			return `${src}/service-worker.js`;
 		},
 
-		output: (sourcemap: boolean | 'inline' = defaultSourcemap): OutputOptions => {
+		output: (): OutputOptions => {
 			return {
 				file: `${dest}/service-worker.js`,
 				format: 'iife',

--- a/src/config/rollup.ts
+++ b/src/config/rollup.ts
@@ -1,8 +1,7 @@
 import { dev, src, dest } from './env';
-import { InputOption, OutputOptions } from 'rollup'
+import { InputOption, OutputOptions } from 'rollup';
 
-const defaultSourcemap =
-	dev === true ? 'inline' : false
+const defaultSourcemap = dev ? 'inline' : false;
 
 export default {
 	dev,
@@ -12,7 +11,7 @@ export default {
 			return `${src}/client.js`
 		},
 
-		output: (sourcemap?: boolean | 'inline'): OutputOptions => {
+		output: (sourcemap: boolean | 'inline' = defaultSourcemap): OutputOptions => {
 			let dir = `${dest}/client`;
 			if (process.env.SAPPER_LEGACY_BUILD) dir += `/legacy`;
 
@@ -21,7 +20,7 @@ export default {
 				entryFileNames: '[name].[hash].js',
 				chunkFileNames: '[name].[hash].js',
 				format: 'esm',
-				sourcemap: sourcemap !== undefined ? sourcemap : defaultSourcemap
+				sourcemap
 			};
 		}
 	},
@@ -33,11 +32,11 @@ export default {
 			};
 		},
 
-		output: (sourcemap?: boolean | 'inline'): OutputOptions => {
+		output: (sourcemap: boolean | 'inline' = defaultSourcemap): OutputOptions => {
 			return {
 				dir: `${dest}/server`,
 				format: 'cjs',
-				sourcemap: sourcemap !== undefined ? sourcemap : defaultSourcemap
+				sourcemap
 			};
 		}
 	},
@@ -47,11 +46,11 @@ export default {
 			return `${src}/service-worker.js`;
 		},
 
-		output: (sourcemap?: boolean | 'inline'): OutputOptions => {
+		output: (sourcemap: boolean | 'inline' = defaultSourcemap): OutputOptions => {
 			return {
 				file: `${dest}/service-worker.js`,
 				format: 'iife',
-				sourcemap: sourcemap !== undefined ? sourcemap : defaultSourcemap
+				sourcemap
 			}
 		}
 	}

--- a/src/config/rollup.ts
+++ b/src/config/rollup.ts
@@ -1,14 +1,15 @@
 import { dev, src, dest } from './env';
+import { InputOption, OutputOptions } from 'rollup'
 
 export default {
 	dev,
 
 	client: {
-		input: () => {
+		input: (): InputOption => {
 			return `${src}/client.js`
 		},
 
-		output: () => {
+		output: (sourcemap?: boolean | 'inline'): OutputOptions => {
 			let dir = `${dest}/client`;
 			if (process.env.SAPPER_LEGACY_BUILD) dir += `/legacy`;
 
@@ -17,33 +18,33 @@ export default {
 				entryFileNames: '[name].[hash].js',
 				chunkFileNames: '[name].[hash].js',
 				format: 'esm',
-				sourcemap: dev
+				sourcemap
 			};
 		}
 	},
 
 	server: {
-		input: () => {
+		input: (): InputOption => {
 			return {
 				server: `${src}/server.js`
 			};
 		},
 
-		output: () => {
+		output: (sourcemap?: boolean | 'inline'): OutputOptions => {
 			return {
 				dir: `${dest}/server`,
 				format: 'cjs',
-				sourcemap: dev
+				sourcemap
 			};
 		}
 	},
 
 	serviceworker: {
-		input: () => {
+		input: (): InputOption => {
 			return `${src}/service-worker.js`;
 		},
 
-		output: () => {
+		output: (): OutputOptions => {
 			return {
 				file: `${dest}/service-worker.js`,
 				format: 'iife'

--- a/src/config/rollup.ts
+++ b/src/config/rollup.ts
@@ -18,7 +18,7 @@ export default {
 				entryFileNames: '[name].[hash].js',
 				chunkFileNames: '[name].[hash].js',
 				format: 'esm',
-				sourcemap
+				sourcemap: sourcemap !== undefined ? sourcemap : (dev === true ? 'inline' : false)
 			};
 		}
 	},
@@ -34,7 +34,7 @@ export default {
 			return {
 				dir: `${dest}/server`,
 				format: 'cjs',
-				sourcemap
+				sourcemap: sourcemap !== undefined ? sourcemap : (dev === true ? 'inline' : false)
 			};
 		}
 	},

--- a/src/config/rollup.ts
+++ b/src/config/rollup.ts
@@ -1,6 +1,9 @@
 import { dev, src, dest } from './env';
 import { InputOption, OutputOptions } from 'rollup'
 
+const defaultSourcemap =
+	dev === true ? 'inline' : false
+
 export default {
 	dev,
 
@@ -18,7 +21,7 @@ export default {
 				entryFileNames: '[name].[hash].js',
 				chunkFileNames: '[name].[hash].js',
 				format: 'esm',
-				sourcemap: sourcemap !== undefined ? sourcemap : (dev === true ? 'inline' : false)
+				sourcemap: sourcemap !== undefined ? sourcemap : defaultSourcemap
 			};
 		}
 	},
@@ -34,7 +37,7 @@ export default {
 			return {
 				dir: `${dest}/server`,
 				format: 'cjs',
-				sourcemap: sourcemap !== undefined ? sourcemap : (dev === true ? 'inline' : false)
+				sourcemap: sourcemap !== undefined ? sourcemap : defaultSourcemap
 			};
 		}
 	},
@@ -44,10 +47,11 @@ export default {
 			return `${src}/service-worker.js`;
 		},
 
-		output: (): OutputOptions => {
+		output: (sourcemap?: boolean | 'inline'): OutputOptions => {
 			return {
 				file: `${dest}/service-worker.js`,
-				format: 'iife'
+				format: 'iife',
+				sourcemap: sourcemap !== undefined ? sourcemap : defaultSourcemap
 			}
 		}
 	}


### PR DESCRIPTION
Adds `sourcemap` arg to the output function.

This issue was brought up in https://github.com/sveltejs/sapper/issues/590#issuecomment-482396543

After #771 gets merged this is a crucial option to have imo