### PR TITLE
site: add script to deploy to gh-pages

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -5,9 +5,7 @@
   "scripts": {
     "dev": "sapper dev",
     "export": "sapper export --legacy",
-    "stage": "netlify deploy --dir=__sapper__/export",
-    "deploy": "netlify deploy --dir=__sapper__/export --prod",
-    "prestage": "npm run export",
+    "deploy": "./scripts/deploy.sh",
     "predeploy": "npm run export",
     "cy:run": "cypress run",
     "cy:open": "cypress open",

--- a/site/scripts/deploy.sh
+++ b/site/scripts/deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+HEAD=$(git symbolic-ref HEAD)
+git symbolic-ref HEAD refs/heads/gh-pages
+git reset $HEAD
+git rm --cached -rf ..
+cd __sapper__/export
+find -type f | cut -c 3- | xargs -I '{}' sh -c 'git update-index --add --cacheinfo 100644,$(git hash-object -w "{}"),"{}"'
+git commit -m '[build site]'
+git symbolic-ref HEAD $HEAD
+git reset
+git push -f origin gh-pages

--- a/site/static/CNAME
+++ b/site/static/CNAME
@@ -1,0 +1,1 @@
+sapper.svelte.dev


### PR DESCRIPTION
This updates `npm run deploy` to call a new script which commits the contents of the `site/__sapper__/export` directory (moved to the root of the repo) as the gh-pages branch (off of the current HEAD) and pushes it to origin.

This plus updating DNS to point to sveltejs.github.io should be all that's needed to move the site to GitHub pages.