### PR TITLE
[WIP, please help improve] Fix #699 when importing css using postcss

### DIFF
--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -39,12 +39,14 @@ export default class RollupCompiler {
 				this.chunks.push(chunk);
 			},
 			transform: (code: string, id: string) => {
-				if (/\.css$/.test(id) && !/styleInject/.test(code)) {
-					this.css_files.push({ id, code });
-					return ``;
-				} else if (/styleInject/.test(code)) {
+				if (!/\.css$/.test(id)) return;
+				
+				if (/styleInject/.test(code)) {
 					return code;
 				}
+				
+				this.css_files.push({ id, code });
+				return ``;
 			}
 		});
 

--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -39,9 +39,11 @@ export default class RollupCompiler {
 				this.chunks.push(chunk);
 			},
 			transform: (code: string, id: string) => {
-				if (/\.css$/.test(id)) {
+				if (/\.css$/.test(id) && !/styleInject/.test(code)) {
 					this.css_files.push({ id, code });
 					return ``;
+				} else if (/styleInject/.test(code)) {
+					return code;
 				}
 			}
 		});


### PR DESCRIPTION
All the bug info can be found in #699, but here's a short summary.

When you use `import './styles.css'` in your Svelte or JS code and you use `rollup-plugin-postcss` to process that css file first, then your css output looks like javascript. Depending on your configuration it could look like:

```js
export default undefined;
export default undefined;
/* sourceMappingURL=./chunk.e3537e20.css.map */
```

or

```js
var css = "a.link.svelte-131civd{color:#d3d3d3}";
export default css;
import styleInject from 'C:/Users/admin/Code/domainhax/node_modules/style-inject/dist/style-inject.es.js';
styleInject(css);
var css = "main.svelte-1joomdn{padding-right:15px;padding-left:15px;margin-right:auto;margin-left:auto;width:64em}input.svelte-1joomdn{width:100%}#description.svelte-1joomdn>div.svelte-1joomdn{width:50%;padding:0;float:left}header.svelte-1joomdn{text-align:center}p.svelte-1joomdn{margin-top:0}a.svelte-1joomdn{color:#959595}h1.svelte-1joomdn a.svelte-1joomdn{color:#dfdfdf}";
export default css;
import styleInject from 'C:/Users/admin/Code/domainhax/node_modules/style-inject/dist/style-inject.es.js';
styleInject(css);
/* sourceMappingURL=./chunk.e3537e20.css.map */
```

I saw that the bug has gone unfixed for a long time. Now I don't understand Sapper well enough to understand all the intricacies that I need to be mindful of when fixing a bug. So I'm aware that this PR is probably relatively bad. I didn't run the tests, but when I run `npm run dev` I get the following warning repeatedly:

    Sourcemap is likely to be incorrect: a plugin (sapper-internal) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help

But other than that, it now does output the css correctly, finally. So is anyone willing to take a look at my PR and improve whatever needs to be improved before it can be merged?