### PR TITLE
site: Add documentation about rel=external

### DIFF
--- a/site/content/docs/03-client-api.md
+++ b/site/content/docs/03-client-api.md
@@ -51,7 +51,7 @@ const saveItem = () => {
 
 * `href` — the page to prefetch
 
-Programmatically prefetches the given page, which means a) ensuring that the code for the page is loaded, and b) calling the page's `preload` method with the appropriate options. This is the same behaviour that Sapper triggers when the user taps or mouses over an `<a>` element with [rel=prefetch](docs#Prefetching).
+Programmatically prefetches the given page, which means a) ensuring that the code for the page is loaded, and b) calling the page's `preload` method with the appropriate options. This is the same behaviour that Sapper triggers when the user taps or mouses over an `<a>` element with [rel=prefetch](docs#rel_prefetch).
 
 Returns a `Promise` that resolves when the prefetch is complete.
 

--- a/site/content/docs/08-link-options.md
+++ b/site/content/docs/08-link-options.md
@@ -22,7 +22,7 @@ We can mitigate that by *prefetching* the data. Adding a `rel=prefetch` attribut
 
 ### rel=external
 
-The sapper router listens for clicks on `<a>` elements and bypasses the normal browser navigation for relative (same origin) paths. We sometimes need links that are targeted at routes that are not part of the sapper app and hence should be reached by a normal browser navigation.
+By default, the Sapper runtime intercepts clicks on `<a>` elements and bypasses the normal browser navigation for relative (same-origin) URLs that match one of your page routes. We sometimes need to tell Sapper that certain links need to be be handled by normal browser navigation.
 
 Adding a `rel=external` attribute to a link...
 

--- a/site/content/docs/08-link-options.md
+++ b/site/content/docs/08-link-options.md
@@ -1,13 +1,12 @@
 ---
-title: Prefetching
+title: Link options
 ---
+
+### rel=prefetch
 
 Sapper uses code splitting to break your app into small chunks (one per route), ensuring fast startup times.
 
 For *dynamic* routes, such as our `src/routes/blog/[slug].svelte` example, that's not enough. In order to render the blog post, we need to fetch the data for it, and we can't do that until we know what `slug` is. In the worst case, that could cause lag as the browser waits for the data to come back from the server.
-
-
-### rel=prefetch
 
 We can mitigate that by *prefetching* the data. Adding a `rel=prefetch` attribute to a link...
 
@@ -20,3 +19,15 @@ We can mitigate that by *prefetching* the data. Adding a `rel=prefetch` attribut
 > `rel=prefetch` is a Sapper idiom, not a standard attribute for `<a>` elements
 
 <!-- TODO add a function to prefetch programmatically -->
+
+### rel=external
+
+The sapper router listens for clicks on `<a>` elements and bypasses the normal browser navigation for relative (same origin) paths. We sometimes need links that are targeted at routes that are not part of the sapper app and hence should be reached by a normal browser navigation.
+
+Adding a `rel=external` attribute to a link...
+
+```html
+<a rel=external href='path'>Path</a>
+```
+
+...will trigger a browser navigation when the link is clicked.


### PR DESCRIPTION
This is a very handy feature that took me an age to find (by reading
the code). This should make it more visible to others.

Ideally I'd like this feature to be documented, so feel free to drop or edit this if it doesn't fit the documentation as you'd like.
