### PR TITLE
Add "Who is using Sapper" section to the website.

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -9,7 +9,8 @@
     "predeploy": "npm run export",
     "cy:run": "cypress run",
     "cy:open": "cypress open",
-    "test": "run-p --race dev cy:run"
+    "test": "run-p --race dev cy:run",
+    "update": "node scripts/update_whos_using.js"
   },
   "dependencies": {
     "@polka/send": "^0.4.0",
@@ -36,6 +37,7 @@
     "rollup-plugin-svelte": "^5.1.0",
     "rollup-plugin-terser": "^5.1.1",
     "sapper": "^0.27.8",
+    "shelljs": "^0.8.3",
     "svelte": "^3.10.1"
   }
 }

--- a/site/scripts/update_whos_using.js
+++ b/site/scripts/update_whos_using.js
@@ -10,3 +10,6 @@ sh.exec('npx degit sveltejs/community scripts/community');
 sh.cp('scripts/community/whos-using-sapper/WhosUsingSapper.svelte', 'src/routes/_components/WhosUsingSapper.svelte');
 sh.rm('-rf', 'static/organisations');
 sh.cp('-r', 'scripts/community/whos-using-sapper/organisations', 'static');
+
+// cleanup
+sh.rm('-rf', 'scripts/community');

--- a/site/scripts/update_whos_using.js
+++ b/site/scripts/update_whos_using.js
@@ -1,0 +1,12 @@
+const sh = require('shelljs');
+
+sh.cd(__dirname + '/../');
+
+// fetch community repo
+sh.rm('-rf','scripts/community');
+sh.exec('npx degit sveltejs/community scripts/community');
+
+// copy over relevant files
+sh.cp('scripts/community/whos-using-sapper/WhosUsingSapper.svelte', 'src/routes/_components/WhosUsingSapper.svelte');
+sh.rm('-rf', 'static/organisations');
+sh.cp('-r', 'scripts/community/whos-using-sapper/organisations', 'static');

--- a/site/src/routes/_components/WhosUsingSapper.svelte
+++ b/site/src/routes/_components/WhosUsingSapper.svelte
@@ -1,0 +1,49 @@
+<!--
+	Instructions for adding new logos:
+
+	* Fork this repo, and clone your fork
+	* Create a branch called e.g. `add-myorganisation-logo`
+	* Add the logo to the `organisations` directory (preferably SVG)
+	* Add a new <a> tag in this component, in alphabetical order
+	* Create a pull request. Thanks!
+-->
+
+<style>
+	.logos {
+		margin: 1em 0 0 0;
+		display: flex;
+		flex-wrap: wrap;
+	}
+
+	a {
+		height: 40px;
+		margin: 0 0.5em 0.5em 0;
+		display: flex;
+		align-items: center;
+		border: 2px solid var(--second);
+		padding: 5px 10px;
+		border-radius: 20px;
+		color: var(--text);
+	}
+
+	.add-yourself {
+		color: var(--prime);
+	}
+
+	picture,
+	img {
+		height: 100%;
+	}
+
+	@media (min-width: 540px) {
+		a {
+			height: 60px;
+			padding: 10px 20px;
+			border-radius: 30px;
+		}
+	}
+</style>
+
+<div class="logos">
+<a target="_blank" rel="noopener" href="https://github.com/sveltejs/community/blob/master/whos-using-sapper/WhosUsingSapper.svelte" class="add-yourself"><span>+ your company?</span></a>
+</div>

--- a/site/src/routes/index.svelte
+++ b/site/src/routes/index.svelte
@@ -1,5 +1,6 @@
 <script>
-	import { Hero, Blurb } from '@sveltejs/site-kit';
+	import { Hero, Blurb, Section } from '@sveltejs/site-kit';
+	import WhosUsingSapper from './_components/WhosUsingSapper.svelte';
 </script>
 
 <style>
@@ -62,3 +63,9 @@ npm run dev & open http://localhost:3000
 		<p class="cta"><a rel="prefetch" href="docs">Learn Sapper</a></p>
 	</div>
 </Blurb>
+
+<Section>
+	<h3>Who's using Sapper?</h3>
+
+	<WhosUsingSapper/>
+</Section>


### PR DESCRIPTION
This adds a _Who's using Sapper ?_ section to the website as proposed in https://github.com/sveltejs/sapper/issues/1113

The actual information is fetched from [svelte/community](https://github.com/sveltejs/community/tree/master/whos-using-sapper) which at the moment is empty, I think it would be better to add some sites there before merging this.


