### PR TITLE
bail when session getter returns an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # sapper changelog
 
+## Unreleased
+
+* Handle errors thrown from session seeding function ([#1273](https://github.com/sveltejs/sapper/issues/1273))
+
+
 ## 0.27.15
 
 * Allow `session` handler to return a Promise ([#740](https://github.com/sveltejs/sapper/issues/740))

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -88,7 +88,12 @@ export function get_page_handler(
 			res.setHeader('Link', link);
 		}
 
-		const session = await session_getter(req, res);
+		let session;
+		try {
+			session = await session_getter(req, res);
+		} catch (err) {
+			return bail(req, res, err);
+		}
 
 		let redirect: { statusCode: number, location: string };
 		let preload_error: { statusCode: number, message: Error | string };

--- a/test/apps/session/src/server.js
+++ b/test/apps/session/src/server.js
@@ -11,9 +11,12 @@ const app = polka()
 	})
 	.use(
 		sapper.middleware({
-			session: async (req, res) => await Promise.resolve({
-				title: `${req.hello} ${res.locals.name}`
-			})
+			session: async (req, res) => {
+				if (req.url === '/error') {
+					throw new Error('error');
+				}
+				return { title: `${req.hello} ${res.locals.name}` };
+			}
 		})
 	);
 

--- a/test/apps/session/test.ts
+++ b/test/apps/session/test.ts
@@ -40,6 +40,10 @@ describe('session', function() {
 		assert.equal(await r.text('h1'), 'changed');
 	});
 
+	it('survives exception from session getter', async () => {
+		await r.load('/error');
+	});
+
 	it('survives the tests with no server errors', () => {
 		assert.deepEqual(r.errors, []);
 	});


### PR DESCRIPTION
Fixes #1273 and adds a test. This uses the existing `bail()` function to handle situations where the session seeding function returns an error.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)