### PR TITLE
Rollup: Explicitly set `output.exports`

### DIFF
--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -148,8 +148,12 @@ export default class RollupCompiler {
 			}
 		});
 
-		const resp = await bundle.generate({ format: 'cjs' });
-		const { code } = resp.output ? resp.output[0] : resp;
+		const {
+			output: [{ code }]
+		} = await bundle.generate({
+			exports: 'named',
+			format: 'cjs'
+		});
 
 		// temporarily override require
 		const defaultLoader = require.extensions['.js'];
@@ -161,7 +165,7 @@ export default class RollupCompiler {
 			}
 		};
 
-		const config: any = require(input);
+		const config: any = require(input).default;
 		delete require.cache[input];
 
 		return config;


### PR DESCRIPTION
Currently, when running a freshly installed Sapper project with Rollup, the following message is displayed:
>Entry module "rollup.config.js" is implicitly using "default" export mode, which means for CommonJS output that its default export is assigned to "module.exports". For many tools, such CommonJS output will not be interchangeable with the original ES module. If this is intended, explicitly set "output.exports" to either "auto" or "default", otherwise you might want to consider changing the signature of "rollup.config.js" to use named exports only.

This pull request explicitly sets `output.exports` to get rid of the above message.