### PR TITLE
Upgrade Svelte in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5334,9 +5334,9 @@
       }
     },
     "svelte": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.6.9.tgz",
-      "integrity": "sha512-k72cp0LYzennT7xgnQU0jB2HJEZ/fQamZbrHJO6JlvsNX+z6a1YJaLrtN4qQ1yfozUkeGw1TOvDxo8a5grOZMg==",
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.23.2.tgz",
+      "integrity": "sha512-hE8GeTM83YVR4GY6/6PeDEcGct4JS5aCi+IYbCAa76oaPSfuF7L85DQYULQxlTK/KPWzw3L1GRGmC3oPG/PQoA==",
       "dev": true
     },
     "svelte-dev-helper": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "sade": "^1.6.1",
     "sirv": "^0.4.2",
     "sucrase": "^3.10.1",
-    "svelte": "^3.23.2",
+    "svelte": "^3.24.0",
     "svelte-loader": "^2.13.6",
     "webpack": "^4.38.0",
     "webpack-format-messages": "^2.0.5"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "sade": "^1.6.1",
     "sirv": "^0.4.2",
     "sucrase": "^3.10.1",
-    "svelte": "^3.6.9",
+    "svelte": "^3.23.2",
     "svelte-loader": "^2.13.6",
     "webpack": "^4.38.0",
     "webpack-format-messages": "^2.0.5"

--- a/test/apps/layout/test.ts
+++ b/test/apps/layout/test.ts
@@ -20,47 +20,47 @@ describe('layout', function() {
 		await r.load('/foo/bar/baz');
 
 		const text1 = await r.text('#sapper');
-		assert.deepEqual(text1.split('\n').map(str => str.trim()).filter(Boolean), [
+		assert.equal(text1.split('\n').map(str => str.trim()).filter(Boolean).join(' '), [
 			'y: bar 1',
 			'z: baz 1',
 			'goto foo/bar/qux',
 			'goto foo/abc/def',
 			'child segment: baz'
-		]);
+		].join(' '));
 
 		await r.sapper.start();
 		const text2 = await r.text('#sapper');
-		assert.deepEqual(text2.split('\n').map(str => str.trim()).filter(Boolean), [
+		assert.equal(text2.split('\n').map(str => str.trim()).filter(Boolean).join(' '), [
 			'y: bar 1',
 			'z: baz 1',
 			'goto foo/bar/qux',
 			'goto foo/abc/def',
 			'child segment: baz'
-		]);
+		].join(' '));
 
 		await r.page.click('[href="foo/bar/qux"]');
 		await r.wait();
 
 		const text3 = await r.text('#sapper');
-		assert.deepEqual(text3.split('\n').map(str => str.trim()).filter(Boolean), [
+		assert.equal(text3.split('\n').map(str => str.trim()).filter(Boolean).join(' '), [
 			'y: bar 1',
 			'z: qux 2',
 			'goto foo/bar/qux',
 			'goto foo/abc/def',
 			'child segment: qux'
-		]);
+		].join(' '));
 
 		await r.page.click('[href="foo/abc/def"]');
 		await r.wait();
 
 		const text4 = await r.text('#sapper');
-		assert.deepEqual(text4.split('\n').map(str => str.trim()).filter(Boolean), [
+		assert.equal(text4.split('\n').map(str => str.trim()).filter(Boolean).join(' '), [
 			'y: abc 2',
 			'z: def 3',
 			'goto foo/bar/qux',
 			'goto foo/abc/def',
 			'child segment: def'
-		]);
+		].join(' '));
 	});
 
 	it('survives the tests with no server errors', () => {


### PR DESCRIPTION
Closes https://github.com/sveltejs/sapper/issues/1284

I'm not quite sure why Svelte is behaving differently starting with 3.10.0, but I'm not sure it matters. Both behaviors are correct and plenty of people are using the newer versions without issue