### PR TITLE
Set publicPath for webpack server bundle

### DIFF
--- a/src/config/webpack.ts
+++ b/src/config/webpack.ts
@@ -32,6 +32,7 @@ export default {
 				path: `${dest}/server`,
 				filename: '[name].js',
 				chunkFilename: '[hash]/[name].[id].js',
+				publicPath: `client/`,
 				libraryTarget: 'commonjs2'
 			};
 		}


### PR DESCRIPTION
This makes the `server` config match the `client` config and is required in order to use Webpack's `file-loader` with SSR rendering. Using Webpack without the `file-loader` works with or without this line