### PR TITLE
Fix broken link to Svelte SSR documentation

### DIFF
--- a/site/content/docs/06-server-side-rendering.md
+++ b/site/content/docs/06-server-side-rendering.md
@@ -2,7 +2,7 @@
 title: Server-side rendering
 ---
 
-Sapper, by default, renders server-side first (SSR), and then re-mounts any dynamic elements on the client. Svelte provides [excellent support for this](https://svelte.dev/docs#server-side-rendering). This has benefits in performance and search engine indexing, among others, but comes with its own set of complexities.
+Sapper, by default, renders server-side first (SSR), and then re-mounts any dynamic elements on the client. Svelte provides [excellent support for this](https://svelte.dev/docs#Server-side_component_API). This has benefits in performance and search engine indexing, among others, but comes with its own set of complexities.
 
 ### Making a component SSR compatible
 


### PR DESCRIPTION
looks like that section was removed, and SSR information is spread around the docs now. This at least jumps to an SSR-related section.