### PR TITLE
Added support for entry points that are not index.html pages

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -92,7 +92,7 @@ async function _export({
 
 	const entryPoints = entry.split(' ').map(entryPoint => {
 		const entry = resolve(origin, `${basepath}/${cleanPath(entryPoint)}`);
-		if (!entry.href.endsWith('/')) entry.href += '/';
+		if (!entry.href.endsWith('/') && path.extname(entry.href) === '') entry.href += '/';
 
 		return entry;
 	});

--- a/test/apps/export/src/routes/test.json.js
+++ b/test/apps/export/src/routes/test.json.js
@@ -1,0 +1,9 @@
+export function get(req, res) {
+	res.writeHead(200, {
+		"Content-Type": "application/json"
+	});
+	const json = {
+		test: 'test value'
+	};
+	res.end(JSON.stringify(json));
+}

--- a/test/apps/export/test.ts
+++ b/test/apps/export/test.ts
@@ -8,7 +8,7 @@ describe('export', function() {
 
 	// hooks
 	before('build app', () => api.build({ cwd: __dirname }));
-	before('export app', () => api.export({ cwd: __dirname }));
+	before('export app', () => api.export({ cwd: __dirname, entry: '/ test.json' }));
 
 	// tests
 	it('crawls a site', () => {
@@ -41,10 +41,17 @@ describe('export', function() {
 			'index.html',
 			'service-worker-index.html',
 			'service-worker.js',
+			'test.json',
 			'test.pdf',
 			...boom
 		].sort());
 	});
+
+	it('produces expected json file', () => {
+		const expected = '{"test":"test value"}';
+		const output = readFileSync(`${__dirname}/__sapper__/export/test.json`, 'utf8')
+		assert.equal(expected, output)
+	})
 
 	it('does not corrupt binary file links (like pdf)', () => {
 		const input = readFileSync(`${__dirname}/static/test.pdf`)


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)

The title pretty much says it all.  This PR adds support for entry points that are not index.html pages to sapper export.  This is useful for generating files that would not normally be accessible via links such as sitemaps.

Resolves  #1289