### PR TITLE
Refresh manifest_data has_preload on changes - fixes #611

### DIFF
--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -506,10 +506,7 @@ function watch_dir(
 
 		watch = new CheapWatch({ dir, filter, debounce: 50 });
 
-		watch.on('+', ({ isNew }: { isNew: boolean }) => {
-			// ignore isNew to refresh the manifest_data.components has_preload values
-			callback();
-		});
+		watch.on('+', callback);
 
 		watch.on('-', callback);
 

--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -507,7 +507,8 @@ function watch_dir(
 		watch = new CheapWatch({ dir, filter, debounce: 50 });
 
 		watch.on('+', ({ isNew }: { isNew: boolean }) => {
-			if (isNew) callback();
+			// ignore isNew to refresh the manifest_data.components has_preload values
+			callback();
 		});
 
 		watch.on('-', callback);


### PR DESCRIPTION
The `has_preload` value was calculated per page component on add/remove routes/pages, but not when a preexisting page/route was updated. This PR also regenerates the `data_manifest` on changes in individual pages/routes so that the `has_preload` value reflects the current source code. Fixes #611