### PR TITLE
Preload context configuration

### DIFF
--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -20,6 +20,8 @@ import {
 import goto from './goto';
 import { page_store } from './stores';
 
+export type ClientPreloadConfigurator = (args: {context: object}) => void;
+
 declare const __SAPPER__;
 export const initial_data = typeof __SAPPER__ !== 'undefined' && __SAPPER__;
 
@@ -67,8 +69,10 @@ export function set_prefetching(href, promise) {
 }
 
 export let target: Element;
-export function set_target(element) {
-	target = element;
+let preload_configurator: ClientPreloadConfigurator;
+export function set_options(opts) {
+	target = opts.target;
+	preload_configurator = opts.preloadConfigurator || (() => {});
 }
 
 export let uid = 1;
@@ -294,6 +298,8 @@ export async function hydrate_target(dest: Target): Promise<HydratedTarget> {
 			props.status = status;
 		}
 	};
+
+	preload_configurator({context: preload_context, ...stores});
 
 	if (!root_preloaded) {
 		const root_preload = root_comp.preload || (() => {});

--- a/runtime/src/app/start/index.ts
+++ b/runtime/src/app/start/index.ts
@@ -7,15 +7,17 @@ import {
 	scroll_state,
 	select_target,
 	handle_error,
-	set_target,
+	set_options,
 	uid,
 	set_uid,
-	set_cid
+	set_cid,
+	ClientPreloadConfigurator
 } from '../app';
 import prefetch from '../prefetch/index';
 
 export default function start(opts: {
-	target: Node
+	target: Node,
+	preloadConfigurator: ClientPreloadConfigurator
 }): Promise<void> {
 	if ('scrollRestoration' in history) {
 		history.scrollRestoration = 'manual';
@@ -34,7 +36,7 @@ export default function start(opts: {
 		history.scrollRestoration = 'manual';
 	});
 
-	set_target(opts.target);
+	set_options(opts);
 
 	addEventListener('click', handle_click);
 	addEventListener('popstate', handle_popstate);

--- a/runtime/src/server/index.ts
+++ b/runtime/src/server/index.ts
@@ -1,1 +1,2 @@
+export { server_fetch as fetch } from './middleware/get_page_handler';
 export { default as middleware } from './middleware/index';

--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -6,12 +6,14 @@ import { get_server_route_handler } from './get_server_route_handler';
 import { get_page_handler } from './get_page_handler';
 
 type IgnoreValue = IgnoreValue[] | RegExp | ((uri: string) => boolean) | string;
+type ServerPreloadConfigurator = (args: {context: object; req: Req; res: Res}) => void;
 
 export default function middleware(opts: {
 	session?: (req: Req, res: Res) => any,
-	ignore?: IgnoreValue
+	ignore?: IgnoreValue,
+	preloadConfigurator?: ServerPreloadConfigurator
 } = {}) {
-	const { session, ignore } = opts;
+	const { session, ignore, preloadConfigurator } = opts;
 
 	let emitted_basepath = false;
 
@@ -62,7 +64,7 @@ export default function middleware(opts: {
 
 		get_server_route_handler(manifest.server_routes),
 
-		get_page_handler(manifest, session || noop)
+		get_page_handler(manifest, session || noop, preloadConfigurator || (() => {}))
 	].filter(Boolean));
 }
 


### PR DESCRIPTION
This makes a lot of things easier:
* Distributed tracing - add a header to every request to trace requests from frontend all the way to datastore (requested by @adamb on Discord. difficulty setting up honeycomb.io also mentioned in https://github.com/sveltejs/sapper/issues/751)
* Using an internal hostname on the server-side (that's what I want this for. my api server is written in another language)
* Using `fetch` in setup - e.g. to setup Apollo client (https://github.com/sveltejs/sapper/issues/1243 https://github.com/sveltejs/sapper/issues/751)
* Specifying a base URL (https://github.com/sveltejs/sapper/issues/489)
* Using a UNIX socket for AWS Lambda (https://github.com/sveltejs/sapper/issues/356)
* Ability to wrap `fetch` (https://github.com/sveltejs/sapper/issues/908)
* It currently requests only over HTTP. A user on Discord reported this wouldn't work with his server than listens only on port 443
* Accessing Polka request on server (https://github.com/sveltejs/sapper/issues/1436)

This was also somewhat suggested by @Conduitry in https://github.com/sveltejs/sapper/issues/908#issuecomment-533636138

I exported the default fetch method so that users can do their own logic first (modifying the URL, logging the request, setting a header, etc.) and then call the default fetch method.