### PR TITLE
Use same serve settings in dev and prod

### DIFF
--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -107,9 +107,7 @@ export function serve({ prefix, pathname, cache_control }: {
 
 	const cache: Map<string, Buffer> = new Map();
 
-	const read = dev
-		? (file: string) => fs.readFileSync(path.join(build_dir, file))
-		: (file: string) => (cache.has(file) ? cache : cache.set(file, fs.readFileSync(path.join(build_dir, file)))).get(file)
+	const read = (file: string) => (cache.has(file) ? cache : cache.set(file, fs.readFileSync(path.join(build_dir, file)))).get(file)
 
 	return (req: Req, res: Res, next: () => void) => {
 		if (filter(req)) {


### PR DESCRIPTION
It's unnecessary to disable the cache in development mode because all files under `client/` contain hashes and so will not be cached if their contents change

Removing this has two benefits:
* Faster reloads in development
* Makes dev more like prod