### PR TITLE
ignore html files with missing base element

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -171,6 +171,7 @@ async function _export({
 
 		let tasks = [];
 
+		handle_html:
 		if (range === 2) {
 			if (type === 'text/html') {
 				// parse link rel=preload headers and embed them in the HTML
@@ -187,6 +188,12 @@ async function _export({
 
 					const base_match = /<base ([\s\S]+?)>/m.exec(cleaned);
 					const base_href = base_match && get_href(base_match[1]);
+					if(base_href === null) {
+                                            oninfo({
+                                                    message: `ignoring html file with missing base element`
+                                            });
+                                            break handle_html
+                                        }
 					const base = resolve(url.href, base_href);
 
 					let match;

--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -188,12 +188,12 @@ async function _export({
 
 					const base_match = /<base ([\s\S]+?)>/m.exec(cleaned);
 					const base_href = base_match && get_href(base_match[1]);
-					if(base_href === null) {
-                                            oninfo({
-                                                    message: `ignoring html file with missing base element`
-                                            });
-                                            break handle_html
-                                        }
+					if (base_href === null) {
+					    oninfo({
+						    message: `ignoring html file with missing base element`
+					    });
+					    break handle_html
+					}
 					const base = resolve(url.href, base_href);
 
 					let match;

--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -189,10 +189,10 @@ async function _export({
 					const base_match = /<base ([\s\S]+?)>/m.exec(cleaned);
 					const base_href = base_match && get_href(base_match[1]);
 					if (base_href === null) {
-					    oninfo({
-						    message: `ignoring html file with missing base element`
-					    });
-					    break handle_html
+						oninfo({
+							message: `ignoring html file with missing base element`
+						});
+						break handle_html
 					}
 					const base = resolve(url.href, base_href);
 


### PR DESCRIPTION
I have some html files in my static folder. This caused `sapper export` to die because it expects all html files to have a `<base>` element and they do not. This is a simple fix.