### PR TITLE
TypeScript support: don't try to compile templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5260,6 +5260,11 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
+    "strip-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw=="
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5260,11 +5260,6 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
-    "strip-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
-      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw=="
-    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -5443,6 +5438,11 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
+    },
+    "tippex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tippex/-/tippex-3.0.0.tgz",
+      "integrity": "sha1-sXYJonzq/+B5ezhzk/2Zh45Nfqk="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "http-link-header": "^1.0.2",
     "shimport": "^1.0.1",
     "sourcemap-codec": "^1.4.6",
-    "string-hash": "^1.1.3"
+    "string-hash": "^1.1.3",
+    "strip-comments": "^2.0.1"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "shimport": "^1.0.1",
     "sourcemap-codec": "^1.4.6",
     "string-hash": "^1.1.3",
-    "strip-comments": "^2.0.1"
+    "tippex": "^3.0.0"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.7",

--- a/src/core/create_manifest_data.ts
+++ b/src/core/create_manifest_data.ts
@@ -15,15 +15,7 @@ export default function create_manifest_data(cwd: string, extensions: string = '
 
 	function has_preload(file: string) {
 		const source = fs.readFileSync(path.join(cwd, file), 'utf-8');
-
-		if (/preload/.test(source)) {
-			try {
-				const { vars } = svelte.compile(source.replace(/<style\b[^>]*>[^]*?<\/style>/g, ''), { generate: false });
-				return vars.some((variable: any) => variable.module && variable.export_name === 'preload');
-			} catch (err) {}
-		}
-
-		return false;
+		return /export\s+(async\s+)?function\s+preload/.test(source);
 	}
 
 	function find_layout(file_name: string, component_name: string, dir: string = '') {

--- a/src/core/create_manifest_data.ts
+++ b/src/core/create_manifest_data.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import svelte from 'svelte/compiler';
 import { Page, PageComponent, ServerRoute, ManifestData } from '../interfaces';
 import { posixify, reserved_words } from '../utils';
 
@@ -15,7 +14,7 @@ export default function create_manifest_data(cwd: string, extensions: string = '
 
 	function has_preload(file: string) {
 		const source = fs.readFileSync(path.join(cwd, file), 'utf-8');
-		return /export\s+(async\s+)?function\s+preload/.test(source);
+		return /export\s+.*?preload/.test(source);
 	}
 
 	function find_layout(file_name: string, component_name: string, dir: string = '') {

--- a/test/unit/create_manifest_data/test.ts
+++ b/test/unit/create_manifest_data/test.ts
@@ -1,6 +1,65 @@
 import * as path from 'path';
 import * as assert from 'assert';
-import create_manifest_data from '../../../src/core/create_manifest_data';
+import create_manifest_data, { string_has_preload } from '../../../src/core/create_manifest_data';
+
+describe('string_has_preload', () => {
+	it('should detect async preload', () => {
+		const source = `
+			<script context="module">
+				export async function preload() {
+					const client = getClient();
+					let response = await client.query({ query: GET_POSTS });
+					let posts = response.data.getPosts;
+					return { posts };
+				}
+			</script>
+		`;
+		assert.ok(string_has_preload(source));
+	});
+
+	it('should detect preload in composed function', () => {
+		const source = `
+			<script context="module">
+				export const preload = verifyUser(catchErrors(function () { console.log('test'); }));
+			</script>
+		`;
+		assert.ok(string_has_preload(source));
+	});
+
+	it('should detect reusable preload functions', () => {
+		const source = `
+			<script context="module">
+				export { preload } from './userData'
+			</script>
+		`;
+		assert.ok(string_has_preload(source));
+	});
+
+	it('should not detect preload functions in single line comment', () => {
+		const source = `
+			<script context="module">
+				//export { preload } from './userData'
+			</script>
+		`;
+		assert.ok(!string_has_preload(source));
+	});
+
+	it('should not detect preload functions in comment block', () => {
+		const source = `
+			<script context="module">
+				/*
+				export async function preload() {
+					const client = getClient();
+					let response = await client.query({ query: GET_POSTS });
+					let posts = response.data.getPosts;
+					return { posts };
+				}
+				*/
+			</script>
+		`;
+		assert.ok(!string_has_preload(source));
+	});
+});
 
 describe('manifest_data', () => {
 	it('creates routes', () => {

--- a/test/unit/create_manifest_data/test.ts
+++ b/test/unit/create_manifest_data/test.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
 import * as assert from 'assert';
-import create_manifest_data, { string_has_preload } from '../../../src/core/create_manifest_data';
+import create_manifest_data, { template_has_preload } from '../../../src/core/create_manifest_data';
 
-describe('string_has_preload', () => {
+describe('template_has_preload', () => {
 	it('should detect async preload', () => {
 		const source = `
 			<script context="module">
@@ -14,7 +14,7 @@ describe('string_has_preload', () => {
 				}
 			</script>
 		`;
-		assert.ok(string_has_preload(source));
+		assert.ok(template_has_preload(source));
 	});
 
 	it('should detect preload in composed function', () => {
@@ -23,7 +23,7 @@ describe('string_has_preload', () => {
 				export const preload = verifyUser(catchErrors(function () { console.log('test'); }));
 			</script>
 		`;
-		assert.ok(string_has_preload(source));
+		assert.ok(template_has_preload(source));
 	});
 
 	it('should detect reusable preload functions', () => {
@@ -32,7 +32,7 @@ describe('string_has_preload', () => {
 				export { preload } from './userData'
 			</script>
 		`;
-		assert.ok(string_has_preload(source));
+		assert.ok(template_has_preload(source));
 	});
 
 	it('should not detect preload functions in single line comment', () => {
@@ -41,7 +41,7 @@ describe('string_has_preload', () => {
 				//export { preload } from './userData'
 			</script>
 		`;
-		assert.ok(!string_has_preload(source));
+		assert.ok(!template_has_preload(source));
 	});
 
 	it('should not detect preload functions in comment block', () => {
@@ -57,7 +57,7 @@ describe('string_has_preload', () => {
 				*/
 			</script>
 		`;
-		assert.ok(!string_has_preload(source));
+		assert.ok(!template_has_preload(source));
 	});
 });
 


### PR DESCRIPTION
Enables TypeScript support https://github.com/sveltejs/sapper/issues/760

TypeScript won't compile with Svelte compiler and first needs to be preprocessed. However, that happens after this check because `create_app` outputs JS which imports these `preload` exports before we try to bundle the whole app

This also has to be much faster to build the mainfest!