### PR TITLE
Support ES6 Modules in Sapper

### DIFF
--- a/src/core/create_compilers/index.ts
+++ b/src/core/create_compilers/index.ts
@@ -41,7 +41,7 @@ export default async function create_compilers(
 	}
 
 	if (bundler === 'webpack') {
-		const config = require(path.resolve(cwd, 'webpack.config.js'));
+		const { default: config } = await import('file:' + path.resolve(cwd, 'webpack.config.js'))
 		validate_config(config, 'webpack');
 
 		return {

--- a/src/core/create_compilers/index.ts
+++ b/src/core/create_compilers/index.ts
@@ -41,7 +41,7 @@ export default async function create_compilers(
 	}
 
 	if (bundler === 'webpack') {
-		const { default: config } = await import('file:' + path.resolve(cwd, 'webpack.config.js'))
+		const { default: config } = await import('file://' + path.resolve(cwd, 'webpack.config.js'))
 		validate_config(config, 'webpack');
 
 		return {


### PR DESCRIPTION
Not sure if this will break commons, but I believe it should not. 

One more note, the __sapper__ build directory should contain a `package.json` that contains
```json
{
   "type": "commonjs"
}
```



### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
