### PR TITLE
Stop swallowing Rollup error details

### DIFF
--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -1,7 +1,11 @@
 import * as path from 'path';
+import color from 'kleur';
 import relative from 'require-relative';
+import { RollupError } from 'rollup/types';
 import { CompileResult } from './interfaces';
 import RollupResult from './RollupResult';
+
+const stderr = console.error.bind(console);
 
 let rollup: any;
 
@@ -71,16 +75,10 @@ export default class RollupCompiler {
 
 			return new RollupResult(Date.now() - start, this, sourcemap);
 		} catch (err) {
-			if (err.filename) {
-				// TODO this is a bit messy. Also, can
-				// Rollup emit other kinds of error?
-				err.message = [
-					`Failed to build — error in ${err.filename}: ${err.message}`,
-					err.frame
-				].filter(Boolean).join('\n');
-			}
+			// flush warnings
+			stderr(new RollupResult(Date.now() - start, this, sourcemap).print());
 
-			throw err;
+			handleError(err);
 		}
 	}
 
@@ -168,4 +166,41 @@ export default class RollupCompiler {
 
 		return config;
 	}
+}
+
+
+// copied from https://github.com/rollup/rollup/blob/master/cli/logging.ts
+// and updated so that it will compile here
+
+export function handleError(err: RollupError, recover = false) {
+	let description = err.message || err;
+	if (err.name) description = `${err.name}: ${description}`;
+	const message =
+		(err.plugin
+			? `(plugin ${(err).plugin}) ${description}`
+			: description) || err;
+
+	stderr(color.bold().red(`[!] ${color.bold(message.toString())}`));
+
+	if (err.url) {
+		stderr(color.cyan(err.url));
+	}
+
+	if (err.loc) {
+		stderr(`${(err.loc.file || err.id)!} (${err.loc.line}:${err.loc.column})`);
+	} else if (err.id) {
+		stderr(err.id);
+	}
+
+	if (err.frame) {
+		stderr(color.dim(err.frame));
+	}
+
+	if (err.stack) {
+		stderr(color.dim(err.stack));
+	}
+
+	stderr('');
+
+	if (!recover) process.exit(1);
 }

--- a/src/core/create_compilers/RollupResult.ts
+++ b/src/core/create_compilers/RollupResult.ts
@@ -26,7 +26,7 @@ export default class RollupResult implements CompileResult {
 		this.sourcemap = sourcemap
 
 		this.errors = compiler.errors.map(munge_warning_or_error);
-		this.warnings = compiler.warnings.map(munge_warning_or_error); // TODO emit this as they happen
+		this.warnings = compiler.warnings.map(munge_warning_or_error);
 
 		this.chunks = compiler.chunks.map(chunk => ({
 			file: chunk.fileName,


### PR DESCRIPTION
Fix two issues and the two TODOs that caused them

Closes https://github.com/sveltejs/sapper/issues/1234

More informative error with this PR:
```
> Building...
[!] (plugin typescript) Error: @rollup/plugin-typescript TS6133: 'routes' is declared but its value is never read.
src/service-worker.ts (1:35)

1 import { timestamp, files, shell, routes } from '@sapper/service-worker';
                                    ~~~~~~

Error: @rollup/plugin-typescript TS6133: 'routes' is declared but its value is never read.
```

Closes https://github.com/sveltejs/sapper/issues/1221.

Warnings are printed now:
```
> @rollup/plugin-typescript TS18003: No inputs were found in config file 'tsconfig.json'. Specified 'include' paths were '["src/**/*"]' and 'exclude' paths were '["node_modules"]'.


[!] (plugin typescript) Error: @rollup/plugin-typescript: Couldn't process compiler options
```