### PR TITLE
Custom error handler for server routes

### DIFF
--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -8,9 +8,10 @@ import { lookup } from './mime';
 
 export default function middleware(opts: {
 	session?: (req: Req, res: Res) => any,
-	ignore?: any
+	ignore?: any,
+	error_handler?: Function
 } = {}) {
-	const { session, ignore } = opts;
+	const { session, ignore, error_handler } = opts;
 
 	let emitted_basepath = false;
 
@@ -59,7 +60,7 @@ export default function middleware(opts: {
 			cache_control: dev ? 'no-cache' : 'max-age=31536000, immutable'
 		}),
 
-		get_server_route_handler(manifest.server_routes),
+		get_server_route_handler(manifest.server_routes, { error_handler }),
 
 		get_page_handler(manifest, session || noop)
 	].filter(Boolean));

--- a/site/content/docs/02-routing.md
+++ b/site/content/docs/02-routing.md
@@ -118,6 +118,25 @@ The `error` object is made available to the template along with the HTTP `status
 
 
 
+### Error handling for server routes
+
+By default, errors occurred in server routes are sent as a text response with the HTTP 500 status. You can define your own error handler by passing it as an option to Sapper middleware:
+
+```js
+function on_error(err, req, res, next) {
+  res.setHeader('Content-Type', 'application/json');
+  res.statusCode = 500;
+	res.end(JSON.stringify({ error: err.message }));
+  // Log error here, etc
+}
+
+app.use(sapper.middleware({ error_handler: on_error }));
+```
+
+Your error handler should either serve the response by calling `res.end()` or pass the error to the default error handler by calling `next(err)`. If your handler throws an error, the default error handler will be used as a fallback (with the original server route error, not your error handler error).
+
+
+
 ### Regexes in routes
 
 You can use a subset of regular expressions to qualify route parameters, by placing them in parentheses after the parameter name.


### PR DESCRIPTION
Regarding: #812 

This commit solves the problem of handling server route errors, which were not properly handled before. It provides opportunity to provide a function which can handle errors in a centralised way (e.g. log them, hide their content from end-user, send them to browser using JSON, etc).

The following code allows providing custom error handler function as an `error_handler` option to the middleware. I also included relevant documentation, which is self-explanatory, so won't repeat it here.