### PR TITLE
move %sapper.scripts% to <head> with defer

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -289,7 +289,7 @@ export function get_page_handler(
 					script += `var s=document.createElement("script");try{new Function("if(0)import('')")();s.src="${main}";s.type="module";s.crossOrigin="use-credentials";}catch(e){s.src="${req.baseUrl}/client/shimport@${build_info.shimport}.js";s.setAttribute("data-main","${main}")}document.head.appendChild(s)`;
 				}
 			} else {
-				script += `</script><script src="${main}">`;
+				script += `</script><script src="${main}" defer>`;
 			}
 
 			let styles: string;

--- a/site/src/template.html
+++ b/site/src/template.html
@@ -38,15 +38,14 @@
 	<!-- This contains the contents of the <svelte:head> component, if
 	     the current page has one -->
 	%sapper.head%
+	<!-- Sapper creates a <script> tag containing `app/client.js`
+			 and anything else it needs to hydrate the app and
+			 initialise the router -->
+	%sapper.scripts%
 </head>
 <body>
 	<!-- The application will be rendered inside this element,
 	     because `app/client.js` references it -->
 	<div id='sapper'>%sapper.html%</div>
-
-	<!-- Sapper creates a <script> tag containing `app/client.js`
-	     and anything else it needs to hydrate the app and
-	     initialise the router -->
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/basics/src/template.html
+++ b/test/apps/basics/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/credentials/src/template.html
+++ b/test/apps/credentials/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/css/src/template.html
+++ b/test/apps/css/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/custom-extension/src/template.html
+++ b/test/apps/custom-extension/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/encoding/src/template.html
+++ b/test/apps/encoding/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/errors/src/template.html
+++ b/test/apps/errors/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/export-multiple-entry/src/template.html
+++ b/test/apps/export-multiple-entry/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/export-queue/src/template.html
+++ b/test/apps/export-queue/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/export-webpack/src/template.html
+++ b/test/apps/export-webpack/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/export/src/template.html
+++ b/test/apps/export/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/ignore/src/template.html
+++ b/test/apps/ignore/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/layout/src/template.html
+++ b/test/apps/layout/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/preloading/src/template.html
+++ b/test/apps/preloading/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/redirects/src/template.html
+++ b/test/apps/redirects/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/scroll/src/template.html
+++ b/test/apps/scroll/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/session/src/template.html
+++ b/test/apps/session/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/with-basepath/src/template.html
+++ b/test/apps/with-basepath/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/with-sourcemaps-webpack/src/template.html
+++ b/test/apps/with-sourcemaps-webpack/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/with-sourcemaps/src/template.html
+++ b/test/apps/with-sourcemaps/src/template.html
@@ -6,9 +6,9 @@
 	%sapper.base%
 	%sapper.styles%
 	%sapper.head%
+	%sapper.scripts%
 </head>
 <body>
 	<div id='sapper'>%sapper.html%</div>
-	%sapper.scripts%
 </body>
 </html>


### PR DESCRIPTION
This PR moves `%sapper.scripts%` to `<head>` with `defer` attribute for the main script.

[Some parts of the inserted scripts](https://github.com/sveltejs/sapper/blob/master/runtime/src/server/middleware/get_page_handler.ts#L270-L290) are inlined, in particular when using Rollup as the bundler.

Inline scripts are not affected by `defer`. 

But it seems in this case the inline scripts mainly import the main script dynamically,  thus it should be executed asynchronously.

Fixes #1121 
