### PR TITLE
Reset layout inheritance if there is a _reset.svelte in the directory.

### DIFF
--- a/site/content/docs/05-layouts.md
+++ b/site/content/docs/05-layouts.md
@@ -84,3 +84,5 @@ Layout components receive a `segment` property which is useful for things like s
 +	>Notifications</a>
 </div>
 ```
+
+If in some cases you would like to disable layout inheritance - you can place a file called `_reset.svelte` in the folder. In this case only root layout will be applied.

--- a/src/core/create_manifest_data.ts
+++ b/src/core/create_manifest_data.ts
@@ -145,6 +145,7 @@ export default function create_manifest_data(cwd: string, extensions: string = '
 
 			if (item.is_dir) {
 				const component = find_layout('_layout', `${get_slug(item.file)}__layout`, item.file);
+				const reset = find_layout('_reset', null, item.file);
 
 				if (component) components.push(component);
 
@@ -152,9 +153,7 @@ export default function create_manifest_data(cwd: string, extensions: string = '
 					path.join(dir, item.basename),
 					segments,
 					params,
-					component
-						? stack.concat({ component, params })
-						: stack.concat(null)
+					(reset ? [] : stack).concat(component ? { component, params } : null)
 				);
 			}
 


### PR DESCRIPTION
Sometimes it is necessary to stop layout inheritance as web page has a different layout but logically needs to be inside this route path.

Example: 
/[product]/[model] - Product page
/[produc]/[model]/zoom - Fullscreen page to view the product

According to the discussion in this thread #823  the feature is needed. I do agree with others that the best way would be to put a _reset.svelte file in the folder for which we need to ignore parent layouts.