### PR TITLE
Add originAliases middleware option

### DIFF
--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -10,9 +10,10 @@ type IgnoreValue = Array | RegExp | function | string;
 
 export default function middleware(opts: {
 	session?: (req: Req, res: Res) => any,
+	originAliases?: Map<String,String>,
 	ignore?: IgnoreValue
 } = {}) {
-	const { session, ignore } = opts;
+	const { session, originAliases, ignore } = opts;
 
 	let emitted_basepath = false;
 
@@ -63,7 +64,7 @@ export default function middleware(opts: {
 
 		get_server_route_handler(manifest.server_routes),
 
-		get_page_handler(manifest, session || noop)
+		get_page_handler(manifest, session || noop, originAliases)
 	].filter(Boolean));
 }
 

--- a/site/content/docs/13-base-urls.md
+++ b/site/content/docs/13-base-urls.md
@@ -26,3 +26,9 @@ If you're [exporting](docs#Exporting) your app, you will need to tell the export
 ```bash
 sapper export --basepath my-base-path
 ```
+
+### `originAliases`
+
+You can specify [URL origin](https://nodejs.org/api/url.html#url_url_strings_and_url_objects) aliases to use when fetching data with `sapper.middleware({ originAliases: Map<String,String> })`. By default, Sapper uses the origin `http://127.0.0.1/` for fetching data from relative URLs, so you would specify that as the map key to override the default origin.
+
+If your API is running on another server (perhaps because you've written it in another language), you can utilize this option to fetch data from that server. You may use this option to specify a private hostname or internal alias for that service. E.g. some server orchestration tools such as Kubernetes will modify `resolv.conf` to provide internal hostnames for your services.


### PR DESCRIPTION
Closes https://github.com/sveltejs/sapper/issues/489 and somewhat solves https://github.com/sveltejs/sapper/issues/356

Allows you to use sapper with an API service residing in another server. This is especially useful if your API server is written in another language.

This solution also allows you to use private internal hostnames when fetching data for better latency (since the request doesn't have to hit the externally-facing load balancer). It also works if fetching data from multiple domains (though I don't imagine that's the common case it seemed better not to prevent it)

I was questioning the best API for this. An alternate API might be two options: a function which rewrites URLs to fetch and a function that decides whether to include credentials. I'm open to other ideas as well and happy to implement anything that makes sense