### PR TITLE
Make path_to_routes absolute instead of relative

### DIFF
--- a/src/core/create_app.ts
+++ b/src/core/create_app.ts
@@ -26,7 +26,7 @@ export function create_app({
 }) {
 	if (!fs.existsSync(output)) fs.mkdirSync(output);
 
-	const path_to_routes = path.relative(`${output}/internal`, routes);
+	const path_to_routes = routes;
 
 	const client_manifest = generate_client_manifest(manifest_data, path_to_routes, bundler, dev, dev_port);
 	const server_manifest = generate_server_manifest(manifest_data, path_to_routes, cwd, src, dest, dev);


### PR DESCRIPTION
This is a tiny change, but solves an issue that crops up in rare cases where sapper is being used as a library symbolically linked to from or within another project.  

(Without getting into too boring details - the problem arose in my case where sapper lives in its own directory, say, /usr/local/sapper, and is being symbolically linked to another project, where it lives as /project/lib/sapper.  So sapper has effectively two homes because of the symlink and the relative `path_to_routes` was causing a failure when one project tried to locate a file that's in a different path tree.)

Since `routes` is a fully-resolved path anyway, there's no apparent benefit to creating the relative `path_to_routes`.  I dug back into the original commits and this appears to be a carryover from before `routes` was given an absolute path.  Now that it has one, `path_to_routes` is unnecessary.

Tests are all passing.  I'm happy to eliminate `path_to_routes` entirely if that's preferred, but there's a minor naming collision with `routes` defined in `generate_client_manifest`, and rather than muck about in more places, I chose this simpler approach.