### PR TITLE
Cache client files in dev mode too

### DIFF
--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -58,7 +58,7 @@ export default function middleware(opts: {
 
 		serve({
 			prefix: '/client/',
-			cache_control: dev ? 'no-cache' : 'max-age=31536000, immutable'
+			cache_control: 'max-age=31536000, immutable'
 		}),
 
 		get_server_route_handler(manifest.server_routes),


### PR DESCRIPTION
It's unnecessary to disable the cache in development mode because all files under `client/` contain hashes and so will not be cached if their contents change

Removing this has two benefits:
* Faster reloads in development
* Makes dev more like prod