### PR TITLE
export: save querystring along with pathname

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -104,7 +104,7 @@ async function _export({
 
 	function save(url: string, status: number, type: string, body: string) {
 		const { pathname } = resolve(origin, url);
-		let file = decodeURIComponent(pathname.slice(1));
+		let file = url;
 
 		if (saved.has(file)) return;
 		saved.add(file);
@@ -136,7 +136,7 @@ async function _export({
 	});
 
 	async function handle(url: URL) {
-		let pathname = url.pathname;
+		let pathname = url.path;
 		if (pathname !== '/service-worker-index.html') {
 			pathname = pathname.replace(root.pathname, '') || '/'
 		}

--- a/test/apps/export/src/routes/index.svelte
+++ b/test/apps/export/src/routes/index.svelte
@@ -9,3 +9,5 @@
 <a>empty anchor #6</a>
 <a href="boom">boom</a>
 <a href="test.pdf">pdf file</a>
+<a href="querystring?q=0">querystring?q=0</a>
+<a href="querystring?q=1">querystring?q=1</a>

--- a/test/apps/export/src/routes/querystring.svelte
+++ b/test/apps/export/src/routes/querystring.svelte
@@ -1,0 +1,11 @@
+<script context="module">
+	export function preload({ query }) {
+		return query;
+	}
+</script>
+
+<script>
+	export let q;
+</script>
+
+<p>q</p>

--- a/test/apps/export/test.ts
+++ b/test/apps/export/test.ts
@@ -27,6 +27,10 @@ describe('export', function() {
 			}
 		}
 
+		const querystring = [];
+		querystring.push('querystring?q=0/index.html');
+		querystring.push('querystring?q=1/index.html');
+
 		assert.deepEqual(non_client_assets.sort(), [
 			'blog.json',
 			'blog/bar.json',
@@ -41,7 +45,8 @@ describe('export', function() {
 			'service-worker-index.html',
 			'service-worker.js',
 			'test.pdf',
-			...boom
+			...boom,
+			...querystring
 		].sort());
 	});
 


### PR DESCRIPTION
Currently, `sapper export` do not distinguish links that have different query strings. This is a very rough attempt to implement such a feature.
