### PR TITLE
Allow usage of a valid Rollup config

### DIFF
--- a/src/config/rollup.ts
+++ b/src/config/rollup.ts
@@ -27,9 +27,7 @@ export default {
 
 	server: {
 		input: (): InputOption => {
-			return {
-				server: `${src}/server.js`
-			};
+			return `${src}/server.js`;
 		},
 
 		output: (): OutputOptions => {

--- a/src/core/create_compilers/index.ts
+++ b/src/core/create_compilers/index.ts
@@ -26,17 +26,21 @@ export default async function create_compilers(
 		const config = await RollupCompiler.load_config(cwd);
 		validate_config(config, 'rollup');
 
-		normalize_rollup_config(config.client);
-		normalize_rollup_config(config.server);
+		const client = get_config(config, 'client');
+		const server = get_config(config, 'server');
+		const serviceworker = get_config(config, 'serviceworker');
 
-		if (config.serviceworker) {
-			normalize_rollup_config(config.serviceworker);
+		normalize_rollup_config(client);
+		normalize_rollup_config(server);
+
+		if (serviceworker) {
+			normalize_rollup_config(serviceworker);
 		}
 
 		return {
-			client: new RollupCompiler(config.client),
-			server: new RollupCompiler(config.server),
-			serviceworker: config.serviceworker && new RollupCompiler(config.serviceworker)
+			client: new RollupCompiler(client),
+			server: new RollupCompiler(server),
+			serviceworker: serviceworker && new RollupCompiler(serviceworker)
 		};
 	}
 
@@ -55,9 +59,9 @@ export default async function create_compilers(
 	throw new Error(`Invalid bundler option '${bundler}'`);
 }
 
-function validate_config(config: any, bundler: 'rollup' | 'webpack') {
-	if (!config.client || !config.server) {
-		throw new Error(`${bundler}.config.js must export a { client, server, serviceworker? } object`);
+function validate_config(config, bundler: 'rollup' | 'webpack') {
+	if (!get_config(config, 'client') || !get_config(config, 'server')) {
+		throw new Error(`${bundler}.config.js must export client and server configuration`);
 	}
 }
 
@@ -69,4 +73,10 @@ function normalize_rollup_config(config: any) {
 			config.input[name] = path.normalize(config.input[name]);
 		}
 	}
+}
+
+function get_config(config: object, name: string) {
+	const filename = name === 'serviceworker' ? `service-worker` : `${name}`;
+	return config[name] || config.find(bundle =>
+		bundle.input.endsWith(`/${filename}.js`) || bundle.input.endsWith(`/${filename}.ts`));
 }


### PR DESCRIPTION
Today it's not possible to use a valid Rollup configuration file with a Sapper project.

Forcing users to use an invalid config file doesn't have many benefits. It does have some drawbacks, however. E.g. it makes it harder to compare the output of Rollup's CLI implementation vs Sapper's Rollup CLI reimplementation. I've hit many issues here. Not being able to execute Rollup directly has caused a lot of difficulty in debugging and in requesting help from the Rollup team.

I implemented this looking at the name of the `input`. Arguably we could instead add an `id` field to look for though this would be a bit of a non-standard field. I filed a feature request to make it more standardized https://github.com/rollup/rollup/issues/3687

Eventually I'd like to consider moving the Sapper compiler to be a bundler plugin (https://github.com/sveltejs/sapper/issues/1346). This would be the first step of that. That would make it much easier to use other development systems like [nollup](https://github.com/sveltejs/sapper/issues/1207), vite, or snowpack. Today there's no way to use an alternative bundler like nollup with Sapper because Sapper must have an implementation for every bundler. It'd be a small change to enable it (https://github.com/rixo/sapper/commit/faca5e01149b4b4157b8f976b48ac981c248a385) and @rixo already has a fork that does that, but I'm not sure it's the right separation of concerns that Sapper should have to know about every possible build system