### PR TITLE
Allow to use window.location.protocol on dev server

### DIFF
--- a/sapper-dev-client.js
+++ b/sapper-dev-client.js
@@ -13,7 +13,7 @@ function check() {
 export function connect(port) {
 	if (source || !window.EventSource) return;
 
-	source = new EventSource(`http://${window.location.hostname}:${port}/__sapper__`);
+	source = new EventSource(`${window.location.protocol}://${window.location.hostname}:${port}/__sapper__`);
 
 	window.source = source;
 


### PR DESCRIPTION
This is just a small feature to allow play with `https` on local environment.

I'm not sure how to test it since it's just change the dev client, not the application at all.

Feedbacks are always welcome :)