### PR TITLE
Support for relative base path to allow website to be served from different paths

### DIFF
--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -122,10 +122,31 @@ export function select_target(url: URL, start: boolean = false): Target {
 	let pathname = url.pathname;
 
 	if (initial_data.baseUrl.startsWith('.')) {
+		if(path.endsWith('index.html')) {
+			path = path.slice(0, path.length-10);
+		}
 		if (start) {
 			const baseDepth = countBaseDepth(initial_data.baseUrl);
 			const splitPath = trimSlashes(path).split('/');
-			pathToCut = '/' + splitPath.slice(0,splitPath.length-baseDepth).join('/')		
+			pathToCut = '/' + splitPath.slice(0, splitPath.length-baseDepth).join('/');
+
+			if(pathToCut === '/') {
+				if (url.href.lastIndexOf('index.html') === url.href.length - 10) {
+					location.replace(url.href.slice(0, url.href.length - 11));
+					return null;
+				 } else if(url.pathname !== '/' && url.href.lastIndexOf('/') === url.href.length - 1) {
+					location.replace(url.href.slice(0, url.href.length - 1));
+					return null;
+				}
+			} else {
+				if (url.href.lastIndexOf('index.html') === url.href.length - 10) {
+					location.replace(url.href.slice(0, url.href.length - 10));
+					return null;
+				} else if(url.href.lastIndexOf('/') !== url.href.length -1) {
+					location.replace(url.href + '/');
+					return null;
+				}
+			}
 		}		
 		path = path.substr(pathToCut.length);
 		if (!path.startsWith('/')) {

--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -130,29 +130,12 @@ export function select_target(url: URL, start: boolean = false): Target {
 			const splitPath = trimSlashes(path).split('/');
 			pathToCut = '/' + splitPath.slice(0, splitPath.length-baseDepth).join('/');
 
-			if(pathToCut === '/') {
-				if (url.href.lastIndexOf('index.html') === url.href.length - 10) {
-					location.replace(url.href.slice(0, url.href.length - 11));
-					return null;
-				 } else if(url.pathname !== '/' && url.href.lastIndexOf('/') === url.href.length - 1) {
-					location.replace(url.href.slice(0, url.href.length - 1));
-					return null;
-				}
-			} else {
-				if (url.href.lastIndexOf('index.html') === url.href.length - 10) {
-					location.replace(url.href.slice(0, url.href.length - 10));
-					return null;
-				} else if(url.href.lastIndexOf('/') !== url.href.length -1) {
-					location.replace(url.href + '/');
-					return null;
-				}
-			}
 		}		
 		path = path.substr(pathToCut.length);
 		if (!path.startsWith('/')) {
 			path = '/' + path;
 		}
-		if(pathToCut !== '/' && !path.endsWith('/')) {
+		if(!path.endsWith('/')) {
 			path = path + '/';
 		}
 		if(pathToCut === '/') {

--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -120,7 +120,7 @@ export function select_target(url: URL, start: boolean = false): Target {
 
 	let path = url.pathname;
 	let pathname = url.pathname;
-
+	let normalPath = pathname;
 	if (initial_data.baseUrl.startsWith('.')) {
 		if(path.endsWith('index.html')) {
 			path = path.slice(0, path.length-10);
@@ -129,12 +129,12 @@ export function select_target(url: URL, start: boolean = false): Target {
 			const baseDepth = countBaseDepth(initial_data.baseUrl);
 			const splitPath = trimSlashes(path).split('/');
 			pathToCut = '/' + splitPath.slice(0, splitPath.length-baseDepth).join('/');
-
 		}		
 		path = path.substr(pathToCut.length);
 		if (!path.startsWith('/')) {
 			path = '/' + path;
 		}
+		normalPath = path;
 		if(!path.endsWith('/')) {
 			path = path + '/';
 		}
@@ -150,10 +150,11 @@ export function select_target(url: URL, start: boolean = false): Target {
 	} else {
 		if (!path.startsWith(initial_data.baseUrl)) return null;
 		path = path.slice(initial_data.baseUrl.length);
+		normalPath = path;
 	}
 
 	// avoid accidental clashes between server routes and page routes
-	if (ignore.some(pattern => pattern.test(path))) return;
+	if (ignore.some(pattern => pattern.test(normalPath))) return;
 
 	for (let i = 0; i < routes.length; i += 1) {
 		const route = routes[i];

--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -95,9 +95,22 @@ export function extract_query(search: string) {
 
 export function select_target(url: URL): Target {
 	if (url.origin !== location.origin) return null;
-	if (!url.pathname.startsWith(initial_data.baseUrl)) return null;
 
-	let path = url.pathname.slice(initial_data.baseUrl.length);
+	let path = url.pathname;
+	if (initial_data.baseUrl.startsWith('.')) {
+		let numBackward = 1;
+		const splitted = initial_data.baseUrl.split('/');
+		for (let split of splitted) {
+			if (split === '..') {
+				numBackward++;
+			}
+		}
+		const pathPart = path.split('/');
+		path = '/' + pathPart.slice(pathPart.length - numBackward).join('/');
+	} else {
+		if (!path.startsWith(initial_data.baseUrl)) return null;
+		path = path.slice(initial_data.baseUrl.length);
+	}
 
 	if (path === '') {
 		path = '/';

--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -150,6 +150,9 @@ export function select_target(url: URL, start: boolean = false): Target {
 	} else {
 		if (!path.startsWith(initial_data.baseUrl)) return null;
 		path = path.slice(initial_data.baseUrl.length);
+		if (path === '') {
+			path = '/';
+		}
 		normalPath = path;
 	}
 

--- a/runtime/src/app/goto/index.ts
+++ b/runtime/src/app/goto/index.ts
@@ -4,7 +4,7 @@ export default function goto(href: string, opts = { replaceState: false }) {
 	const target = select_target(new URL(href, document.baseURI));
 
 	if (target) {
-		history[opts.replaceState ? 'replaceState' : 'pushState']({ id: cid }, '', href);
+		history[opts.replaceState ? 'replaceState' : 'pushState']({ id: cid }, '', target.pathname);
 		return navigate(target, null).then(() => {});
 	}
 

--- a/runtime/src/app/start/index.ts
+++ b/runtime/src/app/start/index.ts
@@ -39,7 +39,7 @@ export default function start(opts: {
 
 		if (initial_data.error) return handle_error(url);
 
-		const target = select_target(url);
+		const target = select_target(url, true);
 		if (target) return navigate(target, uid, true, hash);
 	});
 }
@@ -100,7 +100,7 @@ function handle_click(event: MouseEvent) {
 		const noscroll = a.hasAttribute('sapper-noscroll');
 		navigate(target, null, noscroll, url.hash);
 		event.preventDefault();
-		history.pushState({ id: cid }, '', url.href);
+		history.pushState({ id: cid }, '', target.pathname);
 	}
 }
 

--- a/runtime/src/app/types.ts
+++ b/runtime/src/app/types.ts
@@ -48,6 +48,7 @@ export type Target = {
 	route: Route;
 	match: RegExpExecArray;
 	page: Page;
+	pathname: string;
 };
 
 export type Redirect = {

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -293,15 +293,6 @@ export function get_page_handler(
 				script += `</script><script src="${main}">`;
 			}
 
-			if(req.baseUrl.startsWith('.')) {
-				let reloadIfNonCanonical;
-				if(req.url === '/') {
-					reloadIfNonCanonical = `if(location.href.lastIndexOf('index.html') === location.href.length-10) { location.replace(location.href.slice(0,location.href.length - 10)) } else if(location.href.lastIndexOf('/') !== location.href.length-1) location.replace(location.href + '/')`;
-				} else {
-					reloadIfNonCanonical = `if(location.href.lastIndexOf('index.html') === location.href.length-10) { location.replace(location.href.slice(0,location.href.length - 11)) } else if(location.href.lastIndexOf('/') === location.href.length-1) location.replace(location.href.slice(0,location.href.length-1))`;
-				}
-				script += `</script><script>${reloadIfNonCanonical}`
-			}
 
 			let styles: string;
 

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -293,6 +293,45 @@ export function get_page_handler(
 				script += `</script><script src="${main}">`;
 			}
 
+			// force redirect to canonical url so links/scripts... can be fetched: 
+			// - append / for sub folder path
+			// - leave it for root path (will be redirected by app code)
+			if(req.baseUrl.startsWith('.')) {
+				const reloadIfNonCanonical = `
+					function countBaseDepth(baseUrl) {
+						let depth = 0;
+						const splitted = baseUrl.split('/');
+						for (let split of splitted) {
+							if (split === '..') {
+								depth++;
+							}
+						}
+						return depth;
+					}
+					
+					function trimSlashes(path) {
+						if (path.startsWith('/')) {
+							path = path.slice(1);
+						}
+						if (path.endsWith('/')) {
+							path = path.slice(0, path.length - 1);
+						}
+						return path;
+					}
+					var baseHref = document.getElementsByTagName('base')[0].getAttribute('href');
+					var baseDepth = countBaseDepth(baseHref);
+					var splitPath = trimSlashes(location.pathname).split('/');
+					var pathToCut = '/' + splitPath.slice(0, splitPath.length-baseDepth).join('/');
+					if(pathToCut !== '/') {
+						if (location.href.lastIndexOf('index.html') === location.href.length - 10) {
+							location.replace(location.href.slice(0, location.href.length - 10));
+						} else if(location.href.lastIndexOf('/') !== location.href.length -1) {
+							location.replace(location.href + '/');
+						}
+					}
+				`;
+				script += `</script><script>${reloadIfNonCanonical}`
+			}
 
 			let styles: string;
 

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -45,6 +45,7 @@ export function get_page_handler(
 	}
 
 	async function handle_page(page: Page, req: Req, res: Res, status = 200, error: Error | string = null) {
+		const prefix = req.baseUrl.startsWith('.') ? '' : req.baseUrl + '/';
 		const is_service_worker_index = req.path === '/service-worker-index.html';
 		const build_info: {
 			bundler: 'rollup' | 'webpack',
@@ -72,7 +73,7 @@ export function get_page_handler(
 			// TODO add dependencies and CSS
 			const link = preloaded_chunks
 				.filter(file => file && !file.match(/\.map$/))
-				.map(file => `<${req.baseUrl}/client/${file}>;rel="modulepreload"`)
+				.map(file => `<${prefix}client/${file}>;rel="modulepreload"`)
 				.join(', ');
 
 			res.setHeader('Link', link);
@@ -81,7 +82,7 @@ export function get_page_handler(
 				.filter(file => file && !file.match(/\.map$/))
 				.map((file) => {
 					const as = /\.css$/.test(file) ? 'style' : 'script';
-					return `<${req.baseUrl}/client/${file}>;rel="preload";as="${as}"`;
+					return `<${prefix}client/${file}>;rel="preload";as="${as}"`;
 				})
 				.join(', ');
 
@@ -275,18 +276,18 @@ export function get_page_handler(
 			].filter(Boolean).join(',')}};`;
 
 			if (has_service_worker) {
-				script += `if('serviceWorker' in navigator)navigator.serviceWorker.register('${req.baseUrl}/service-worker.js');`;
+				script += `if('serviceWorker' in navigator)navigator.serviceWorker.register('${prefix}service-worker.js');`;
 			}
 
 			const file = [].concat(build_info.assets.main).filter(file => file && /\.js$/.test(file))[0];
-			const main = `${req.baseUrl}/client/${file}`;
+			const main = `${prefix}client/${file}`;
 
 			if (build_info.bundler === 'rollup') {
 				if (build_info.legacy_assets) {
-					const legacy_main = `${req.baseUrl}/client/legacy/${build_info.legacy_assets.main}`;
-					script += `(function(){try{eval("async function x(){}");var main="${main}"}catch(e){main="${legacy_main}"};var s=document.createElement("script");try{new Function("if(0)import('')")();s.src=main;s.type="module";s.crossOrigin="use-credentials";}catch(e){s.src="${req.baseUrl}/client/shimport@${build_info.shimport}.js";s.setAttribute("data-main",main);}document.head.appendChild(s);}());`;
+					const legacy_main = `${prefix}client/legacy/${build_info.legacy_assets.main}`;
+					script += `(function(){try{eval("async function x(){}");var main="${main}"}catch(e){main="${legacy_main}"};var s=document.createElement("script");try{new Function("if(0)import('')")();s.src=main;s.type="module";s.crossOrigin="use-credentials";}catch(e){s.src="${prefix}client/shimport@${build_info.shimport}.js";s.setAttribute("data-main",main);}document.head.appendChild(s);}());`;
 				} else {
-					script += `var s=document.createElement("script");try{new Function("if(0)import('')")();s.src="${main}";s.type="module";s.crossOrigin="use-credentials";}catch(e){s.src="${req.baseUrl}/client/shimport@${build_info.shimport}.js";s.setAttribute("data-main","${main}")}document.head.appendChild(s)`;
+					script += `var s=document.createElement("script");try{new Function("if(0)import('')")();s.src="${main}";s.type="module";s.crossOrigin="use-credentials";}catch(e){s.src="${prefix}client/shimport@${build_info.shimport}.js";s.setAttribute("data-main","${main}")}document.head.appendChild(s)`;
 				}
 			} else {
 				script += `</script><script src="${main}">`;

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -45,7 +45,10 @@ export function get_page_handler(
 	}
 
 	async function handle_page(page: Page, req: Req, res: Res, status = 200, error: Error | string = null) {
-		const baseHref = req.params.baseHref || req.baseUrl;
+		let baseHref = req.baseUrl;
+		if(req.params && req.params.baseHref) {
+			baseHref = req.params.baseHref;
+		}
 		const prefix = baseHref.startsWith('.') ? '' : baseHref + '/';
 		const is_service_worker_index = req.path === '/service-worker-index.html';
 		const build_info: {

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -293,6 +293,16 @@ export function get_page_handler(
 				script += `</script><script src="${main}">`;
 			}
 
+			if(req.baseUrl.startsWith('.')) {
+				let reloadIfNonCanonical;
+				if(req.url === '/') {
+					reloadIfNonCanonical = `if(location.href.lastIndexOf('index.html') === location.href.length-10) { location.replace(location.href.slice(0,location.href.length - 10)) } else if(location.href.lastIndexOf('/') !== location.href.length-1) location.replace(location.href + '/')`;
+				} else {
+					reloadIfNonCanonical = `if(location.href.lastIndexOf('index.html') === location.href.length-10) { location.replace(location.href.slice(0,location.href.length - 11)) } else if(location.href.lastIndexOf('/') === location.href.length-1) location.replace(location.href.slice(0,location.href.length-1))`;
+				}
+				script += `</script><script>${reloadIfNonCanonical}`
+			}
+
 			let styles: string;
 
 			// TODO make this consistent across apps

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -328,10 +328,19 @@ export function get_page_handler(
 					var baseDepth = countBaseDepth(baseHref);
 					var splitPath = trimSlashes(location.pathname).split('/');
 					var pathToCut = '/' + splitPath.slice(0, splitPath.length-baseDepth).join('/');
-					if (location.href.endsWith('index.html')) {
-						location.replace(location.href.slice(0, location.href.length - 10));
-					} else if(!location.href.endsWith('/')) {
-						location.replace(location.href + '/');
+					var hrefBeforeParams = location.href; 
+					var paramsString = '';
+					var paramsIndex = hrefBeforeParams.indexOf('?');
+					if (paramsIndex > -1) {
+						paramsString = hrefBeforeParams.substring(paramsIndex);
+						hrefBeforeParams = hrefBeforeParams.substring(0, paramsIndex);
+					}
+					if (hrefBeforeParams.endsWith('index.html')) {
+						hrefBeforeParams = hrefBeforeParams.slice(0, hrefBeforeParams.length - 10);
+						location.replace(hrefBeforeParams + paramsString);
+					} else if(!hrefBeforeParams.endsWith('/')) {
+						hrefBeforeParams = hrefBeforeParams + '/';
+						location.replace(hrefBeforeParams + paramsString);
 					}
 				</script>
 				`;

--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -19,12 +19,15 @@ export default function middleware(opts: {
 	return compose_handlers(ignore, [
 		(req: Req, res: Res, next: () => void) => {
 			if (useRelativeBasePath) {
-				req.baseUrl = '.';
-				const numParts = req.path.split('/').length - 1;
-				if (numParts > 1) {
-					req.baseUrl = '..';
-					for (let i = 2; i < numParts; i++) {
-						req.baseUrl += '/..';
+				if(req.url === '/') {
+					req.baseUrl = '.';
+				} else {
+					const numParts = req.path.split('/').length;
+					if (numParts > 1) {
+						req.baseUrl = '..';
+						for (let i = 2; i < numParts; i++) {
+							req.baseUrl += '/..';
+						}
 					}
 				}
 			}

--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -20,13 +20,13 @@ export default function middleware(opts: {
 		(req: Req, res: Res, next: () => void) => {
 			if (useRelativeBasePath) {
 				if(req.url === '/') {
-					req.baseUrl = '.';
+					req.params.baseHref = '.';
 				} else {
 					const numParts = req.path.split('/').length;
 					if (numParts > 1) {
-						req.baseUrl = '..';
+						req.params.baseHref = '..';
 						for (let i = 2; i < numParts; i++) {
-							req.baseUrl += '/..';
+							req.params.baseHref += '/..';
 						}
 					}
 				}

--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -14,8 +14,20 @@ export default function middleware(opts: {
 
 	let emitted_basepath = false;
 
+	const useRelativeBasePath = process.env['SAPPER_RELATIVE_BASEPATH'] === 'true';
+	
 	return compose_handlers(ignore, [
 		(req: Req, res: Res, next: () => void) => {
+			if (useRelativeBasePath) {
+				req.baseUrl = '.';
+				const numParts = req.path.split('/').length - 1;
+				if (numParts > 1) {
+					req.baseUrl = '..';
+					for (let i = 2; i < numParts; i++) {
+						req.baseUrl += '/..';
+					}
+				}
+			}
 			if (req.baseUrl === undefined) {
 				let { originalUrl } = req;
 				if (req.url === '/' && originalUrl[originalUrl.length - 1] !== '/') {

--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -19,6 +19,9 @@ export default function middleware(opts: {
 	return compose_handlers(ignore, [
 		(req: Req, res: Res, next: () => void) => {
 			if (useRelativeBasePath) {
+				if (!req.params) {
+					req.params = {}
+				}
 				if(req.url === '/') {
 					req.params.baseHref = '.';
 				} else {

--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -24,6 +24,7 @@ type Opts = {
 	oninfo?: ({ message }: { message: string }) => void;
 	onfile?: ({ file, size, status }: { file: string, size: number, status: number }) => void;
 	entry?: string;
+	relative_basepath?: boolean;
 };
 
 type Ref = {
@@ -55,7 +56,8 @@ async function _export({
 	concurrent = 8,
 	oninfo = noop,
 	onfile = noop,
-	entry = '/'
+	entry = '/',
+	relative_basepath = false,
 }: Opts = {}) {
 	basepath = basepath.replace(/^\//, '')
 
@@ -94,7 +96,8 @@ async function _export({
 		env: Object.assign({
 			PORT: port,
 			NODE_ENV: 'production',
-			SAPPER_EXPORT: 'true'
+			SAPPER_EXPORT: 'true',
+			SAPPER_RELATIVE_BASEPATH: relative_basepath ? 'true' : undefined,
 		}, process.env)
 	});
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -207,6 +207,7 @@ prog.command('export [dest]')
 	.option('--build-dir', 'Intermediate build directory', '__sapper__/build')
 	.option('--ext', 'Custom page route extensions (space separated)', '.svelte .html')
 	.option('--entry', 'Custom entry points (space separated)', '/')
+	.option('--relative-basepath', 'so exported site can be put in any basepath', false)
 	.action(async (dest = '__sapper__/export', opts: {
 		build: boolean,
 		legacy: boolean,
@@ -222,7 +223,8 @@ prog.command('export [dest]')
 		output: string,
 		'build-dir': string,
 		ext: string
-		entry: string
+		entry: string,
+		'relative-basepath': boolean,
 	}) => {
 		try {
 			if (opts.build) {
@@ -244,7 +246,7 @@ prog.command('export [dest]')
 				timeout: opts.timeout,
 				concurrent: opts.concurrent,
 				entry: opts.entry,
-
+				relative_basepath: opts['relative-basepath'],
 				oninfo: event => {
 					console.log(colors.bold().cyan(`> ${event.message}`));
 				},


### PR DESCRIPTION
This PR add code to support relative base path so that a website can be hosted on any sub path, including IPFS gateways

This fixes : https://github.com/sveltejs/sapper/issues/746

Note that all url will finish with "/" as this is how ipfs gateways handle folder path

We could potentially add an option to specify a different behavior (remove the slash at the end) if we want but I ll leave that as a potential addition to be done in another PR.

Note that any attempt to access the website pages without a "/" at the end or by specifying "/index.html", will be redirected to the canonical url (with a "/")
This is achieved via `location.replace`

Note that it won't solve https://github.com/sveltejs/sapper/issues/863 though as filesystem access has its own problem, push state does not work there and this require to have index.html on every path. 
This might be an extra option in the future if we can solve it.

### Tests

get a sapper website from the get started guide
and execute the following
```
sapper export --relative-basepath
```

You can now serve it from any parent/grandparent folder

Or upload it on ipfs

An example can be found here on cloudflare gateway : https://cloudflare-ipfs.com/ipfs/QmNVTWGZ4qoW4DwiTze3icNJKhKBArR4HrCR1sapAFaPYg/

To show how the website can be loaded from different sub path I also added it to a ENS name. You can use a browser that support ENS or you can use the following link : https://wighawag.eth.link 

You can also use a gateway like this : https://cloudflare-ipfs.com/ipns/wighawag.eth.link/

Note that I ll unpin the file and/or update that ENS domain in the future so appologies in advance for future readers :)

