### PR TITLE
Fix source maps for rollup builds

### DIFF
--- a/src/core/create_compilers/extract_css.ts
+++ b/src/core/create_compilers/extract_css.ts
@@ -216,8 +216,21 @@ export default function extract_css(client_result: CompileResult, components: Pa
 
 		const source = fs.readFileSync(`${asset_dir}/${file}`, 'utf-8');
 
-		const replaced = source.replace(/["']__SAPPER_CSS_PLACEHOLDER:(.+?)__["']/g, (m, route) => {
-			return JSON.stringify(result.chunks[route]);
+		const replaced = source.replace(/(\\?["'])__SAPPER_CSS_PLACEHOLDER:([^"']+?)__\1/g, (m, quotes, route) => {
+			let replacement = JSON.stringify(result.chunks[route]);
+
+			// If the quotation marks are escaped, then
+			// the source code is in a string literal
+			// (e.g., source maps) rather than raw
+			// JavaScript source. We need to stringify
+			// again and then remove the extra quotation
+			// marks so that replacement is correct.
+			if (quotes[0] === '\\') {
+				replacement = JSON.stringify(replacement);
+				replacement = replacement.substring(1, replacement.length - 1);
+			}
+
+			return replacement;
 		});
 
 		fs.writeFileSync(`${asset_dir}/${file}`, replaced);


### PR DESCRIPTION
When substituting \_\_SAPPER_CSS_PLACEHOLDER:foo\_\_, tighten the regexp
to require matching quotation marks and to not match too much if
there's an error.

Also, make the replacement logic smart about recognizing when we're
matching JavaScript code that's been quoted (e.g., in source maps),
and to generate a substitution that's still valid in that context.

Fixes #808.