### PR TITLE
Add docs for --legacy flag

### DIFF
--- a/site/content/docs/09-building.md
+++ b/site/content/docs/09-building.md
@@ -16,9 +16,9 @@ node __sapper__/build
 
 ### Browser support
 
-By default, Sapper builds your site only for the latest versions of modern evergreen browsers.
+Your site is built only for the latest versions of modern evergreen browsers by default. If you are using Rollup, you can use the `--legacy`[1] flag to build a second bundle for legacy browsers like Internet Explorer. Sapper will then serve up the correct bundle at runtime[2].
 
-If you are using Rollup, you can use the `--legacy` flag to build two bundles: one for modern browsers and one for legacy browsers like Internet Explorer[1]. Sapper will then serve up the correct bundle[2] at runtime.
+When using `--legacy`, Sapper will pass an environment variable `SAPPER_LEGACY_BUILD` to your Rollup config. Sapper will then build your client-side bundle twice: once with `SAPPER_LEGACY_BUILD` set to `true` and once with it set to `false`. [sapper-template-rollup](https://github.com/sveltejs/sapper-template-rollup) provides an example of utilizing this configuration.[3]
 
 You may wish to add this flag to a script in your `package.json`:
 ```
@@ -27,5 +27,6 @@ You may wish to add this flag to a script in your `package.json`:
   },
 ```
 
-[1] You will also need to polyfill APIs that are not present in older browsers.
+[1] This option is unrelated to Svelte's `legacy` option
 [2] Browsers which do not support `async/await` syntax will be served the legacy bundle
+[3] You will also need to polyfill APIs that are not present in older browsers.

--- a/site/content/docs/09-building.md
+++ b/site/content/docs/09-building.md
@@ -18,7 +18,7 @@ node __sapper__/build
 
 By default, Sapper builds your site only for the latest versions of modern evergreen browsers.
 
-If you are using Rollup, you can use the `--legacy` flag to build two bundles: one for modern browsers and one for legacy browsers like Internet Explorer. Sapper will then serve up the correct bundle at runtime.
+If you are using Rollup, you can use the `--legacy` flag to build two bundles: one for modern browsers and one for legacy browsers like Internet Explorer[1]. Sapper will then serve up the correct bundle[2] at runtime.
 
 You may wish to add this flag to a script in your `package.json`:
 ```

--- a/site/content/docs/09-building.md
+++ b/site/content/docs/09-building.md
@@ -18,10 +18,13 @@ node __sapper__/build
 
 By default, Sapper builds your site only for the latest versions of modern evergreen browsers.
 
-For older browsers, like Internet Explorer, you will need to use the `--legacy` flag:
+If you are using Rollup, you can use the `--legacy` flag to build two bundles: one for modern browsers and one for legacy browsers like Internet Explorer. Sapper will then serve up the correct bundle at runtime.
 
+You may wish to add this flag to a script in your `package.json`:
 ```
-npx sapper build --legacy
+  "scripts": {
+    "build": "sapper build --legacy",
+  },
 ```
 
 You will also need to polyfill APIs that are not present in older browsers.

--- a/site/content/docs/09-building.md
+++ b/site/content/docs/09-building.md
@@ -27,4 +27,5 @@ You may wish to add this flag to a script in your `package.json`:
   },
 ```
 
-You will also need to polyfill APIs that are not present in older browsers.
+[1] You will also need to polyfill APIs that are not present in older browsers.
+[2] Browsers which do not support `async/await` syntax will be served the legacy bundle

--- a/site/content/docs/09-building.md
+++ b/site/content/docs/09-building.md
@@ -13,3 +13,15 @@ The output is a Node app that you can run from the project root:
 ```bash
 node __sapper__/build
 ```
+
+### Browser support
+
+By default, Sapper builds your site only for the latest versions of modern evergreen browsers.
+
+For older browsers, like Internet Explorer, you will need to use the `--legacy` flag:
+
+```
+npx sapper build --legacy
+```
+
+You will also need to polyfill APIs that are not present in older browsers.

--- a/site/content/docs/09-building.md
+++ b/site/content/docs/09-building.md
@@ -16,7 +16,7 @@ node __sapper__/build
 
 ### Browser support
 
-Your site is built only for the latest versions of modern evergreen browsers by default. If you are using Rollup, you can use the `--legacy`[1] flag to build a second bundle for legacy browsers like Internet Explorer. Sapper will then serve up the correct bundle at runtime[2].
+Your site is built only for the latest versions of modern evergreen browsers by default. If you are using Rollup, you can use the `--legacy`[1] flag to build a second bundle that can be used to support legacy browsers like Internet Explorer. Sapper will then serve up the correct bundle at runtime[2].
 
 When using `--legacy`, Sapper will pass an environment variable `SAPPER_LEGACY_BUILD` to your Rollup config. Sapper will then build your client-side bundle twice: once with `SAPPER_LEGACY_BUILD` set to `true` and once with it set to `false`. [sapper-template-rollup](https://github.com/sveltejs/sapper-template-rollup) provides an example of utilizing this configuration.[3]
 


### PR DESCRIPTION
Sending this based off the discussion in https://github.com/sveltejs/sapper/pull/1206

Closes https://github.com/sveltejs/sapper/issues/876
Closes https://github.com/sveltejs/sapper/issues/739

This isn't really the whole story for legacy browser support, but it's a good start. I think a lot of the docs for cross-browser support should go in the Svelte docs, which is why I didn't try to add more here yet.

Questions I have:
* Does Sapper do anything special or is this a straight pass-through to Svelte's `--legacy` option?
* Should we mention that a legacy browser is one that doesn't support `async`? (https://github.com/sveltejs/sapper/pull/1206#issuecomment-629801152). I think it'd be useful for people to know exactly which browsers are in each bundle. Where's the code that does this?