### PR TITLE
Fix CSS code splitting with Rollup 2

### DIFF
--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -41,7 +41,7 @@ export default class RollupCompiler {
 			transform: (code: string, id: string) => {
 				if (/\.css$/.test(id)) {
 					this.css_files.push({ id, code });
-					return ``;
+					return {code: '', moduleSideEffects: 'no-treeshake'};
 				}
 			}
 		});


### PR DESCRIPTION
Addresses the issue described in https://github.com/sveltejs/sapper-template/issues/233, which is that CSS modules get tree shaken out in Rollup 2

Thanks to @habibrosyad for the bug report and also testing and confirming that this fix works both with the latest Rollup release and older Rollup releases