### PR TITLE
Fix for situations where you want to execute a popevent handler before page transitions start

### DIFF
--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -377,11 +377,17 @@ export function load_component(component: ComponentLoader): Promise<{
 	default: ComponentConstructor,
 	preload?: (input: any) => any
 }> {
-	// TODO this is temporary — once placeholders are
-	// always rewritten, scratch the ternary
-	const promises: Array<Promise<any>> = (typeof component.css === 'string' ? [] : component.css.map(load_css));
-	promises.unshift(component.js());
-	return Promise.all(promises).then(values => values[0]);
+  // TODO this is temporary — once placeholders are
+  // always rewritten, scratch the ternary
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      // This setTimeout assures that when component is already loaded by webpack, the call stack will be executed in the same order as if it is not.
+      // This fix situations where you want to do page transitions but at the simetime you have to execute code on popstate event before the transition begins
+      const promises: Array<Promise<any>> = (typeof component.css === 'string' ? [] : component.css.map(load_css));
+      promises.unshift(component.js());
+      resolve(Promise.all(promises).then((values) => values[0]));
+    });
+  });
 }
 
 function detach(node: Node) {

--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -382,7 +382,7 @@ export function load_component(component: ComponentLoader): Promise<{
   return new Promise((resolve) => {
     setTimeout(() => {
       // This setTimeout assures that when component is already loaded by webpack, the call stack will be executed in the same order as if it is not.
-      // This fix situations where you want to do page transitions but at the simetime you have to execute code on popstate event before the transition begins
+      // This fix situations where you want to do page transitions but at the sametime you have to execute code on popstate event before the transition begins
       const promises: Array<Promise<any>> = (typeof component.css === 'string' ? [] : component.css.map(load_css));
       promises.unshift(component.js());
       resolve(Promise.all(promises).then((values) => values[0]));


### PR DESCRIPTION
When trying to execute code on popstate event, components transitions start before the popevent handler is executed whenever the component is already loaded.

What i'm trying to do is reversing the direction of my transition when the user clicks the back button:

**My popevent handler**
```
  function onPopState(e: PopStateEvent) {
    console.log("my pop event handler");
    if (window.location.href.includes("login")) $isHistoryBack$ = true;
  }

  onMount(() => {
    window.addEventListener("popstate", onPopState);

    ready = true;
  });
```

**My component**
```
  let reverse = false;
  let isHistoryBack$ = getPageContext().isHistoryBack$;
  $: reverse = $isHistoryBack$;
```
```
<div out:leaveEnter={{ direction: reverse ? 'enter' : 'leave' }} in:leaveEnter={{ direction: reverse ? 'leave' : 'enter' }}>
  ...
</div>
```

**Before fix rendering logs:**
![before-fix](https://user-images.githubusercontent.com/53383860/88482637-dfff0c00-cf62-11ea-971c-1d953bdbac47.png)
![before-fix](https://user-images.githubusercontent.com/53383860/88482816-feb1d280-cf63-11ea-8b6c-4938149f1c43.gif)

**After fix rendering logs:**
![after-fix](https://user-images.githubusercontent.com/53383860/88482639-e42b2980-cf62-11ea-8854-bb4ee5c1598a.png)
![after-fix](https://user-images.githubusercontent.com/53383860/88482827-0a9d9480-cf64-11ea-8e64-fc14e2ddf944.gif)

