### PR TITLE
Suppress warning in rollup@^2.22.0

### DIFF
--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -148,7 +148,7 @@ export default class RollupCompiler {
 			}
 		});
 
-		const resp = await bundle.generate({ format: 'cjs' });
+		const resp = await bundle.generate({ format: 'cjs', exports: 'auto' });
 		const { code } = resp.output ? resp.output[0] : resp;
 
 		// temporarily override require


### PR DESCRIPTION
This small change suppresses warnings when using rollup versions 2.22.0 and higher about the default export used in rollup.config.js.

No tests needed since `exports: 'auto'` is the default already, it just needs to be stated explicitly.
