### PR TITLE
Stop corrupting binary files in build

### DIFF
--- a/src/core/create_compilers/extract_css.ts
+++ b/src/core/create_compilers/extract_css.ts
@@ -225,7 +225,7 @@ export default function extract_css(
 	});
 
 	fs.readdirSync(asset_dir).forEach(file => {
-		if (fs.statSync(`${asset_dir}/${file}`).isDirectory()) return;
+		if (!file.endsWith('.js') || fs.statSync(`${asset_dir}/${file}`).isDirectory()) return;
 
 		const source = fs.readFileSync(`${asset_dir}/${file}`, 'utf-8');
 


### PR DESCRIPTION
Fixes https://github.com/sveltejs/sapper/issues/1245

There's no need to attempt to extract css from images and then overwrite those images with their supposedly original content