### PR TITLE
Close event source before window is unloaded

### DIFF
--- a/sapper-dev-client.js
+++ b/sapper-dev-client.js
@@ -37,4 +37,11 @@ export function connect(port) {
 			check();
 		}
 	};
+
+	// Close the event source before the window is unloaded to prevent an error
+	// ("The connection was interrupted while the page was loading.") in Firefox
+	// when the page is reloaded.
+	window.addEventListener('beforeunload', function() {
+		source.close();
+	});
 }


### PR DESCRIPTION
If Sapper is run in development mode, Firefox outputs a (meaningless) error in the console every time the page is reloaded manually or after a reload action was received by the dev client's `EventSource`:

![sapper-firefox-console](https://user-images.githubusercontent.com/1312807/67122725-bb654f00-f1ee-11e9-985f-1533342912ec.png)

This seems to be a bug in Firefox because the error doesn't occur in Chrome or Safari. I've added an event listener that closes the event source before the window is unloaded, which prevents the error.