### PR TITLE
Added "any" method and fixed `res.write()`

### DIFF
--- a/runtime/src/server/middleware/get_server_route_handler.ts
+++ b/runtime/src/server/middleware/get_server_route_handler.ts
@@ -8,7 +8,7 @@ export function get_server_route_handler(routes: ServerRoute[]) {
 		// 'delete' cannot be exported from a module because it is a keyword,
 		// so check for 'del' instead
 		const method_export = method === 'delete' ? 'del' : method;
-		const handle_method = route.handlers[method_export];
+		const handle_method = route.handlers[method_export] || route.handlers.any;
 		if (handle_method) {
 			if (process.env.SAPPER_EXPORT) {
 				const { write, end, setHeader } = res;
@@ -18,7 +18,7 @@ export function get_server_route_handler(routes: ServerRoute[]) {
 				// intercept data so that it can be exported
 				res.write = function(chunk: any) {
 					chunks.push(Buffer.from(chunk));
-					write.apply(res, arguments);
+					return write.apply(res, arguments);
 				};
 
 				res.setHeader = function(name: string, value: string) {


### PR DESCRIPTION
1. Added "any" field
Many web frameworks allowing you to match all HTTP methods.
https://expressjs.com/en/4x/api.html#app.all for example.

2. See https://nodejs.org/api/http.html#http_response_write_chunk_encoding_callback
`res.write()` must return boolean, but it doesn't because data got intercepted.



### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
