### PR TITLE
Recogonize typescript configuration files for webpack and rollup

### DIFF
--- a/src/api/utils/validate_bundler.ts
+++ b/src/api/utils/validate_bundler.ts
@@ -12,7 +12,7 @@ export default function validate_bundler(bundler?: 'rollup' | 'webpack') {
 			deprecate_dir('rollup');
 			deprecate_dir('webpack');
 
-			throw new Error(`Could not find a configuration file for rollup, neither webpack`);
+			throw new Error(`Could not find a configuration file for rollup or webpack`);
 		}
 	}
 

--- a/src/api/utils/validate_bundler.ts
+++ b/src/api/utils/validate_bundler.ts
@@ -3,9 +3,8 @@ import * as fs from 'fs';
 export default function validate_bundler(bundler?: 'rollup' | 'webpack') {
 	if (!bundler) {
 		bundler = (
-			fs.existsSync('rollup.config.js') ? 'rollup' :
-			fs.existsSync('webpack.config.js') ? 'webpack' :
-			null
+			fs.existsSync('rollup.config.js') || fs.existsSync('rollup.config.ts') ? 'rollup' :
+			fs.existsSync('webpack.config.js') || fs.existsSync('webpack.config.ts') ? 'webpack' : null
 		);
 
 		if (!bundler) {
@@ -13,7 +12,7 @@ export default function validate_bundler(bundler?: 'rollup' | 'webpack') {
 			deprecate_dir('rollup');
 			deprecate_dir('webpack');
 
-			throw new Error(`Could not find rollup.config.js or webpack.config.js`);
+			throw new Error(`Could not find a configuration file for rollup, neither webpack`);
 		}
 	}
 


### PR DESCRIPTION
### Description
Enable the recognition of `rollup.config.ts` and `webpack.config.ts` as valid bundler configuration files

### Issues
Actually, it's not possible to make use of the type-checking features of typescript for neither rollup or webpack configuration files

### Changes
- Added an extra condition on both lines 6 and 7 of `validate_bundler.ts`, looking for the typescript configuration files for rollup (`rollup.config.ts`) and webpack (`webpack.config.ts`)

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
