### PR TITLE
Start with 'seen' set from copied static assets

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -68,7 +68,9 @@ async function _export({
 	rimraf(export_dir);
 
 	const seen: Set<string> = new Set();
-	copy(static_files, export_dir, seen, static_files + "/");
+	copy(static_files, export_dir)
+		.forEach((element:string) => seen.add(element.replace(static_files + "/", "")));
+
 	copy(path.join(build_dir, 'client'), path.join(export_dir, 'client'));
 	copy(path.join(build_dir, 'service-worker.js'), path.join(export_dir, 'service-worker.js'));
 	copy(path.join(build_dir, 'service-worker.js.map'), path.join(export_dir, 'service-worker.js.map'));

--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -67,7 +67,7 @@ async function _export({
 	// Prep output directory
 	rimraf(export_dir);
 
-	copy(static_files, export_dir);
+	const seen = copy(static_files, export_dir);
 	copy(path.join(build_dir, 'client'), path.join(export_dir, 'client'));
 	copy(path.join(build_dir, 'service-worker.js'), path.join(export_dir, 'service-worker.js'));
 	copy(path.join(build_dir, 'service-worker.js.map'), path.join(export_dir, 'service-worker.js.map'));
@@ -98,7 +98,6 @@ async function _export({
 		}, process.env)
 	});
 
-	const seen = new Set();
 	const saved = new Set();
 	const q = yootils.queue(concurrent);
 

--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -67,7 +67,8 @@ async function _export({
 	// Prep output directory
 	rimraf(export_dir);
 
-	const seen = copy(static_files, export_dir);
+	const seen: Set<string> = new Set();
+	copy(static_files, export_dir, seen, static_files + "/");
 	copy(path.join(build_dir, 'client'), path.join(export_dir, 'client'));
 	copy(path.join(build_dir, 'service-worker.js'), path.join(export_dir, 'service-worker.js'));
 	copy(path.join(build_dir, 'service-worker.js.map'), path.join(export_dir, 'service-worker.js.map'));

--- a/src/api/utils/fs_utils.ts
+++ b/src/api/utils/fs_utils.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { stringify } from '../../utils';
 
 export function mkdirp(dir: string) {
 	const parent = path.dirname(dir);
@@ -30,18 +31,23 @@ export function rimraf(thing: string) {
 	}
 }
 
-export function copy(from: string, to: string, seen?: Set<string>, basedir?: string) {
+export function copy(from: string, to: string): Set<string> { // returns a Set which contains all the paths of the copied files
+	const copied: Set<string> = new Set();
+	
 	if (!fs.existsSync(from)) return;
 
 	const stats = fs.statSync(from);
 
 	if (stats.isDirectory()) {
-	fs.readdirSync(from).forEach(file => {
-		copy(path.join(from, file), path.join(to, file), seen, basedir);
-	});
+		fs.readdirSync(from).forEach(file => {
+			copy(path.join(from, file), path.join(to, file))
+				.forEach(element => copied.add(element))
+		});
 	} else {
-	mkdirp(path.dirname(to));
-	fs.writeFileSync(to, fs.readFileSync(from));
-	if (seen instanceof Set) seen.add(from.replace(basedir, ""));
+		mkdirp(path.dirname(to));
+		fs.writeFileSync(to, fs.readFileSync(from));
+		copied.add(from);
 	}
+
+	return copied;
 }

--- a/src/api/utils/fs_utils.ts
+++ b/src/api/utils/fs_utils.ts
@@ -31,16 +31,24 @@ export function rimraf(thing: string) {
 }
 
 export function copy(from: string, to: string) {
-	if (!fs.existsSync(from)) return;
-
-	const stats = fs.statSync(from);
-
-	if (stats.isDirectory()) {
+	const seen = new Set();
+	const startDir = from + "/";
+	copyFiles(from, to);
+	return seen;
+  
+	function copyFiles(from: string, to: string) {
+	  if (!fs.existsSync(from)) return;
+  
+	  const stats = fs.statSync(from);
+  
+	  if (stats.isDirectory()) {
 		fs.readdirSync(from).forEach(file => {
-			copy(path.join(from, file), path.join(to, file));
+		  copyFiles(path.join(from, file), path.join(to, file));
 		});
-	} else {
+	  } else {
 		mkdirp(path.dirname(to));
 		fs.writeFileSync(to, fs.readFileSync(from));
+		seen.add(from.replace(startDir, ""));
+	  }
 	}
-}
+  }

--- a/src/api/utils/fs_utils.ts
+++ b/src/api/utils/fs_utils.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { stringify } from '../../utils';
 
 export function mkdirp(dir: string) {
 	const parent = path.dirname(dir);
@@ -34,7 +33,7 @@ export function rimraf(thing: string) {
 export function copy(from: string, to: string): Set<string> { // returns a Set which contains all the paths of the copied files
 	const copied: Set<string> = new Set();
 	
-	if (!fs.existsSync(from)) return;
+	if (!fs.existsSync(from)) return copied;
 
 	const stats = fs.statSync(from);
 

--- a/src/api/utils/fs_utils.ts
+++ b/src/api/utils/fs_utils.ts
@@ -31,10 +31,10 @@ export function rimraf(thing: string) {
 }
 
 export function copy(from: string, to: string) {
-	const seen = new Set();
+	const copied = new Set();
 	const startDir = from + "/";
 	copyFiles(from, to);
-	return seen;
+	return copied;
   
 	function copyFiles(from: string, to: string) {
 	  if (!fs.existsSync(from)) return;
@@ -48,7 +48,7 @@ export function copy(from: string, to: string) {
 	  } else {
 		mkdirp(path.dirname(to));
 		fs.writeFileSync(to, fs.readFileSync(from));
-		seen.add(from.replace(startDir, ""));
+		copied.add(from.replace(startDir, ""));
 	  }
 	}
   }

--- a/src/api/utils/fs_utils.ts
+++ b/src/api/utils/fs_utils.ts
@@ -30,25 +30,18 @@ export function rimraf(thing: string) {
 	}
 }
 
-export function copy(from: string, to: string) {
-	const copied = new Set();
-	const startDir = from + "/";
-	copyFiles(from, to);
-	return copied;
-  
-	function copyFiles(from: string, to: string) {
-	  if (!fs.existsSync(from)) return;
-  
-	  const stats = fs.statSync(from);
-  
-	  if (stats.isDirectory()) {
-		fs.readdirSync(from).forEach(file => {
-		  copyFiles(path.join(from, file), path.join(to, file));
-		});
-	  } else {
-		mkdirp(path.dirname(to));
-		fs.writeFileSync(to, fs.readFileSync(from));
-		copied.add(from.replace(startDir, ""));
-	  }
+export function copy(from: string, to: string, seen?: Set<string>, basedir?: string) {
+	if (!fs.existsSync(from)) return;
+
+	const stats = fs.statSync(from);
+
+	if (stats.isDirectory()) {
+	fs.readdirSync(from).forEach(file => {
+		copy(path.join(from, file), path.join(to, file), seen, basedir);
+	});
+	} else {
+	mkdirp(path.dirname(to));
+	fs.writeFileSync(to, fs.readFileSync(from));
+	if (seen instanceof Set) seen.add(from.replace(basedir, ""));
 	}
-  }
+}


### PR DESCRIPTION
I started working on this branch when I noticed that assets in static that were being linked to from a webpage got corrupted when running `sapper export` (pdf files in particular).
THEN I noticed that I was on an older version of sapper (0.27.4) and that this issue has been resolved since (ie pdfs appear fine in sapper exports in version 0.27.8)
Still, I think it makes sense to skip crawling files in `static`, since those got copied before so no point in going over those again.

Of course happy to get some feedback, still really new in this code base (and js in general) :)