### PR TITLE
Mention `preload` being called on the server and on navigation only

### DIFF
--- a/site/content/docs/04-preloading.md
+++ b/site/content/docs/04-preloading.md
@@ -19,6 +19,8 @@ As seen in the [routing](docs#Routing) section, page components can have an opti
 
 It lives in a `context="module"` script — see the [tutorial](https://svelte.dev/tutorial/module-exports) — because it's not part of the component instance itself; instead, it runs *before* the component is created, allowing you to avoid flashes while data is fetched.
 
+The `preload` function is only called on the server and when navigating from page to page.
+
 ### Argument
 
 The `preload` function receives two arguments — `page` and `session`.


### PR DESCRIPTION
Hi!

This is a quick docs PR for an issue I had trying to understand the inner workings of `preload`.

For me it wasn't clear that it is only called on the server and on page navigation.

It's kind of implicitly stated [in the docs](http://localhost:3000/docs#Return_value) but I would find it useful to state that right at the beginning.

Cheers,
thenoseman