### PR TITLE
user template replaces proposal

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -317,9 +317,6 @@ export function get_page_handler(
 				styles = (css && css.code ? `<style>${css.code}</style>` : '');
 			}
 
-			// users can set a CSP nonce using res.locals.nonce
-			const nonce_attr = (res.locals && res.locals.nonce) ? ` nonce="${res.locals.nonce}"` : '';
-
 			let replacers: PageContentReducer[] = res.replacers || [];
 			replacers = replacers.concat([
 				(ctx) => (ctx.body = ctx.body.replace('%sapper.base%', `<base href="${ctx.baseUrl}/">`), ctx),
@@ -335,7 +332,8 @@ export function get_page_handler(
 					baseUrl: req.baseUrl,
 					head,
 					html,
-					nonce_attr,
+					// users can set a CSP nonce using res.locals.nonce
+					nonceAttr: (res.locals && res.locals.nonce) ? ` nonce="${res.locals.nonce}"` : '',
 					script,
 					styles
 				}

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -319,11 +319,11 @@ export function get_page_handler(
 
 			let replacers: PageContentReducer[] = res.replacers || [];
 			replacers = replacers.concat([
-				(ctx) => (ctx.body = ctx.body.replace('%sapper.base%', `<base href="${ctx.baseUrl}/">`), ctx),
-				(ctx) => (ctx.body = ctx.body.replace('%sapper.head%', `<noscript id='sapper-head-start'></noscript>${ctx.head}<noscript id='sapper-head-end'></noscript>`), ctx),
-				(ctx) => (ctx.body = ctx.body.replace('%sapper.styles%', ctx.styles), ctx),
-				(ctx) => (ctx.body = ctx.body.replace('%sapper.html%', ctx.html), ctx),
-				(ctx) => (ctx.body = ctx.body.replace('%sapper.scripts%', `<script${ctx.nonce_attr}>${ctx.script}</script>`), ctx),
+				(ctx) => (ctx.body = ctx.body.replace('%sapper.base%', () => `<base href="${ctx.baseUrl}/">`), ctx),
+				(ctx) => (ctx.body = ctx.body.replace('%sapper.head%', () => `<noscript id='sapper-head-start'></noscript>${ctx.head}<noscript id='sapper-head-end'></noscript>`), ctx),
+				(ctx) => (ctx.body = ctx.body.replace('%sapper.styles%', () => ctx.styles), ctx),
+				(ctx) => (ctx.body = ctx.body.replace('%sapper.html%', () => ctx.html), ctx),
+				(ctx) => (ctx.body = ctx.body.replace('%sapper.scripts%', () => `<script${ctx.nonceAttr}>${ctx.script}</script>`), ctx),
 			]);
 
 			const pageContent = replacers.reduce((ctx: PageContent, replace: PageContentReducer) => replace(ctx),

--- a/runtime/src/server/middleware/types.ts
+++ b/runtime/src/server/middleware/types.ts
@@ -68,7 +68,7 @@ export interface PageContent {
 	head: string,
 	styles: string,
 	html: string,
-	nonce_attr: string,
+	nonceAttr: string,
 	script: string,
 }
 

--- a/runtime/src/server/middleware/types.ts
+++ b/runtime/src/server/middleware/types.ts
@@ -62,14 +62,4 @@ interface Component {
 	}
 }
 
-export interface PageContent {
-	body: string,
-	baseUrl: string,
-	head: string,
-	styles: string,
-	html: string,
-	nonceAttr: string,
-	script: string,
-}
-
-export type PageContentReducer = (context: PageContent) => PageContent;
+export type TemplateReducer = (body: string) => string;

--- a/runtime/src/server/middleware/types.ts
+++ b/runtime/src/server/middleware/types.ts
@@ -61,3 +61,15 @@ interface Component {
 		html: string
 	}
 }
+
+export interface PageContent {
+	body: string,
+	baseUrl: string,
+	head: string,
+	styles: string,
+	html: string,
+	nonce_attr: string,
+	script: string,
+}
+
+export type PageContentReducer = (context: PageContent) => PageContent;

--- a/test/apps/basics/src/server.js
+++ b/test/apps/basics/src/server.js
@@ -4,6 +4,17 @@ import * as sapper from '@sapper/server';
 import { start } from '../../common.js';
 
 const app = polka()
+	.use((req, res, next) => {
+		if (req.headers['disable-js'] === 'true') {
+			res.replacers = [doNotInsertScript]
+		}
+		next()
+	})
 	.use(sapper.middleware())
 
 start(app);
+
+function doNotInsertScript (ctx) {
+	ctx.body = ctx.body.replace('%sapper.scripts%', '');
+	return ctx;
+}

--- a/test/apps/basics/src/server.js
+++ b/test/apps/basics/src/server.js
@@ -6,15 +6,10 @@ import { start } from '../../common.js';
 const app = polka()
 	.use((req, res, next) => {
 		if (req.headers['disable-js'] === 'true') {
-			res.replacers = [doNotInsertScript]
+			res.replacers = [(body) => body.replace('%sapper.scripts%', '')]
 		}
 		next()
 	})
 	.use(sapper.middleware())
 
 start(app);
-
-function doNotInsertScript (ctx) {
-	ctx.body = ctx.body.replace('%sapper.scripts%', '');
-	return ctx;
-}

--- a/test/apps/basics/test.ts
+++ b/test/apps/basics/test.ts
@@ -271,6 +271,16 @@ describe('basics', function() {
 		assert.equal(html.indexOf('%sapper'), -1);
 	});
 
+	it('lets middleware control replacers', async () => {
+		const page = await get(`${r.base}/middleware`, {
+			headers: {
+				'disable-js': 'true'
+			}
+		});
+
+		assert.equal(page.body.indexOf('<script'), -1);
+	});
+
 	it('navigates between routes with empty parts', async () => {
 		await r.load('/dirs/foo');
 		await r.sapper.start();


### PR DESCRIPTION
This PR gives the user control after page render, but before `res.end`, so that the HTML output can be altered. This can be handy to:

- replace text in the body template
- omitting script when a header is set
- alter the base href to be absolute for certain user-agents
- etc.

Multiple issues falls into this category, "let user control HTML output", like #657, #984, #1034, #1036, #1066, etc.

Today this is possible to some degree, by monkey-patching `res.end(body)`, which is the last call in `handle_page`:

```js
function (req, res, next) {
    if (req.get('user-agent').toLowerCase().includes("msie")) {
        let resEnd = res.end;

        res.end = function () {
            let body = arguments[0]
            if (typeof body === "string") {
                // absolute base href
                let base = `<base href="${req.protocol}://${req.get('host')}${req.baseUrl}/">`
                body = body.replace(/<base href="[^"]+">/, base)
                // do not send scripts
                body = body.replace(/<script.*\/script>/g, '')

                arguments[0] = body
            }

            resEnd.call(this, ...arguments)
        }
    }

    next()
},
```

Though, that may get clunky depending on your middleware call order.

This proposal spins of @vilarfg's #1037, but also lets the user:

- replace anything (replacing is not bound to `%sapper.key%`)
- override system replacers (by replacing `%sapper.key%` first)

**Implementation**
Before responding with the page, replace text in the page body with "replacers". A "replacer" is a reducer (`TemplateReducer`) which is called with the template body and returns the body back.

Replacers are run in the order they are defined and system replacers will
run last: base href → head → styles → html → script.

**Examples**

Omit javascript for Internet Explorer:
```js
// handler before sapper middleware
(req, res, next) => {
	if (req.get('user-agent').toLowerCase().includes("msie")) {
		res.replacers = res.replacers || []
		// remove script from page content, return content back
		res.replacers.push((body) => body.replace("%sapper.scripts%", ""))
	}
	next()
}
```

Insert footer notice when unsupported browser:
```js
(req, res, next) => {
	// matchesUA: https://github.com/browserslist/browserslist-useragent
	if (!matchesUA(req.get('user-agent'))) {
		res.replacers = res.replacers || [];
		res.replacers.push((body) =>
			body.replace('</body>', `${unsupportedBrowserNotice}</body>`)
		);
	}
	next();
}
```