### PR TITLE
Docs: shorten heading

### DIFF
--- a/site/content/docs/11-deploying.md
+++ b/site/content/docs/11-deploying.md
@@ -4,9 +4,9 @@ title: Deployment
 
 Sapper apps run anywhere that supports Node 8 or higher.
 
-### Deploying to Vercel ([formerly ZEIT Now](https://vercel.com/blog/zeit-is-now-vercel))
+### Deploying to Vercel
 
-We can use a third-party library like [the `vercel-sapper` builder](https://www.npmjs.com/package/vercel-sapper) to deploy our projects to [Vercel]. See [that project's readme](https://github.com/thgh/vercel-sapper#readme) for more details regarding [Vercel] deployments.
+We can use a third-party library like [the `vercel-sapper` builder](https://www.npmjs.com/package/vercel-sapper) to deploy our projects to [Vercel] ([formerly ZEIT Now](https://vercel.com/blog/zeit-is-now-vercel)). See [that project's readme](https://github.com/thgh/vercel-sapper#readme) for more details regarding [Vercel] deployments.
 
 ### Deploying service workers
 


### PR DESCRIPTION
The heading is quite long and doesn't display well in the sidebar. Having linked content in the sidebar also appears out of place. I've attached a screenshot of the current sidebar rendering

I'd like to propose moving this text from the heading to the main content

![Screenshot from 2020-06-03 11-51-39](https://user-images.githubusercontent.com/322311/83677553-30747180-a591-11ea-81b3-9d73cdf9a4cf.png)

