### PR TITLE
Add documentation for now v2 deployment

### DIFF
--- a/site/content/docs/11-deploying.md
+++ b/site/content/docs/11-deploying.md
@@ -7,9 +7,55 @@ Sapper apps run anywhere that supports Node 8 or higher.
 
 ### Deploying to Now
 
-> This section relates to Now 1, not Now 2
+We can very easily deploy our apps to [Now][https://zeit.co/dashboard]:
 
-We can very easily deploy our apps to [Now][]:
+#### Using Now v2 (recommended)
+
+We can use the [now-sapper loader](https://www.npmjs.com/package/now-sapper) to deploy our project and start the runtime.
+
+To do so, we will need set up our environment to work with `now`.  
+We do this by adding a `now.json` file to our project that specifies our loader and scripts to use. (`build` and `start` for runtime)
+
+```json
+{
+  "version": 2,
+    "builds": [
+    { "src": "package.json", "use": "now-sapper" }
+  ],
+}
+```
+
+We should also ignore some files using the `.nowignore`
+
+```
+__sapper__
+cypress
+node_modules
+```
+
+Lastly, but definitely no less important we will need to export our runtime environment in our `server.js`
+
+replace
+
+```js
+polka().use( //same with Express
+	[...]
+)
+```
+
+with
+```js
+const app = polka().use( //same with Express
+	[...]
+)
+
+export default app.handler // Remove .handler when using Express
+```
+
+
+#### Using Now v1 (deprecated)
+
+> This section relates to Now 1, not Now 2
 
 ```bash
 npm install -g now

--- a/site/content/docs/11-deploying.md
+++ b/site/content/docs/11-deploying.md
@@ -51,7 +51,7 @@ const app = polka() //same with Express
     [...]
   )
 
-export default app.handler // Remove .handler when using Express
+export default app
 ```
 
 

--- a/site/content/docs/11-deploying.md
+++ b/site/content/docs/11-deploying.md
@@ -46,7 +46,7 @@ polka() //same with Express
 
 with
 ```js
-const app = polka //same with Express
+const app = polka() //same with Express
   .use(
     [...]
   )

--- a/site/content/docs/11-deploying.md
+++ b/site/content/docs/11-deploying.md
@@ -38,16 +38,18 @@ Lastly, but definitely no less important we will need to export our runtime envi
 replace
 
 ```js
-polka().use( //same with Express
-	[...]
-)
+polka() //same with Express
+  .use(
+    [...]
+  )
 ```
 
 with
 ```js
-const app = polka().use( //same with Express
-	[...]
-)
+const app = polka //same with Express
+  .use(
+    [...]
+  )
 
 export default app.handler // Remove .handler when using Express
 ```

--- a/site/content/docs/11-deploying.md
+++ b/site/content/docs/11-deploying.md
@@ -7,7 +7,7 @@ Sapper apps run anywhere that supports Node 8 or higher.
 
 ### Deploying to Now
 
-We can very easily deploy our apps to [Now][https://zeit.co/dashboard]:
+We can very easily deploy our apps to [Now]:
 
 #### Using Now v2 (recommended)
 
@@ -73,7 +73,7 @@ For other hosting environments, you may need to do `npm run build` yourself.
 Sapper makes the Service Worker file (`service-worker.js`) unique by including a timestamp in the source code
 (calculated using `Date.now()`).
 
-In environments where the app is deployed to multiple servers (such as [Now][]), it is advisable to use a
+In environments where the app is deployed to multiple servers (such as [Now]), it is advisable to use a
 consistent timestamp for all deployments. Otherwise, users may run into issues where the Service Worker
 updates unexpectedly because the app hits server 1, then server 2, and they have slightly different timestamps.
 
@@ -103,7 +103,7 @@ Then you can set it using the environment variable, e.g.:
 SAPPER_TIMESTAMP=$(date +%s%3N) npm run build
 ```
 
-When deploying to [Now][], you can pass the environment variable into Now itself:
+When deploying to [Now], you can pass the environment variable into Now itself:
 
 ```bash
 now -e SAPPER_TIMESTAMP=$(date +%s%3N)


### PR DESCRIPTION
V1 is now offically deprecated and can no longer be used in new projects.
Add new documentation for V2

### Before submitting the PR, please make sure you do the following
- [X] Related to https://github.com/sveltejs/sapper-template/issues/102
- [X] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [X] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [X] Run the tests tests with `npm test` or `yarn test`)
