### PR TITLE
Fix for detaching meta in <svelte:head>

### DIFF
--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -386,5 +386,7 @@ export function load_component(component: ComponentLoader): Promise<{
 }
 
 function detach(node: Node) {
+	if (!node.parentNode) return;
+
 	node.parentNode.removeChild(node);
 }


### PR DESCRIPTION
Fix for the problem discovered here:
https://github.com/sveltejs/sapper-template/pull/158

Page transition breaks if there's `meta` tag inside `<svelte:head>`.