### PR TITLE
Handle shell escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -401,7 +401,7 @@ Also:
 
 ## 0.15.0
 
-* Nested routes (consult [migration guide](https://sapper.svelte.technology/guide#0-14-to-0-15) and docs on [layouts](https://sapper.svelte.technology/guide#layouts)) ([#262](https://github.com/sveltejs/sapper/issues/262))
+* Nested routes (consult [migration guide](https://sapper.svelte.dev/migrating#0_14_to_0_15) and docs on [layouts](https://sapper.svelte.technology/guide#layouts)) ([#262](https://github.com/sveltejs/sapper/issues/262))
 
 ## 0.14.2
 

--- a/site/scripts/deploy.sh
+++ b/site/scripts/deploy.sh
@@ -4,7 +4,8 @@ git symbolic-ref HEAD refs/heads/gh-pages
 git reset $HEAD
 git rm --cached -rf ..
 cd __sapper__/export
-find . -type f | cut -c 3- | xargs -I '{}' sh -c 'git update-index --add --cacheinfo 100644,$(git hash-object -w "{}"),"{}"'
+files=($(find -type f | cut -c 3-))
+for file in ${files[@]}; do hash=$(git hash-object -w $file); git update-index --add --cacheinfo 100644,$hash,$file; done
 git commit -m '[build site]'
 git symbolic-ref HEAD $HEAD
 git reset


### PR DESCRIPTION
this commit will handle file names with '$' characters correctly
when using the deploy script

Signed-off-by: louis <louis@localhost.localdomain>


actually closes: https://github.com/sveltejs/sapper/issues/1279
