### PR TITLE
Fix missing wasm mime-type. Issue #1136

### DIFF
--- a/runtime/src/server/middleware/mime-types.md
+++ b/runtime/src/server/middleware/mime-types.md
@@ -464,6 +464,7 @@ application/vnd.yellowriver-custom-menu		cmp
 application/vnd.zul				zir zirz
 application/vnd.zzazz.deck+xml			zaz
 application/voicexml+xml			vxml
+application/wasm  				wasm
 application/widget				wgt
 application/winhlp				hlp
 application/wsdl+xml				wsdl


### PR DESCRIPTION
Mime-types.md is missing the wasm file type, which ends up with 404 not found error, when importing wasm modules. This pull request adds mime-type for .wasm files and solves issue #1136 