### PR TITLE
handleServerErrors parameter for sapper.middleware

### DIFF
--- a/runtime/src/server/middleware/get_server_route_handler.ts
+++ b/runtime/src/server/middleware/get_server_route_handler.ts
@@ -1,6 +1,6 @@
 import { Req, Res, ServerRoute } from './types';
 
-export function get_server_route_handler(routes: ServerRoute[], handleServerErrors: boolean) {
+export function get_server_route_handler(routes: ServerRoute[], handleServerErrors?: boolean) {
 	async function handle_route(route: ServerRoute, req: Req, res: Res, next: () => void) {
 		req.params = route.params(route.pattern.exec(req.path));
 

--- a/runtime/src/server/middleware/get_server_route_handler.ts
+++ b/runtime/src/server/middleware/get_server_route_handler.ts
@@ -1,6 +1,6 @@
 import { Req, Res, ServerRoute } from './types';
 
-export function get_server_route_handler(routes: ServerRoute[]) {
+export function get_server_route_handler(routes: ServerRoute[], handleServerErrors: boolean) {
 	async function handle_route(route: ServerRoute, req: Req, res: Res, next: () => void) {
 		req.params = route.params(route.pattern.exec(req.path));
 
@@ -43,11 +43,11 @@ export function get_server_route_handler(routes: ServerRoute[]) {
 			}
 
 			const handle_next = (err?: Error) => {
-				if (err) {
+				if (err && !handleServerErrors) {
 					res.statusCode = 500;
 					res.end(err.message);
 				} else {
-					process.nextTick(next);
+					process.nextTick(() => next(err));
 				}
 			};
 

--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -8,7 +8,8 @@ import { lookup } from './mime';
 
 export default function middleware(opts: {
 	session?: (req: Req, res: Res) => any,
-	ignore?: any
+	ignore?: any,
+	handleServerErrors?: boolean
 } = {}) {
 	const { session, ignore } = opts;
 
@@ -59,7 +60,7 @@ export default function middleware(opts: {
 			cache_control: dev ? 'no-cache' : 'max-age=31536000, immutable'
 		}),
 
-		get_server_route_handler(manifest.server_routes),
+		get_server_route_handler(manifest.server_routes, handleServerErrors),
 
 		get_page_handler(manifest, session || noop)
 	].filter(Boolean));


### PR DESCRIPTION

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)

Issue: https://github.com/sveltejs/sapper/issues/993

Sapper's server errors need to pass through to my server's error handler middleware instead of immediately responding with a 500.
