### PR TITLE
Set scrollRestoration to auto for page refresh

### DIFF
--- a/runtime/src/app/start/index.ts
+++ b/runtime/src/app/start/index.ts
@@ -20,6 +20,19 @@ export default function start(opts: {
 	if ('scrollRestoration' in history) {
 		history.scrollRestoration = 'manual';
 	}
+	
+	// Adopted from Nuxt.js
+	// Reset scrollRestoration to auto when leaving page, allowing page reload
+	// and back-navigation from other pages to use the browser to restore the
+	// scrolling position.
+	addEventListener('beforeunload', () => {
+		history.scrollRestoration = 'auto';
+	});
+
+	// Setting scrollRestoration to manual again when returning to this page.
+	addEventListener('load', () => {
+		history.scrollRestoration = 'manual';
+	});
 
 	set_target(opts.target);
 


### PR DESCRIPTION
After manual or automatic (editing styles) refresh the page always jumps to the top. When styling a long website it adds a lot of scrolling to see changes.

I've copied potential solution from Nuxt.js repo.

Reference issue: https://github.com/sveltejs/sapper/issues/784