### PR TITLE
Export: Use newly obtained unused port in forked process

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -91,11 +91,14 @@ async function _export({
 
 	const proc = child_process.fork(path.resolve(`${build_dir}/server/server.js`), [], {
 		cwd,
-		env: Object.assign({
-			PORT: port,
-			NODE_ENV: 'production',
-			SAPPER_EXPORT: 'true'
-		}, process.env)
+		env: { 
+			...process.env,
+			...{
+				PORT: port,
+				NODE_ENV: 'production',
+				SAPPER_EXPORT: 'true'
+			}
+		}
 	});
 
 	const seen = new Set();


### PR DESCRIPTION
I think i might have found a bug (or, maybe, this is just not supported?) with programmatic usage of the export functionality.

If i'm not mistaken, Object.assign() with that parameter order does not actually provide the newly obtained unused port (in case there's already one set in `process.env` at that time) to the forked process.

I'm trying to programatically trigger exports (of specific/individual pages) from within the sapper app itself & this seems to prevent the export from working (while the sapper app itself is running).

Before the change, this is the error (a `console.log(process.env.PORT)` in `/src/server.js` confirms that the port is indeed not changed within the forked process):

```
Error: listen EADDRINUSE: address already in use :::3000
    at Server.setupListenHandle [as _listen2] (net.js:1306:16)
    at listenInCluster (net.js:1354:12)
    at Server.listen (net.js:1442:7)
    at Polka.listen (/Users/[..]./Projects/[...]/frontend/node_modules/polka/build.js:59:22)
    at Object.<anonymous> (/Users/[...]/Projects/[...]/frontend/__sapper__/static/server/server.js:10832:8)
    at Module._compile (internal/modules/cjs/loader.js:955:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:991:10)
    at Module.load (internal/modules/cjs/loader.js:811:32)
    at Function.Module._load (internal/modules/cjs/loader.js:723:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1043:10)
Emitted 'error' event on Server instance at:
    at emitErrorNT (net.js:1333:8)
    at processTicksAndRejections (internal/process/task_queues.js:81:21) {
  code: 'EADDRINUSE',
  errno: 'EADDRINUSE',
  syscall: 'listen',
  address: '::',
  port: 3000
}
```

With the proposed change, the export works (and the `console.log(process.env.PORT)` in `/src/server.js` confirms that the port is changed within the forked process).

I have not found a correlating existing issue, thus this PR.

Test output is the same without and with this change: 

```
sapper@0.27.9 test /Users/[...]/Projects/temp/sapper-fork
> mocha --opts mocha.opts

  clean_html
    ✓ removes-cdata
    ✓ removes-comments
    ✓ removes-script-contents

  manifest_data
    ✓ creates routes
    ✓ encodes invalid characters
    ✓ allows regex qualifiers
    ✓ sorts routes correctly
    ✓ ignores files and directories with leading underscores
    ✓ ignores files and directories with leading dots except .well-known
    ✓ fails on clashes
    ✓ fails if dynamic params are not separated
    ✓ errors when trying to use reserved characters in route regexp
    ✓ ignores things that look like lockfiles
    ✓ works with custom extensions

  basics
    ✓ serves / (112ms)
    ✓ serves /?
    ✓ serves static route
    ✓ serves static route from dir/index.html file
    ✓ serves dynamic route
    ✓ navigates to a new page without reloading (161ms)
    ✓ navigates programmatically
    ✓ prefetches programmatically
    ✓ sets Content-Type, Link...modulepreload, and Cache-Control headers
    ✓ calls a delete handler (77ms)
    ✓ hydrates initial route
    ✓ does not attempt client-side navigation to server routes (101ms)
    ✓ allows reserved words as route names
    ✓ accepts value-less query string parameter on server
    ✓ accepts value-less query string parameter on client (125ms)
    ✓ accepts duplicated query string parameter on server
    ✓ accepts duplicated query string parameter on client (82ms)
    ✓ can access host through page store
    ✓ resets the active element after navigation (126ms)
    ✓ replaces %sapper.xxx% tags safely
    ✓ navigates between routes with empty parts (92ms)
    ✓ navigates to ...rest (447ms)
    ✓ navigates between dynamic routes with same segments (112ms)
    ✓ find regexp routes (160ms)
    ✓ runs server route handlers before page handlers, if they match
    ✓ invalidates page when a segment is skipped (116ms)
    ✓ survives the tests with no server errors

  credentials
    ✓ sends cookies when using this.fetch with credentials: "include" (69ms)
    ✓ does not send cookies when using this.fetch without credentials
    ✓ delegates to fetch on the client (131ms)
    ✓ survives the tests with no server errors

  css
    ✓ includes critical CSS with server render (60ms)
    ✓ loads CSS when navigating client-side (117ms)
    ✓ loads CSS for a lazily-rendered component (105ms)
    ✓ survives the tests with no server errors

  custom extensions
    ✓ works with arbitrary extensions (62ms)
    ✓ works with other arbitrary extensions (62ms)

  encoding
    ✓ encodes routes (68ms)
    ✓ encodes req.params and req.query for server-rendered pages
    ✓ encodes req.params and req.query for client-rendered pages (148ms)
    ✓ encodes req.params for server routes
    ✓ survives the tests with no server errors

  errors
    ✓ handles missing route on server (62ms)
    ✓ handles missing route on client (117ms)
    ✓ handles explicit 4xx on server
    ✓ handles explicit 4xx on client (92ms)
    ✓ handles error on server
    ✓ handles error on client (91ms)
    ✓ does not serve error page for explicit non-page errors
Error: oops
    at get$1 (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:23:8)
    at handle_route (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:450:11)
    at Array.find_route (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:464:5)
    at nth_handler (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:2967:14)
    at /Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:2967:31
    at Array.<anonymous> (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:3017:4)
    at nth_handler (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:2967:14)
    at /Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:2967:31
    at Array.<anonymous> (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:3017:4)
    at nth_handler (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:2967:14)
    ✓ does not serve error page for thrown non-page errors
    ✓ execute error page hooks
Error: oops
    at get (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:15:25)
    at handle_route (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:450:11)
    at Array.find_route (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:464:5)
    at nth_handler (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:2967:14)
    at /Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:2967:31
    at Array.<anonymous> (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:3017:4)
    at nth_handler (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:2967:14)
    at /Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:2967:31
    at Array.<anonymous> (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:3017:4)
    at nth_handler (/Users/[...]/Projects/temp/sapper-fork/test/apps/errors/__sapper__/build/server/server.js:2967:14)
    ✓ does not serve error page for async non-page error
    ✓ clears props.error on successful render (159ms)
    ✓ survives the tests with no server errors

  export multiple entrypoints
    ✓ crawls a site when given unlinked entrypoints

  export-queue
    ✓ exports a site with inconsistent load time (197ms)

  export-webpack
    ✓ injects <link rel=preload> tags

  export
    ✓ crawls a site
    ✓ does not corrupt binary file links (like pdf)

  ignore
    ✓ respects `options.ignore` values (RegExp) (73ms)
    ✓ respects `options.ignore` values (String #1)
    ✓ respects `options.ignore` values (String #2)
    ✓ respects `options.ignore` values (Function)
    ✓ survives the tests with no server errors

  layout
    ✓ only recreates components when necessary (221ms)
    ✓ survives the tests with no server errors

  preloading
    ✓ serializes Set objects returned from preload (74ms)
    ✓ retrieves host from preload
    ✓ prevent crash if preload return nothing
    ✓ bails on custom classes returned from preload
    ✓ sets preloading true when appropriate (108ms)
    ✓ runs preload in root component
    ✓ cancels navigation if subsequent navigation occurs during preload (163ms)
    ✓ navigates to prefetched urls (364ms)
    ✓ survives the tests with no server errors
    ✓ re-runs preload when page.query changes (103ms)

  redirects
    ✓ redirects on server (69ms)
    ✓ redirects in client (118ms)
    ✓ redirects to root on server
    ✓ redirects to root in client (88ms)
    ✓ redirects to external URL on server (117ms)
    ✓ redirects to external URL in client (204ms)
    ✓ survives the tests with no server errors

  scroll
    ✓ scrolls to active deeplink (68ms)
    ✓ scrolls to any deeplink if it was already active
    ✓ resets scroll when a link is clicked (93ms)
    ✓ preserves scroll when a link with sapper-noscroll is clicked (101ms)
    ✓ scrolls into a deeplink on a new page (101ms)
    ✓ survives the tests with no server errors

  session
    ✓ renders session props (145ms)
    ✓ preloads session props (47ms)
    ✓ survives the tests with no server errors

  with-basepath
    ✓ serves /custom-basepath (60ms)
    ✓ emits a basepath message
    ✓ crawls an exported site with basepath
    ✓ redirects on server
    ✓ redirects in client (123ms)
    ✓ survives the tests with no server errors

  with-sourcemaps-webpack
    ✓ does not put sourcemap files in service worker shell

  with-sourcemaps
    ✓ does not put sourcemap files in service worker shell

  114 passing (20s)
```

Thanks & let me know if there's a need for tests around this & (optimally) how to start with those (just beginning to grok this fantastic project).

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
