### PR TITLE
Add `application/wasm` to known MIME types

### DIFF
--- a/runtime/src/server/middleware/mime-types.md
+++ b/runtime/src/server/middleware/mime-types.md
@@ -464,6 +464,7 @@ application/vnd.yellowriver-custom-menu		cmp
 application/vnd.zul				zir zirz
 application/vnd.zzazz.deck+xml			zaz
 application/voicexml+xml			vxml
+application/wasm				wasm
 application/widget				wgt
 application/winhlp				hlp
 application/wsdl+xml				wsdl


### PR DESCRIPTION
The `application/wasm` mime type is associated with the `.wasm` file extension.