### PR TITLE
Update pkg.json description.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sapper",
   "version": "0.27.4",
-  "description": "Military-grade apps, engineered by Svelte",
+  "description": "The next small thing in web development, powered by Svelte",
   "bin": {
     "sapper": "./sapper"
   },


### PR DESCRIPTION
Removes the old tagline from the package.json in place of the newer one. I'm guessing this was just a leftover after the redesign.

Closes #263.