### PR TITLE
Docs: improve docs for skipping server-side script execution

### DIFF
--- a/site/content/docs/06-server-side-rendering.md
+++ b/site/content/docs/06-server-side-rendering.md
@@ -4,11 +4,11 @@ title: Server-side rendering
 
 Sapper, by default, renders server-side first (SSR), and then re-mounts any dynamic elements on the client. Svelte provides [excellent support for this](https://svelte.dev/docs#Server-side_component_API). This has benefits in performance and search engine indexing, among others, but comes with its own set of complexities.
 
-### Making a component SSR compatible
+### Skipping SSR for a component
 
-Sapper works well with most third-party libraries you are likely to come across. However, sometimes, a third-party library comes bundled in a way which allows it to work with multiple different module loaders. Sometimes, this code creates a dependency on `window`, such as checking for the existence of `window.global` might do.
+Sapper works well with most third-party libraries you are likely to come across. However, sometimes you may wish to use a library only on the client-side or a third-party library comes bundled in a way which is not compatible with Sapper.
 
-Since there is no `window` in a server-side environment like Sapper's, the action of simply importing such a module can cause the import to fail, and terminate the Sapper's server with an error such as:
+Incompatibility with Sapper will occur when a library has dependency on `window`. One of the more common causes of this can occur when a library is bundled to work with multiple different module loaders in a way that checks for the existence of `window.global`. Since there is no `window` in a server-side environment like Sapper's, the action of simply importing such a module can cause the import to fail, and terminate the Sapper's server with an error such as:
 
 ```bash
 ReferenceError: window is not defined
@@ -23,7 +23,7 @@ The way to get around this is to use a dynamic import for your component, from w
 	let MyComponent;
 
 	onMount(async () => {
-		const module = await import('my-non-ssr-component');
+		const module = await import('my-client-side-component');
 		MyComponent = module.default;
 	});
 </script>

--- a/site/content/docs/06-server-side-rendering.md
+++ b/site/content/docs/06-server-side-rendering.md
@@ -4,11 +4,9 @@ title: Server-side rendering
 
 Sapper, by default, renders server-side first (SSR), and then re-mounts any dynamic elements on the client. Svelte provides [excellent support for this](https://svelte.dev/docs#Server-side_component_API). This has benefits in performance and search engine indexing, among others, but comes with its own set of complexities.
 
-### Skipping SSR for a component
+### Skipping server-side script execution
 
-Sapper works well with most third-party libraries you are likely to come across. However, sometimes you may wish to use a library only on the client-side or a third-party library comes bundled in a way which is not compatible with Sapper.
-
-Incompatibility with Sapper will occur when a library has dependency on `window`. One of the more common causes of this can occur when a library is bundled to work with multiple different module loaders in a way that checks for the existence of `window.global`. Since there is no `window` in a server-side environment like Sapper's, the action of simply importing such a module can cause the import to fail, and terminate the Sapper's server with an error such as:
+Sapper works well with most third-party libraries you are likely to come across. However, sometimes, a third-party library comes bundled in a way which allows it to work with multiple different module loaders. Sometimes, this code creates a dependency on `window`, such as checking for the existence of `window.global`. Since there is no `window` in a server-side environment like Sapper's, the action of simply importing such a module can cause the import to fail, and terminate the Sapper's server with an error such as:
 
 ```bash
 ReferenceError: window is not defined


### PR DESCRIPTION
The old title "Making a component SSR compatible" didn't seem quite accurate to me. We're not making the component SSR compatible in the sense that it renders on the server. Rather we're just rendering the component on the client

This also cleans up some of the text and makes it clearer that you can use the same technique for any module you wish to render on the client-side only and not just ones that would fail on the server-side