### PR TITLE
separate <Layout> from <Error> in generate_app( )

### DIFF
--- a/src/core/create_app.ts
+++ b/src/core/create_app.ts
@@ -283,13 +283,13 @@ function generate_app(manifest_data: ManifestData, path_to_routes: string) {
 			setContext(CONTEXT_KEY, stores);
 		</script>
 
-		<Layout segment="{segments[0]}" {...level0.props}>
-			{#if error}
-				<Error {error} {status}/>
-			{:else}
+		{#if error}
+			<Error {error} {status}/>
+		{:else}
+			<Layout segment="{segments[0]}" {...level0.props}>
 				${pyramid.replace(/\n/g, '\n\t\t\t\t')}
-			{/if}
-		</Layout>
+			</Layout>
+		{/if}
 	`.replace(/^\t\t/gm, '').trim();
 }
 


### PR DESCRIPTION
_error.svelte will now be able to be styled independently of _layout.svelte to allow for unique error pages. This is in response to the comment by @intrikate in PR #948: _error.svelte should not inherit the common layout by default.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
