### PR TITLE
Be more explicit in regex example

### DIFF
--- a/site/content/docs/02-routing.md
+++ b/site/content/docs/02-routing.md
@@ -138,6 +138,6 @@ The `error` object is made available to the template along with the HTTP `status
 
 You can use a subset of regular expressions to qualify route parameters, by placing them in parentheses after the parameter name.
 
-For example, `src/routes/items/[id([0-9]+)].svelte` would only match numeric IDs — `/items/123` would match, but `/items/xyz` would not.
+For example, `src/routes/items/[id([0-9]+)].svelte` would only match numeric IDs — `/items/123` would match and make the value `123` available in `page.params.id`, but `/items/xyz` would not match.
 
 Because of technical limitations, the following characters cannot be used: `/`, `\`, `?`, `:`, `(` and `)`.


### PR DESCRIPTION
Closes https://github.com/sveltejs/sapper/pull/1071. I'm proposing this as an alternative to that PR to help close it out. The original submitter said he would be happy with this solution, which I think puts the pieces together with less redundant info