### PR TITLE
remove cache-control header

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -54,7 +54,6 @@ export function get_page_handler(
 		 } = get_build_info();
 
 		res.setHeader('Content-Type', 'text/html');
-		res.setHeader('Cache-Control', dev ? 'no-cache' : 'max-age=600');
 
 		// preload main.js and current route
 		// TODO detect other stuff we can preload? images, CSS, fonts?

--- a/test/apps/basics/test.ts
+++ b/test/apps/basics/test.ts
@@ -126,17 +126,12 @@ describe('basics', function() {
 	});
 
 	// TODO equivalent test for a webpack app
-	it('sets Content-Type, Link...modulepreload, and Cache-Control headers', async () => {
+	it('sets Content-Type, Link...modulepreload', async () => {
 		const { headers } = await get(r.base);
 
 		assert.equal(
 			headers['content-type'],
 			'text/html'
-		);
-
-		assert.equal(
-			headers['cache-control'],
-			'max-age=600'
 		);
 
 		// TODO preload more than just the entry point


### PR DESCRIPTION
This PR resolves the [outstanding `maxage` header issue](https://github.com/sveltejs/sapper/issues/567). A fixed `maxage` header is not practical. There should be either a way to customize the maxage, or, more simple, the Sapper middleware shouldn't even set it at all.

The solution is to remove the `res.setHeader('Cache-Control', dev ? 'no-cache' : 'max-age=600');` line and the corresponding test.