### PR TITLE
Add noscroll option to goto, document sapper-noscroll on links

### DIFF
--- a/runtime/src/app/goto/index.ts
+++ b/runtime/src/app/goto/index.ts
@@ -1,11 +1,11 @@
 import { history, select_target, navigate, cid } from '../app';
 
-export default function goto(href: string, opts = { replaceState: false }) {
+export default function goto(href: string, opts = { noscroll: false, replaceState: false }) {
 	const target = select_target(new URL(href, document.baseURI));
 
 	if (target) {
 		history[opts.replaceState ? 'replaceState' : 'pushState']({ id: cid }, '', href);
-		return navigate(target, null).then(() => {});
+		return navigate(target, null, opts.noscroll).then(() => {});
 	}
 
 	location.href = href;

--- a/runtime/src/app/start/index.ts
+++ b/runtime/src/app/start/index.ts
@@ -110,7 +110,7 @@ function handle_click(event: MouseEvent) {
 
 	const target = select_target(url);
 	if (target) {
-		const noscroll = a.hasAttribute('sapper-noscroll');
+		const noscroll = a.hasAttribute('sapper:noscroll');
 		navigate(target, null, noscroll, url.hash);
 		event.preventDefault();
 		history.pushState({ id: cid }, '', url.href);

--- a/site/content/docs/03-client-api.md
+++ b/site/content/docs/03-client-api.md
@@ -27,7 +27,9 @@ sapper.start({
 ### goto(href, options?)
 
 * `href` — the page to go to
-* `options` — can include a `replaceState` property, which determines whether to use `history.pushState` (the default) or `history.replaceState`. Not required
+* `options` - not required
+  * `replaceState` (`boolean`, default `false`) — determines whether to use `history.pushState` (the default) or `history.replaceState`.
+  * `noscroll` (`boolean`, default `false`) — prevent scroll to top after navigation.
 
 Programmatically navigates to the given `href`. If the destination is a Sapper route, Sapper will handle the navigation, otherwise the page will be reloaded with the new `href`. In other words, the behaviour is as though the user clicked on a link with this `href`.
 

--- a/site/content/docs/03-client-api.md
+++ b/site/content/docs/03-client-api.md
@@ -27,7 +27,7 @@ sapper.start({
 ### goto(href, options?)
 
 * `href` — the page to go to
-* `options` - not required
+* `options` — not required
   * `replaceState` (`boolean`, default `false`) — determines whether to use `history.pushState` (the default) or `history.replaceState`.
   * `noscroll` (`boolean`, default `false`) — prevent scroll to top after navigation.
 

--- a/site/content/docs/08-link-options.md
+++ b/site/content/docs/08-link-options.md
@@ -31,3 +31,15 @@ Adding a `rel=external` attribute to a link...
 ```
 
 ...will trigger a browser navigation when the link is clicked.
+
+### sapper-noscroll
+
+When navigating to internal links, Sapper will change the scroll position to 0,0 so that the user is at the very top left of the page. When a hash is defined, it will scroll to the element with a matching ID.
+
+In certain cases, you may wish to disable this behaviour. Adding a `sapper-noscroll` attribute to a link...
+
+```html
+<a href='path' sapper-noscroll>Path</a>
+```
+
+...will prevent scrolling after the link is clicked.

--- a/site/content/docs/08-link-options.md
+++ b/site/content/docs/08-link-options.md
@@ -32,14 +32,14 @@ Adding a `rel=external` attribute to a link...
 
 ...will trigger a browser navigation when the link is clicked.
 
-### sapper-noscroll
+### sapper:noscroll
 
 When navigating to internal links, Sapper will change the scroll position to 0,0 so that the user is at the very top left of the page. When a hash is defined, it will scroll to the element with a matching ID.
 
-In certain cases, you may wish to disable this behaviour. Adding a `sapper-noscroll` attribute to a link...
+In certain cases, you may wish to disable this behaviour. Adding a `sapper:noscroll` attribute to a link...
 
 ```html
-<a href='path' sapper-noscroll>Path</a>
+<a href='path' sapper:noscroll>Path</a>
 ```
 
 ...will prevent scrolling after the link is clicked.

--- a/test/apps/scroll/src/routes/search-form.svelte
+++ b/test/apps/scroll/src/routes/search-form.svelte
@@ -1,8 +1,12 @@
 <script>
   import { goto } from "@sapper/app";
 
-  function handleSearch() {
+  function preserveScroll() {
     goto("/a-third-tall-page", { noscroll: true });
+  }
+
+  function scroll() {
+    goto("/a-third-tall-page");
   }
 </script>
 
@@ -11,6 +15,7 @@
 <div style="height: 9999px" />
 
 <div id="search">
-  <button on:click={handleSearch}>Search</button>
+  <button id="scroll" on:click={scroll}>Don't preserve scroll</button>
+  <button id="preserve" on:click={preserveScroll}>Preserve scroll</button>
 </div>
 

--- a/test/apps/scroll/src/routes/search-form.svelte
+++ b/test/apps/scroll/src/routes/search-form.svelte
@@ -1,0 +1,15 @@
+<script>
+	import { goto } from "@sapper/app";
+
+	function handleSearch() {
+		goto("?q=foo");
+	}
+</script>
+
+<h1>A search form</h1>
+
+<div style="height: 9999px"></div>
+
+<div id="search">
+	<button on:click={handleSearch()}>Search</button>
+</div>

--- a/test/apps/scroll/src/routes/search-form.svelte
+++ b/test/apps/scroll/src/routes/search-form.svelte
@@ -1,15 +1,16 @@
 <script>
-	import { goto } from "@sapper/app";
+  import { goto } from "@sapper/app";
 
-	function handleSearch() {
-		goto("?q=foo");
-	}
+  function handleSearch() {
+    goto("/a-third-tall-page", { noscroll: true });
+  }
 </script>
 
 <h1>A search form</h1>
 
-<div style="height: 9999px"></div>
+<div style="height: 9999px" />
 
 <div id="search">
-	<button on:click={handleSearch()}>Search</button>
+  <button on:click={handleSearch}>Search</button>
 </div>
+

--- a/test/apps/scroll/src/routes/search-form.svelte
+++ b/test/apps/scroll/src/routes/search-form.svelte
@@ -1,13 +1,13 @@
 <script>
-  import { goto } from "@sapper/app";
+	import { goto } from "@sapper/app";
 
-  function preserveScroll() {
-    goto("/a-third-tall-page", { noscroll: true });
-  }
+	function preserveScroll() {
+		goto("/a-third-tall-page", { noscroll: true });
+	}
 
-  function scroll() {
-    goto("/a-third-tall-page");
-  }
+	function scroll() {
+		goto("/a-third-tall-page");
+	}
 </script>
 
 <h1>A search form</h1>
@@ -15,7 +15,6 @@
 <div style="height: 9999px" />
 
 <div id="search">
-  <button id="scroll" on:click={scroll}>Don't preserve scroll</button>
-  <button id="preserve" on:click={preserveScroll}>Preserve scroll</button>
+	<button id="scroll" on:click={scroll}>Don't preserve scroll</button>
+	<button id="preserve" on:click={preserveScroll}>Preserve scroll</button>
 </div>
-

--- a/test/apps/scroll/test.ts
+++ b/test/apps/scroll/test.ts
@@ -1,133 +1,133 @@
 import * as assert from 'assert';
-import {build} from '../../../api';
-import {AppRunner} from '../AppRunner';
+import { build } from '../../../api';
+import { AppRunner } from '../AppRunner';
 
-describe('scroll', function () {
-  this.timeout(10000);
+describe('scroll', function() {
+	this.timeout(10000);
 
-  let r: AppRunner;
+	let r: AppRunner;
 
-  // hooks
-  before('build app', () => build({cwd: __dirname}));
-  before('start runner', async () => {
-    r = await new AppRunner().start(__dirname);
-  });
+	// hooks
+	before('build app', () => build({ cwd: __dirname }));
+	before('start runner', async () => {
+		r = await new AppRunner().start(__dirname);
+	});
 
-  after(() => r && r.end());
+	after(() => r && r.end());
 
-  // tests
-  it('scrolls to active deeplink', async () => {
-    await r.load('/tall-page#foo');
-    await r.sapper.start();
+	// tests
+	it('scrolls to active deeplink', async () => {
+		await r.load('/tall-page#foo');
+		await r.sapper.start();
 
-    const scrollY = await r.page.evaluate(() => window.scrollY);
-    assert.ok(scrollY > 0, String(scrollY));
-  });
+		const scrollY = await r.page.evaluate(() => window.scrollY);
+		assert.ok(scrollY > 0, String(scrollY));
+	});
 
-  it('scrolls to any deeplink if it was already active', async () => {
-    await r.load('/tall-page#foo');
-    await r.sapper.start();
+	it('scrolls to any deeplink if it was already active', async () => {
+		await r.load('/tall-page#foo');
+		await r.sapper.start();
 
-    let scrollY = await r.page.evaluate(() => window.scrollY);
-    assert.ok(scrollY > 0, String(scrollY));
+		let scrollY = await r.page.evaluate(() => window.scrollY);
+		assert.ok(scrollY > 0, String(scrollY));
 
-    scrollY = await r.page.evaluate(() => {
-      window.scrollTo(0, 0)
-      return window.scrollY
-    });
-    assert.ok(scrollY === 0, String(scrollY));
+		scrollY = await r.page.evaluate(() => {
+			window.scrollTo(0, 0)
+			return window.scrollY
+		});
+		assert.ok(scrollY === 0, String(scrollY));
 
-    await r.page.click('[href="tall-page#foo"]');
-    scrollY = await r.page.evaluate(() => window.scrollY);
-    assert.ok(scrollY > 0, String(scrollY));
-  });
+		await r.page.click('[href="tall-page#foo"]');
+		scrollY = await r.page.evaluate(() => window.scrollY);
+		assert.ok(scrollY > 0, String(scrollY));
+	});
 
-  it('resets scroll when a link is clicked', async () => {
-    await r.load('/tall-page#foo');
-    await r.sapper.start();
-    await r.sapper.prefetchRoutes();
+	it('resets scroll when a link is clicked', async () => {
+		await r.load('/tall-page#foo');
+		await r.sapper.start();
+		await r.sapper.prefetchRoutes();
 
-    await r.page.click('[href="another-tall-page"]');
-    await r.wait();
+		await r.page.click('[href="another-tall-page"]');
+		await r.wait();
 
-    assert.equal(
-      await r.page.evaluate(() => window.scrollY),
-      0
-    );
-  });
+		assert.equal(
+			await r.page.evaluate(() => window.scrollY),
+			0
+		);
+	});
 
-  it('preserves scroll when a link with sapper-noscroll is clicked', async () => {
-    await r.load('/tall-page#foo');
-    await r.sapper.start();
-    await r.sapper.prefetchRoutes();
+	it('preserves scroll when a link with sapper-noscroll is clicked', async () => {
+		await r.load('/tall-page#foo');
+		await r.sapper.start();
+		await r.sapper.prefetchRoutes();
 
-    await r.page.click('[href="another-tall-page"][sapper-noscroll]');
-    await r.wait();
+		await r.page.click('[href="another-tall-page"][sapper-noscroll]');
+		await r.wait();
 
-    const scrollY = await r.page.evaluate(() => window.scrollY);
+		const scrollY = await r.page.evaluate(() => window.scrollY);
 
-    assert.ok(scrollY > 0);
-  });
+		assert.ok(scrollY > 0);
+	});
 
-  it('scrolls into a deeplink on a new page', async () => {
-    await r.load('/tall-page#foo');
-    await r.sapper.start();
-    await r.sapper.prefetchRoutes();
+	it('scrolls into a deeplink on a new page', async () => {
+		await r.load('/tall-page#foo');
+		await r.sapper.start();
+		await r.sapper.prefetchRoutes();
 
-    await r.page.click('[href="another-tall-page#bar"]');
-    await r.wait();
-    assert.equal(await r.text('h1'), 'Another tall page');
-    const scrollY = await r.page.evaluate(() => window.scrollY);
-    assert.ok(scrollY > 0);
-  });
+		await r.page.click('[href="another-tall-page#bar"]');
+		await r.wait();
+		assert.equal(await r.text('h1'), 'Another tall page');
+		const scrollY = await r.page.evaluate(() => window.scrollY);
+		assert.ok(scrollY > 0);
+	});
 
-  it('scrolls to a deeplink on a new page no matter the previous scroll position', async () => {
-    await r.load('/a-third-tall-page#top');
-    await r.sapper.start();
-    await r.sapper.prefetchRoutes();
+	it('scrolls to a deeplink on a new page no matter the previous scroll position', async () => {
+		await r.load('/a-third-tall-page#top');
+		await r.sapper.start();
+		await r.sapper.prefetchRoutes();
 
-    await r.page.click('a#top');
-    await r.wait();
-    const firstScrollY = await r.page.evaluate(() => window.scrollY);
+		await r.page.click('a#top');
+		await r.wait();
+		const firstScrollY = await r.page.evaluate(() => window.scrollY);
 
-    await r.load('/a-third-tall-page#bottom');
-    await r.sapper.start();
-    await r.sapper.prefetchRoutes();
+		await r.load('/a-third-tall-page#bottom');
+		await r.sapper.start();
+		await r.sapper.prefetchRoutes();
 
-    await r.page.click('a#bottom');
-    await r.wait();
-    const secondScrollY = await r.page.evaluate(() => window.scrollY);
+		await r.page.click('a#bottom');
+		await r.wait();
+		const secondScrollY = await r.page.evaluate(() => window.scrollY);
 
-    assert.equal(firstScrollY, secondScrollY);
+		assert.equal(firstScrollY, secondScrollY);
   });
 
   it('scrolls to the top when navigating with goto', async () => {
-    await r.load(`/search-form#search`);
-    await r.sapper.start();
+      await r.load(`/search-form#search`);
+      await r.sapper.start();
 
-    let initialScrollY = await r.page.evaluate(() => window.scrollY);
-    assert.ok(initialScrollY > 0, String(initialScrollY));
+      let initialScrollY = await r.page.evaluate(() => window.scrollY);
+      assert.ok(initialScrollY > 0, String(initialScrollY));
 
-    await r.page.click("button#scroll");
+      await r.page.click(`button#scroll`);
 
-    let scrollY = await r.page.evaluate(() => window.scrollY);
-    assert.ok(scrollY === 0, String(scrollY));
+      let scrollY = await r.page.evaluate(() => window.scrollY);
+      assert.ok(scrollY === 0, String(scrollY));
   });
 
   it('preserves scroll when noscroll: true is passed to goto', async () => {
-    await r.load(`/search-form#search`);
-    await r.sapper.start();
+      await r.load(`/search-form#search`);
+      await r.sapper.start();
 
-    let initialScrollY = await r.page.evaluate(() => window.scrollY);
-    assert.ok(initialScrollY > 0, String(initialScrollY));
+      let initialScrollY = await r.page.evaluate(() => window.scrollY);
+      assert.ok(initialScrollY > 0, String(initialScrollY));
 
-    await r.page.click("button#preserve");
+      await r.page.click(`button#preserve`);
 
-    let scrollY = await r.page.evaluate(() => window.scrollY);
-    assert.ok(scrollY === initialScrollY, String(scrollY));
+      let scrollY = await r.page.evaluate(() => window.scrollY);
+      assert.ok(scrollY === initialScrollY, String(scrollY));
   });
 
-  it('survives the tests with no server errors', () => {
-    assert.deepEqual(r.errors, []);
-  });
+	it('survives the tests with no server errors', () => {
+		assert.deepEqual(r.errors, []);
+	});
 });

--- a/test/apps/scroll/test.ts
+++ b/test/apps/scroll/test.ts
@@ -102,29 +102,29 @@ describe('scroll', function() {
   });
 
   it('scrolls to the top when navigating with goto', async () => {
-      await r.load(`/search-form#search`);
-      await r.sapper.start();
+	  await r.load(`/search-form#search`);
+	  await r.sapper.start();
 
-      let initialScrollY = await r.page.evaluate(() => window.scrollY);
-      assert.ok(initialScrollY > 0, String(initialScrollY));
+	  let initialScrollY = await r.page.evaluate(() => window.scrollY);
+	  assert.ok(initialScrollY > 0, String(initialScrollY));
 
-      await r.page.click(`button#scroll`);
+	  await r.page.click(`button#scroll`);
 
-      let scrollY = await r.page.evaluate(() => window.scrollY);
-      assert.ok(scrollY === 0, String(scrollY));
+	  let scrollY = await r.page.evaluate(() => window.scrollY);
+	  assert.ok(scrollY === 0, String(scrollY));
   });
 
   it('preserves scroll when noscroll: true is passed to goto', async () => {
-      await r.load(`/search-form#search`);
-      await r.sapper.start();
+	  await r.load(`/search-form#search`);
+	  await r.sapper.start();
 
-      let initialScrollY = await r.page.evaluate(() => window.scrollY);
-      assert.ok(initialScrollY > 0, String(initialScrollY));
+	  let initialScrollY = await r.page.evaluate(() => window.scrollY);
+	  assert.ok(initialScrollY > 0, String(initialScrollY));
 
-      await r.page.click(`button#preserve`);
+	  await r.page.click(`button#preserve`);
 
-      let scrollY = await r.page.evaluate(() => window.scrollY);
-      assert.ok(scrollY === initialScrollY, String(scrollY));
+	  let scrollY = await r.page.evaluate(() => window.scrollY);
+	  assert.ok(scrollY === initialScrollY, String(scrollY));
   });
 
 	it('survives the tests with no server errors', () => {

--- a/test/apps/scroll/test.ts
+++ b/test/apps/scroll/test.ts
@@ -101,14 +101,27 @@ describe('scroll', function () {
     assert.equal(firstScrollY, secondScrollY);
   });
 
-  it('preserves scroll when noscroll is passed to goto', async () => {
+  it('scrolls to the top when navigating with goto', async () => {
     await r.load(`/search-form#search`);
     await r.sapper.start();
 
     let initialScrollY = await r.page.evaluate(() => window.scrollY);
     assert.ok(initialScrollY > 0, String(initialScrollY));
 
-    await r.page.click("button");
+    await r.page.click("button#scroll");
+
+    let scrollY = await r.page.evaluate(() => window.scrollY);
+    assert.ok(scrollY === 0, String(scrollY));
+  });
+
+  it('preserves scroll when noscroll: true is passed to goto', async () => {
+    await r.load(`/search-form#search`);
+    await r.sapper.start();
+
+    let initialScrollY = await r.page.evaluate(() => window.scrollY);
+    assert.ok(initialScrollY > 0, String(initialScrollY));
+
+    await r.page.click("button#preserve");
 
     let scrollY = await r.page.evaluate(() => window.scrollY);
     assert.ok(scrollY === initialScrollY, String(scrollY));

--- a/test/apps/scroll/test.ts
+++ b/test/apps/scroll/test.ts
@@ -101,20 +101,20 @@ describe('scroll', function () {
     assert.equal(firstScrollY, secondScrollY);
   });
 
-  it('survives the tests with no server errors', () => {
-    assert.deepEqual(r.errors, []);
-  });
-
   it('preserves scroll when noscroll is passed to goto', async () => {
     await r.load(`/search-form#search`);
     await r.sapper.start();
 
-    let scrollY = await r.page.evaluate(() => window.scrollY);
-    assert.ok(scrollY > 0, String(scrollY));
+    let initialScrollY = await r.page.evaluate(() => window.scrollY);
+    assert.ok(initialScrollY > 0, String(initialScrollY));
 
     await r.page.click("button");
 
-    scrollY = await r.page.evaluate(() => window.scrollY);
-    assert.ok(scrollY > 0, String(scrollY));
+    let scrollY = await r.page.evaluate(() => window.scrollY);
+    assert.ok(scrollY === initialScrollY, String(scrollY));
+  });
+
+  it('survives the tests with no server errors', () => {
+    assert.deepEqual(r.errors, []);
   });
 });

--- a/test/apps/scroll/test.ts
+++ b/test/apps/scroll/test.ts
@@ -1,107 +1,120 @@
 import * as assert from 'assert';
-import { build } from '../../../api';
-import { AppRunner } from '../AppRunner';
+import {build} from '../../../api';
+import {AppRunner} from '../AppRunner';
 
-describe('scroll', function() {
-	this.timeout(10000);
+describe('scroll', function () {
+  this.timeout(10000);
 
-	let r: AppRunner;
+  let r: AppRunner;
 
-	// hooks
-	before('build app', () => build({ cwd: __dirname }));
-	before('start runner', async () => {
-		r = await new AppRunner().start(__dirname);
-	});
+  // hooks
+  before('build app', () => build({cwd: __dirname}));
+  before('start runner', async () => {
+    r = await new AppRunner().start(__dirname);
+  });
 
-	after(() => r && r.end());
+  after(() => r && r.end());
 
-	// tests
-	it('scrolls to active deeplink', async () => {
-		await r.load('/tall-page#foo');
-		await r.sapper.start();
+  // tests
+  it('scrolls to active deeplink', async () => {
+    await r.load('/tall-page#foo');
+    await r.sapper.start();
 
-		const scrollY = await r.page.evaluate(() => window.scrollY);
-		assert.ok(scrollY > 0, String(scrollY));
-	});
+    const scrollY = await r.page.evaluate(() => window.scrollY);
+    assert.ok(scrollY > 0, String(scrollY));
+  });
 
-	it('scrolls to any deeplink if it was already active', async () => {
-		await r.load('/tall-page#foo');
-		await r.sapper.start();
+  it('scrolls to any deeplink if it was already active', async () => {
+    await r.load('/tall-page#foo');
+    await r.sapper.start();
 
-		let scrollY = await r.page.evaluate(() => window.scrollY);
-		assert.ok(scrollY > 0, String(scrollY));
+    let scrollY = await r.page.evaluate(() => window.scrollY);
+    assert.ok(scrollY > 0, String(scrollY));
 
-		scrollY = await r.page.evaluate(() => {
-			window.scrollTo(0, 0)
-			return window.scrollY
-		});
-		assert.ok(scrollY === 0, String(scrollY));
+    scrollY = await r.page.evaluate(() => {
+      window.scrollTo(0, 0)
+      return window.scrollY
+    });
+    assert.ok(scrollY === 0, String(scrollY));
 
-		await r.page.click('[href="tall-page#foo"]');
-		scrollY = await r.page.evaluate(() => window.scrollY);
-		assert.ok(scrollY > 0, String(scrollY));
-	});
+    await r.page.click('[href="tall-page#foo"]');
+    scrollY = await r.page.evaluate(() => window.scrollY);
+    assert.ok(scrollY > 0, String(scrollY));
+  });
 
-	it('resets scroll when a link is clicked', async () => {
-		await r.load('/tall-page#foo');
-		await r.sapper.start();
-		await r.sapper.prefetchRoutes();
+  it('resets scroll when a link is clicked', async () => {
+    await r.load('/tall-page#foo');
+    await r.sapper.start();
+    await r.sapper.prefetchRoutes();
 
-		await r.page.click('[href="another-tall-page"]');
-		await r.wait();
+    await r.page.click('[href="another-tall-page"]');
+    await r.wait();
 
-		assert.equal(
-			await r.page.evaluate(() => window.scrollY),
-			0
-		);
-	});
+    assert.equal(
+      await r.page.evaluate(() => window.scrollY),
+      0
+    );
+  });
 
-	it('preserves scroll when a link with sapper-noscroll is clicked', async () => {
-		await r.load('/tall-page#foo');
-		await r.sapper.start();
-		await r.sapper.prefetchRoutes();
+  it('preserves scroll when a link with sapper-noscroll is clicked', async () => {
+    await r.load('/tall-page#foo');
+    await r.sapper.start();
+    await r.sapper.prefetchRoutes();
 
-		await r.page.click('[href="another-tall-page"][sapper-noscroll]');
-		await r.wait();
+    await r.page.click('[href="another-tall-page"][sapper-noscroll]');
+    await r.wait();
 
-		const scrollY = await r.page.evaluate(() => window.scrollY);
+    const scrollY = await r.page.evaluate(() => window.scrollY);
 
-		assert.ok(scrollY > 0);
-	});
+    assert.ok(scrollY > 0);
+  });
 
-	it('scrolls into a deeplink on a new page', async () => {
-		await r.load('/tall-page#foo');
-		await r.sapper.start();
-		await r.sapper.prefetchRoutes();
+  it('scrolls into a deeplink on a new page', async () => {
+    await r.load('/tall-page#foo');
+    await r.sapper.start();
+    await r.sapper.prefetchRoutes();
 
-		await r.page.click('[href="another-tall-page#bar"]');
-		await r.wait();
-		assert.equal(await r.text('h1'), 'Another tall page');
-		const scrollY = await r.page.evaluate(() => window.scrollY);
-		assert.ok(scrollY > 0);
-	});
+    await r.page.click('[href="another-tall-page#bar"]');
+    await r.wait();
+    assert.equal(await r.text('h1'), 'Another tall page');
+    const scrollY = await r.page.evaluate(() => window.scrollY);
+    assert.ok(scrollY > 0);
+  });
 
-	it('scrolls to a deeplink on a new page no matter the previous scroll position', async () => {
-		await r.load('/a-third-tall-page#top');
-		await r.sapper.start();
-		await r.sapper.prefetchRoutes();
+  it('scrolls to a deeplink on a new page no matter the previous scroll position', async () => {
+    await r.load('/a-third-tall-page#top');
+    await r.sapper.start();
+    await r.sapper.prefetchRoutes();
 
-		await r.page.click('a#top');
-		await r.wait();
-		const firstScrollY = await r.page.evaluate(() => window.scrollY);
+    await r.page.click('a#top');
+    await r.wait();
+    const firstScrollY = await r.page.evaluate(() => window.scrollY);
 
-		await r.load('/a-third-tall-page#bottom');
-		await r.sapper.start();
-		await r.sapper.prefetchRoutes();
+    await r.load('/a-third-tall-page#bottom');
+    await r.sapper.start();
+    await r.sapper.prefetchRoutes();
 
-		await r.page.click('a#bottom');
-		await r.wait();
-		const secondScrollY = await r.page.evaluate(() => window.scrollY);
+    await r.page.click('a#bottom');
+    await r.wait();
+    const secondScrollY = await r.page.evaluate(() => window.scrollY);
 
-		assert.equal(firstScrollY, secondScrollY);
-	});
+    assert.equal(firstScrollY, secondScrollY);
+  });
 
-	it('survives the tests with no server errors', () => {
-		assert.deepEqual(r.errors, []);
-	});
+  it('survives the tests with no server errors', () => {
+    assert.deepEqual(r.errors, []);
+  });
+
+  it('preserves scroll when noscroll is passed to goto', async () => {
+    await r.load(`/search-form#search`);
+    await r.sapper.start();
+
+    let scrollY = await r.page.evaluate(() => window.scrollY);
+    assert.ok(scrollY > 0, String(scrollY));
+
+    await r.page.click("button");
+
+    scrollY = await r.page.evaluate(() => window.scrollY);
+    assert.ok(scrollY > 0, String(scrollY));
+  });
 });


### PR DESCRIPTION
This adds an option to `goto` - `noscroll: boolean` - which allows preservation of scroll position when navigating programmatically.

`noscroll` already exists as an option on `navigate`, and this just passes the option through to that underlying method.

I've added tests that show the default behaviour when using `goto` (scrolling to the top), and the preservation behaviour when the option is passed.

This implements https://github.com/sveltejs/sapper/issues/584

**Note**: In working on this, I discovered a bug in `goto`/`navigate` - the scroll position is not preserved when using `noscroll: true` when only the search params are updated (not the pathname). I will add a separate issue for this.

edit: [added issue with test cases](https://github.com/sveltejs/sapper/issues/1321)

### Before submitting the PR, please make sure you do the following
- [-] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [-] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [-] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [-] Run the tests tests with `npm test` or `yarn test`)
