### PR TITLE
Fix typing issues in core files

### DIFF
--- a/src/api/build.ts
+++ b/src/api/build.ts
@@ -63,7 +63,7 @@ export async function build({
 
 	// remove this in a future version
 	if (template.indexOf('%sapper.base%') === -1) {
-		const error = new Error(`As of Sapper v0.10, your template.html file must include %sapper.base% in the <head>`);
+		const error: NodeJS.ErrnoException = new Error(`As of Sapper v0.10, your template.html file must include %sapper.base% in the <head>`);
 		error.code = `missing-sapper-base`;
 		throw error;
 	}

--- a/src/api/build.ts
+++ b/src/api/build.ts
@@ -61,13 +61,6 @@ export async function build({
 	// TODO compile this to a function? could be quicker than str.replace(...).replace(...).replace(...)
 	const template = read_template(src);
 
-	// remove this in a future version
-	if (template.indexOf('%sapper.base%') === -1) {
-		const error: NodeJS.ErrnoException = new Error(`As of Sapper v0.10, your template.html file must include %sapper.base% in the <head>`);
-		error.code = `missing-sapper-base`;
-		throw error;
-	}
-
 	fs.writeFileSync(`${dest}/template.html`, minify_html(template));
 
 	const manifest_data = create_manifest_data(routes, ext);

--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -120,7 +120,7 @@ class Watcher extends EventEmitter {
 		// remove this in a future version
 		const template = read_template(src);
 		if (template.indexOf('%sapper.base%') === -1) {
-			const error = new Error(`As of Sapper v0.10, your template.html file must include %sapper.base% in the <head>`);
+			const error: NodeJS.ErrnoException = new Error(`As of Sapper v0.10, your template.html file must include %sapper.base% in the <head>`);
 			error.code = `missing-sapper-base`;
 			throw error;
 		}

--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -11,7 +11,6 @@ import Deferred from './utils/Deferred';
 import validate_bundler from './utils/validate_bundler';
 import { copy_shimport } from './utils/copy_shimport';
 import { ManifestData, FatalEvent, ErrorEvent, ReadyEvent, InvalidEvent } from '../interfaces';
-import read_template from '../core/read_template';
 import { noop } from './utils/noop';
 import { copy_runtime } from './utils/copy_runtime';
 import { rimraf, mkdirp } from './utils/fs_utils';
@@ -116,14 +115,6 @@ class Watcher extends EventEmitter {
 			unique_errors: new Set(),
 			unique_warnings: new Set()
 		};
-
-		// remove this in a future version
-		const template = read_template(src);
-		if (template.indexOf('%sapper.base%') === -1) {
-			const error: NodeJS.ErrnoException = new Error(`As of Sapper v0.10, your template.html file must include %sapper.base% in the <head>`);
-			error.code = `missing-sapper-base`;
-			throw error;
-		}
 
 		process.env.NODE_ENV = 'development';
 

--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import color from 'kleur';
 import relative from 'require-relative';
-import { RollupError } from 'rollup/types';
+import { InputOption, RollupError } from 'rollup';
 import { CompileResult } from './interfaces';
 import RollupResult from './RollupResult';
 
@@ -13,7 +13,7 @@ export default class RollupCompiler {
 	_: Promise<any>;
 	_oninvalid: (filename: string) => void;
 	_start: number;
-	input: string;
+	input: InputOption;
 	warnings: any[];
 	errors: any[];
 	chunks: any[];

--- a/src/core/create_compilers/interfaces.ts
+++ b/src/core/create_compilers/interfaces.ts
@@ -23,6 +23,7 @@ export interface CompileResult {
 	chunks: Chunk[];
 	assets: Record<string, string>;
 	css_files: CssFile[];
+	print: () => void;
 
 	to_json: (manifest_data: ManifestData, dirs: Dirs) => BuildInfo
 }
@@ -31,7 +32,7 @@ export type BuildInfo = {
 	bundler: string;
 	shimport: string;
 	assets: Record<string, string>;
-	dependencies: Record<string, string[]>;
+	dependencies?: Record<string, string[]>;
 	legacy_assets?: Record<string, string>;
 	css: {
 		main: string | null,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -68,11 +68,19 @@ export type ReadyEvent = {
 
 export type ErrorEvent = {
 	type: string;
-	error: Error;
+	error: Error & {
+		frame?: unknown;
+		loc?: {
+			file?: string;
+			line: number;
+			column: number;
+		};
+	};
 };
 
 export type FatalEvent = {
 	message: string;
+	log?: unknown;
 };
 
 export type InvalidEvent = {


### PR DESCRIPTION
These changes are necessary to turn on basic type checking. It turns out that despite using TypeScript we don't actually get any of its benefits in terms of safety today.

I'm splitting this PR into multiple because otherwise it's just too big and unwieldy to review. There's a larger set of changes I'll send later fix issues in the `runtime` directory and turn on the checks after working through some final issues. I stole most of these changes from @ajbouh who went much further than this in turning on many additional checks, but I'm trying to do the bare minimum to use TypeScript with all the checks turned off to keep the PR small