### PR TITLE
Update export.ts

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -112,7 +112,8 @@ async function _export({
 		const is_html = type === 'text/html';
 
 		if (is_html) {
-			if (pathname !== '/service-worker-index.html') {
+			// if (pathname !== '/service-worker-index.html') {
+			if (pathname.slice(-5) !== '.html') {
 				file = file === '' ? 'index.html' : `${file}/index.html`;
 			}
 			body = minify_html(body);


### PR DESCRIPTION
fix for https://github.com/sveltejs/sapper/issues/871

add check for .html in file name
replace just 
```js
// if (pathname !== '/service-worker-index.html') {
// to 
// if (pathname.slice(-5) !== '.html') {
```
or long version:
```js
// replace
// file = file === '' ? 'index.html' : `${file}/index.html`;
// to
if (file === '') {
    file = 'index.html';
} else if (file.slice(-5) === '.html') {
    // create just .html file
    // file = file;
}else{
    // create folder and index.html file 
    file = `${file}/index.html`;
}

```

It's change export logic
from
```routes/test-page.html.svelte -> /test-page.html/index.html```
to
```routes/test-page.html.svelte -> /test-page.html```

after export I have url:
before with trail slash after .html
http://doman.com//test-page.html/
now:
http://doman.com//test-page.html
