### PR TITLE
changed handle_error and index segments

### DIFF
--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -145,7 +145,7 @@ export function handle_error(url: URL) {
 			},
 			component: ErrorComponent
 		},
-		segments: preloaded
+		segments: ['_error']
 
 	}
 	const query = extract_query(search);
@@ -274,7 +274,8 @@ export async function hydrate_target(target: Target): Promise<{
 	branch?: Array<{ Component: ComponentConstructor, preload: (page) => Promise<any>, segment: string }>;
 }> {
 	const { route, page } = target;
-	const segments = page.path.split('/').filter(Boolean);
+	const segments = page.path === '/' ? ['index'] : page.path.split('/').filter(Boolean);
+	
 
 	let redirect: Redirect = null;
 


### PR DESCRIPTION
Right now, the 'segment' prop that is passed to `_layout.svelte` will be undefined for both the index page, and for the error handling page. This will change the segments to `['index']` and `['_error']` respectively. Being able to differentiate between the two pages in the `segment` prop will allow the designer greater control over determining how the page is displayed, such as changing the Nav appearance based upon the segment sent.



### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
