### PR TITLE
add support for url with suffix of index.html in export mode

### DIFF
--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -99,6 +99,9 @@ export function select_target(url: URL): Target {
 
 	let path = url.pathname.slice(initial_data.baseUrl.length);
 
+	// support url with suffix index.html in export mode
+	path = path.replace(/index\.html$/, '');
+
 	if (path === '') {
 		path = '/';
 	}


### PR DESCRIPTION
I have uploaded my exported site to a third side cloud storage to make a static site.

But the cloud storage will automatically transfer url `/some/path` to `/some/path/index.html`

The HTML content is loaded correctly, but the script for that route is only loaded in URL `/some/path` but not the `/some/path/index.html`, even they are the same.

So, I change the `select_target` function, add 

```javascript
	path = path.replace(/index\.html$/, '');
```

before the match of path and route.