### PR TITLE
Fix deeplinks no matter previous scroll position

### DIFF
--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -200,7 +200,7 @@ export async function navigate(target: Target, id: number, noscroll?: boolean, h
 			if (deep_linked) {
 				scroll = {
 					x: 0,
-					y: deep_linked.getBoundingClientRect().top
+					y: deep_linked.getBoundingClientRect().top + scrollY
 				};
 			}
 		}

--- a/test/apps/scroll/src/routes/a-third-tall-page.svelte
+++ b/test/apps/scroll/src/routes/a-third-tall-page.svelte
@@ -1,0 +1,5 @@
+<h1>A third tall page</h1>
+
+<a href="tall-page#foo" id="top">link</a>
+<div style="height: 9999px"></div>
+<a href="tall-page#foo" id="bottom">link</a>

--- a/test/apps/scroll/test.ts
+++ b/test/apps/scroll/test.ts
@@ -81,6 +81,26 @@ describe('scroll', function() {
 		assert.ok(scrollY > 0);
 	});
 
+	it('scrolls to a deeplink on a new page no matter the previous scroll position', async () => {
+		await r.load('/a-third-tall-page#top');
+		await r.sapper.start();
+		await r.sapper.prefetchRoutes();
+
+		await r.page.click('a#top');
+		await r.wait();
+		const firstScrollY = await r.page.evaluate(() => window.scrollY);
+
+		await r.load('/a-third-tall-page#bottom');
+		await r.sapper.start();
+		await r.sapper.prefetchRoutes();
+
+		await r.page.click('a#bottom');
+		await r.wait();
+		const secondScrollY = await r.page.evaluate(() => window.scrollY);
+
+		assert.equal(firstScrollY, secondScrollY);
+	});
+
 	it('survives the tests with no server errors', () => {
 		assert.deepEqual(r.errors, []);
 	});


### PR DESCRIPTION
Hello, and thanks for this awesome tool! I found what appears to be a bug in anchor deeplinks.

See a demo of the [broken behavior](https://arkanemoose.github.io/sapper-anchor-scroll-demo/broken/) and the [fixed behavior](https://arkanemoose.github.io/sapper-anchor-scroll-demo/fixed/).

![2020-04-01 12-39-05](https://user-images.githubusercontent.com/6319326/78163299-34abd380-7416-11ea-9ac8-e92d14f9049b.gif)

If you're scrolled down on one page, and you click a deeplink that goes to a different page, the scroll position on the new page is wrong. This might be what is being referred to in the "anchor linking" part of #784, but I'm not quite sure.

This broken behavior seems to be because of [this line](https://github.com/sveltejs/sapper/blob/5e2c68606124a7c4407250c2889a7e23cf2c3d73/runtime/src/app/app.ts#L203) which computes the new scroll position according to the `getBoundingClientRect().top` of the deeplinked element. [According to MDN,](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) this value is relative to the top-left of the viewport, so if you want a position that is relative to the top-left of the document, you need to add the value of `window.scrollY`.

This PR implements that, and it also adds a test that verifies that the behavior is broken prior to this PR and fixed afterwards.

Let me know if there's anything you'd like me to change. Thanks!