### PR TITLE
chore: bump sirv version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5745,6 +5745,12 @@
         "kleur": "^3.0.0"
       }
     },
+    "webpack-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-modules/-/webpack-modules-1.0.0.tgz",
+      "integrity": "sha512-2SvHR8a9jigRPxh8SoiVG4D4HBU1gZ0N6s8dk9WuTiyVm+ASCkeZSnKEKC3W0CdZqwZchYhaJQqxAEl/oMAklA==",
+      "dev": true
+    },
     "webpack-sources": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2073,8 +2073,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2095,14 +2094,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2117,20 +2114,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2247,8 +2241,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2260,7 +2253,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2275,7 +2267,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2283,14 +2274,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2309,7 +2298,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2390,8 +2378,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2403,7 +2390,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2489,8 +2475,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2526,7 +2511,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2546,7 +2530,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2590,14 +2573,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4895,13 +4876,22 @@
       "dev": true
     },
     "sirv": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-0.4.2.tgz",
-      "integrity": "sha512-dQbZnsMaIiTQPZmbGmktz+c74zt/hyrJEB4tdp2Jj0RNv9J6B/OWR5RyrZEvIn9fyh9Zlg2OlE2XzKz6wMKGAw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.0.tgz",
+      "integrity": "sha512-NYxkb52SaeZWHH4cKwmY5N+Qv/oAVZHOUNuV+N7ohuJrlEYyQ0NdnR9s6+Ki2UFfYE4hjThzDCG9oU/qSNRdYA==",
       "dev": true,
       "requires": {
-        "@polka/url": "^0.5.0",
-        "mime": "^2.3.1"
+        "@polka/url": "^1.0.0-next.9",
+        "mime": "^2.3.1",
+        "totalist": "^1.0.0"
+      },
+      "dependencies": {
+        "@polka/url": {
+          "version": "1.0.0-next.11",
+          "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.11.tgz",
+          "integrity": "sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==",
+          "dev": true
+        }
       }
     },
     "slice-ansi": {
@@ -5501,6 +5491,12 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
+    },
+    "totalist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.0.1.tgz",
+      "integrity": "sha512-HuAt9bWDCdLkebrIQr+i63NgQSvjeD2VTNUIEBqof/4pG4Gb6omuBOMUX0vF371cbfImXQzmb4Ue/0c9MUWGew==",
+      "dev": true
     },
     "trouter": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "rollup-plugin-sucrase": "^2.1.0",
     "rollup-plugin-svelte": "^5.1.0",
     "sade": "^1.6.1",
-    "sirv": "^0.4.2",
+    "sirv": "^1.0.0",
     "sucrase": "^3.10.1",
     "svelte": "^3.6.9",
     "svelte-loader": "^2.13.6",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "svelte": "^3.6.9",
     "svelte-loader": "^2.13.6",
     "webpack": "^4.38.0",
-    "webpack-format-messages": "^2.0.5"
+    "webpack-format-messages": "^2.0.5",
+    "webpack-modules": "^1.0.0"
   },
   "peerDependencies": {
     "svelte": "^3.5.0"

--- a/test/apps/export-webpack/webpack.config.js
+++ b/test/apps/export-webpack/webpack.config.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack');
+const WebpackModules = require('webpack-modules');
 const config = require('../../../config/webpack.js');
 
 const mode = process.env.NODE_ENV;
@@ -61,7 +62,10 @@ module.exports = {
 				}
 			]
 		},
-		mode: process.env.NODE_ENV
+		mode: process.env.NODE_ENV,
+		plugins: [
+			new WebpackModules()
+		]
 	},
 
 	serviceworker: {


### PR DESCRIPTION
### Summary

Updates `sirv` dependency to 1.0. There are no (relevant) breaking changes since Sapper's tests and site never made use of `single` (because it didn't exist outside of the `@next` prereleases).

### Tests

-  [x] Ran the tests tests with `npm test` or `yarn test`)

---

I don't know what's changed between the Actions run yesterday and today, but the `master` branch is failing for me locally. This branch (after latest commit) and master now fail in the same way.