### PR TITLE
added errorRedirect to middleware opts

### DIFF
--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -8,9 +8,10 @@ import { lookup } from './mime';
 
 export default function middleware(opts: {
 	session?: (req: Req, res: Res) => any,
-	ignore?: any
+	ignore?: any,
+	errorRedirect?:any
 } = {}) {
-	const { session, ignore } = opts;
+	const { session, ignore, errorRedirect } = opts;
 
 	let emitted_basepath = false;
 
@@ -61,7 +62,7 @@ export default function middleware(opts: {
 
 		get_server_route_handler(manifest.server_routes),
 
-		get_page_handler(manifest, session || noop)
+		get_page_handler(manifest, session || noop, errorRedirect)
 	].filter(Boolean));
 }
 


### PR DESCRIPTION
errorRedirect is an object that can be passed to middleware that allows server side redirect on an error code.

errorRedirect: {errorStatus: 404, statusCode: 301, location: '/'} 

The above object can be passed to allow a server side redirect to the specified location based on the errorStatus.
errorStatus can be a number, string, or array of number/string, and will default to 404
statusCode can be a number/string for the reroute status code; i.e. 301, 302, and will default to 301
location will be a string with the path to redirect to, and will default to '/'



### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
