### PR TITLE
Update 10-exporting.md with a note on --entry

### DIFF
--- a/site/content/docs/10-exporting.md
+++ b/site/content/docs/10-exporting.md
@@ -44,7 +44,7 @@ You can also add a script to your package.json...
 
 When you run `sapper export`, Sapper first builds a production version of your app, as though you had run `sapper build`, and copies the contents of your `static` folder to the destination. It then starts the server, and navigates to the root of your app. From there, it follows any `<a>` elements it finds, and captures any data served by the app.
 
-Because of this, any pages you want to be included in the exported site must be reachable by `<a>` elements. Additionally, any non-page routes should be requested in `preload`, *not* in `onMount` or elsewhere.
+Because of this, any pages you want to be included in the exported site must either be reachable by `<a>` elements or added to the `--entry` option of the `sapper export` command. Additionally, any non-page routes should be requested in `preload`, *not* in `onMount` or elsewhere.
 
 
 ### When not to export


### PR DESCRIPTION
I have pages whose only links are inside a settings menu normally hidden with an <#if> statement, but I can still export using `sapper export --entry="/ /about"`. Docs are currently misleading on this point.