### PR TITLE
better error: show a warning/error when server-preloaded data can't be transmitted to the client

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -267,7 +267,10 @@ export function get_page_handler(
 			const { html, head, css } = App.render(props);
 
 			const serialized = {
-				preloaded: `[${preloaded.map(data => try_serialize(data)).join(',')}]`,
+				preloaded: `[${preloaded.map(data => try_serialize(data, err => {
+					console.error(`Failed to serialize preloaded data to transmit to the client at the /${segments.join('/')} route: ${err.message}`);
+					console.warn('The client will re-render over the server-rendered page fresh instead of continuing where it left off. See https://sapper.svelte.dev/docs#Return_value for more information');
+				})).join(',')}]`,
 				session: session && try_serialize(session, err => {
 					throw new Error(`Failed to serialize session data: ${err.message}`);
 				}),


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] *It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.*: There are no directly related issues for this because it is already semi-documented behavior. That being said, there is no runtime error/warning when this happens. Tangentially related issues: https://github.com/sveltejs/sapper/issues/843, https://github.com/sveltejs/sapper/issues/710 (another instance where re-rendering was unwanted from messing up `preload`), https://github.com/sveltejs/sapper/issues/447 (resolved issue that never got closed by the way; there is already an error for the same situation with the `session` store) 
- [x] *Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)*: There is no way to mock/assert console output in `mocha`/`assert` without introducing another dependency like [`sinon`](https://sinonjs.org/releases/v9.0.2/spies/). By the way, there is no longer a `lint` package script.
### Tests
-  [x] *Run the tests tests with `npm test` or `yarn test`*: 1 test was already failing and this doesn't change that

Like was said in #447, if there is data in `preload`'s return that cannot be serialized by `devalue` (like a function in my case), the client will not receive a copy. There are no warnings for this (i.e. this is a completely silent failure), which was a source of confusion for me, despite this behavior being documented. (Actually, another PR to specify what it means [when serialization fails](https://sapper.svelte.dev/docs#Return_value) could be needed since it is not explicitly stated that `preload` runs again client-side rather than displaying an error page). 

This pull request introduces an error (where serialization failed and why) + warning (consequences and more information) message combo in the server side console while remaining silent in the client side. This approach was taken to remain backwards compatible and not bother the client with the server's mistakes. 

Possible problems or improvements still needed with this:
* There are two console calls (`error` then `warn`) rather than one
* The warning could be restricted to `dev`
* Being silent on the client is different behavior than what happens when the `session` store's serialization fails, which displays an error page (see 2 lines later in the same file)