### PR TITLE
Add --crawlstaticroutes flag to sapper export to add static routes as entrypoints to export

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -207,6 +207,7 @@ prog.command('export [dest]')
 	.option('--build-dir', 'Intermediate build directory', '__sapper__/build')
 	.option('--ext', 'Custom page route extensions (space separated)', '.svelte .html')
 	.option('--entry', 'Custom entry points (space separated)', '/')
+	.option('--crawlstaticroutes', 'Add all static routes as entrypoints. Additive to --entry.', false)
 	.action(async (dest = '__sapper__/export', opts: {
 		build: boolean,
 		legacy: boolean,
@@ -221,8 +222,9 @@ prog.command('export [dest]')
 		static: string,
 		output: string,
 		'build-dir': string,
-		ext: string
-		entry: string
+		ext: string,
+		entry: string,
+		crawlstaticroutes: boolean,
 	}) => {
 		try {
 			if (opts.build) {
@@ -243,7 +245,10 @@ prog.command('export [dest]')
 				host_header: opts.host,
 				timeout: opts.timeout,
 				concurrent: opts.concurrent,
+				routes: opts.routes,
 				entry: opts.entry,
+				ext: opts.ext,
+				crawlstaticroutes: opts.crawlstaticroutes,
 
 				oninfo: event => {
 					console.log(colors.bold().cyan(`> ${event.message}`));

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -35,6 +35,7 @@ export type PageComponent = {
 
 export type Page = {
 	pattern: RegExp;
+	canonical_path?: string; // set on Pages with non-dynamic routes.
 	parts: Array<{
 		component: PageComponent;
 		params: string[];


### PR DESCRIPTION
Fixes #1014 when limited to static (i.e., non-dynamic) routes.

This add `--crawlstaticroutes` to `sapper export` so that static routes in `src/routes/` are added as entrypoints for the export process. This is

1. what people expect this feature to do (i.e., less surprising)
2. a major ergonomic benefit for those that have static routes not reachable through an SSR crawl

The current implementation is backwards compatible, though I do believe per (1) that in a future major version update this would be a good candidate for a breaking change to make this flag default true.