### PR TITLE
Prevent server restarting while restart in progress

### DIFF
--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -310,14 +310,14 @@ class Watcher extends EventEmitter {
 					};
 
 					if (this.proc) {
-                        if (this.restarting) return;
-                        this.restarting = true;
+						if (this.restarting) return;
+						this.restarting = true;
 						this.proc.removeListener('exit', emitFatal);
 						this.proc.kill();
 						this.proc.on('exit', async () => {
 							start_server();
 							await restart();
-                            this.restarting = false;
+							this.restarting = false;
 						});
 					} else {
 						start_server();

--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -246,7 +246,7 @@ class Watcher extends EventEmitter {
 					const restart = () => {
 						this.crashed = false;
 
-						ports.wait(this.port)
+						return ports.wait(this.port)
 							.then((() => {
 								this.emit('ready', <ReadyEvent>{
 									port: this.port,
@@ -310,11 +310,14 @@ class Watcher extends EventEmitter {
 					};
 
 					if (this.proc) {
+                        if (this.restarting) return;
+                        this.restarting = true;
 						this.proc.removeListener('exit', emitFatal);
 						this.proc.kill();
-						this.proc.on('exit', () => {
+						this.proc.on('exit', async () => {
 							start_server();
-							restart();
+							await restart();
+                            this.restarting = false;
 						});
 					} else {
 						start_server();


### PR DESCRIPTION
Resolves https://github.com/sveltejs/sapper/issues/920

The issue was caused by the server file watcher process calling `handle_result` in rapid succession. The source of this could be IDEs making many file saves (I only saw the issue in VSCode not vim), or just caused by people with an itchy cmd+S finger.

Initially considered debouncing the `handle_result` method, but a simple flag seems to be sufficient.

Flag was added inside the callback code for server changes and it prevents the server restart process if the flag is true.