### PR TITLE
Consolidate migration info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,7 @@
 * 🎉 TypeScript support! 🎉
 * 🎉 Asset `preload` headers for Rollup projects 🎉
 
-And these breaking changes:
-
-* Sapper now requires at least Rollup 1
-* IE 9 support dropped for Webpack projects. `script` tag will now be loaded with `defer` attribute and IE9 may interleave script execution.
-* You must set `hydratable: true` to hydrate `<head>` elements ([#1067](https://github.com/sveltejs/sapper/pull/1067))
-* The files in the generated `service-worker.js` file are now prefixed with a `/` ([#1244](https://github.com/sveltejs/sapper/pull/1244))
-* The `sapper-noscroll` attribute was renamed to `sapper:noscroll` ([#1320](https://github.com/sveltejs/sapper/pull/1320))
+Please see the ([migration guide](https://sapper.svelte.dev/migrating#0_27_to_0_28)) for details on a number of small breaking changes that were made in this release.
 
 Also:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,18 @@
 * 🎉 TypeScript support! 🎉
 * 🎉 Asset `preload` headers for Rollup projects 🎉
 
-Please see the ([migration guide](https://sapper.svelte.dev/migrating#0_27_to_0_28)) for details on a number of small breaking changes that were made in this release.
+Please see the ([migration guide](https://sapper.svelte.dev/migrating#0_27_to_0_28)) for details on migrating from Sapper 0.27 to Sapper 0.28.
 
 Also:
 
+* Explicitly set `output.exports` to avoid warning from Rollup ([#1326](https://github.com/sveltejs/sapper/pull/1326))
+* `<script>` tags will now be loaded with the `defer` attribute ([#1123](https://github.com/sveltejs/sapper/pull/1123))
+* The `<head>` element hydration workaround was removed ([#1067](https://github.com/sveltejs/sapper/pull/1067))
+* The files in the generated `service-worker.js` file are now prefixed with a `/` ([#1244](https://github.com/sveltejs/sapper/pull/1244)).
+* The `sapper-noscroll` attribute was renamed to `sapper:noscroll` ([#1320](https://github.com/sveltejs/sapper/pull/1320))
 * Fix handling of routes beginning with /client/ ([#1142](https://github.com/sveltejs/sapper/issues/1142))
 * Fix path normalization of chunks on Windows ([#1256](https://github.com/sveltejs/sapper/issues/1256), [#1333](https://github.com/sveltejs/sapper/issues/1333))
 * Fix CSS splitting when using Rollup 2 ([#1306](https://github.com/sveltejs/sapper/pull/1306))
-* Explicitly set `output.exports` to avoid warning from Rollup ([#1326](https://github.com/sveltejs/sapper/pull/1326))
 * Set `publicPath` in webpack server config for benefit of `file-loader` ([#1342](https://github.com/sveltejs/sapper/pull/1342))
 * Detect presence of `preload` at runtime, so we don't need to worry about preprocessors and compiling components when doing so ([#1344](https://github.com/sveltejs/sapper/pull/1344))
 * Load `script` tag with `defer` attribute in Webpack projects ([#1123](https://github.com/sveltejs/sapper/pull/1123))

--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -8,7 +8,13 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 
 ### 0.27 to 0.28
 
-`%sapper.scripts%` can be moved to the `<head>` section for slightly better performance because it now uses deferred loading
+* Sapper now requires at least Rollup 1
+* `script` tag will now be loaded with `defer` attribute ([#1123](https://github.com/sveltejs/sapper/pull/1123)) which means:
+	* IE 9 support wasdropped since IE9 may interleave deferred script execution.
+	* `%sapper.scripts%` can be moved to the `<head>` section for slightly better performance
+* You must set `hydratable: true` to hydrate `<head>` elements ([#1067](https://github.com/sveltejs/sapper/pull/1067))
+* The files in the generated `service-worker.js` file are now prefixed with a `/` ([#1244](https://github.com/sveltejs/sapper/pull/1244))
+* The `sapper-noscroll` attribute was renamed to `sapper:noscroll` ([#1320](https://github.com/sveltejs/sapper/pull/1320))
 
 ### 0.25 to 0.26
 

--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -10,7 +10,7 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 
 * Sapper dropped support for Rollup 0.x.x. <br>Any version greater than 1.x is supported but the latest (currently 2.x) is strongly recommended.
 * `<script>` tags will now be loaded with the `defer` attribute ([#1123](https://github.com/sveltejs/sapper/pull/1123)), which means:
-	* IE 9 support was dropped since IE9 may interleave deferred script execution.
+	* IE9 support was dropped since IE9 may interleave deferred script execution. 
 	* `%sapper.scripts%` can be moved to the `<head>` section for slightly better performance
 * You must set `hydratable: true` to hydrate `<head>` elements ([#1067](https://github.com/sveltejs/sapper/pull/1067))
 * The files in the generated `service-worker.js` file are now prefixed with a `/` ([#1244](https://github.com/sveltejs/sapper/pull/1244)). If you are using the `service-worker.js` from the default template, no changes will be necessary. If you have modified your service worker, please check to ensure compatibility.

--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -8,7 +8,7 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 
 ### 0.27 to 0.28
 
-* Sapper now requires at least Rollup 1
+* Sapper dropped support for Rollup 0.x.x. <br>Any version greater than 1.x is supported but the latest (currently 2.x) is strongly recommended.
 * `script` tag will now be loaded with `defer` attribute ([#1123](https://github.com/sveltejs/sapper/pull/1123)) which means:
 	* IE 9 support wasdropped since IE9 may interleave deferred script execution.
 	* `%sapper.scripts%` can be moved to the `<head>` section for slightly better performance

--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -9,7 +9,7 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 ### 0.27 to 0.28
 
 * Sapper dropped support for Rollup 0.x.x. <br>Any version greater than 1.x is supported but the latest (currently 2.x) is strongly recommended.
-* `script` tags will now be loaded with the `defer` attribute ([#1123](https://github.com/sveltejs/sapper/pull/1123)) which means:
+* `<script>` tags will now be loaded with the `defer` attribute ([#1123](https://github.com/sveltejs/sapper/pull/1123)), which means:
 	* IE 9 support was dropped since IE9 may interleave deferred script execution.
 	* `%sapper.scripts%` can be moved to the `<head>` section for slightly better performance
 * You must set `hydratable: true` to hydrate `<head>` elements ([#1067](https://github.com/sveltejs/sapper/pull/1067))

--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -10,7 +10,7 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 
 * Rollup 0.x.x is no longer supported. ([#1326](https://github.com/sveltejs/sapper/pull/1326)). Any version greater than 1.x is supported, but the latest (currently 2.x) is strongly recommended.
 * `<script>` tags will now be loaded with the `defer` attribute ([#1123](https://github.com/sveltejs/sapper/pull/1123)), which means:
-	* IE9 support was dropped since IE9 may interleave deferred script execution. 
+	* IE9 support was dropped since IE9 may interleave deferred script execution.
 	* `%sapper.scripts%` can be moved to the `<head>` section for slightly better performance
 * You must set `hydratable: true` in your server build as well in order to properly hydrate `<head>` elements ([#1067](https://github.com/sveltejs/sapper/pull/1067))
 * The files in the generated `service-worker.js` file are now prefixed with a `/` ([#1244](https://github.com/sveltejs/sapper/pull/1244)). If you are using the `service-worker.js` from the default template, no changes will be necessary. If you have modified your service worker, please check to ensure compatibility.

--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -12,7 +12,7 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 * `<script>` tags will now be loaded with the `defer` attribute ([#1123](https://github.com/sveltejs/sapper/pull/1123)), which means:
 	* IE9 support was dropped since IE9 may interleave deferred script execution. 
 	* `%sapper.scripts%` can be moved to the `<head>` section for slightly better performance
-* You must set `hydratable: true` to hydrate `<head>` elements ([#1067](https://github.com/sveltejs/sapper/pull/1067))
+* You must set `hydratable: true` in your server build as well in order to properly hydrate `<head>` elements ([#1067](https://github.com/sveltejs/sapper/pull/1067))
 * The files in the generated `service-worker.js` file are now prefixed with a `/` ([#1244](https://github.com/sveltejs/sapper/pull/1244)). If you are using the `service-worker.js` from the default template, no changes will be necessary. If you have modified your service worker, please check to ensure compatibility.
 * The `sapper-noscroll` attribute was renamed to `sapper:noscroll` ([#1320](https://github.com/sveltejs/sapper/pull/1320))
 * Rollup users should update the `onwarn` filter in `rollup.config.js` ((sapper-template#246)[https://github.com/sveltejs/sapper-template/pull/246])

--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -15,7 +15,7 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 * You must set `hydratable: true` in your server build as well in order to properly hydrate `<head>` elements ([#1067](https://github.com/sveltejs/sapper/pull/1067))
 * The files in the generated `service-worker.js` file are now prefixed with a `/` ([#1244](https://github.com/sveltejs/sapper/pull/1244)). If you are using the `service-worker.js` from the default template, no changes will be necessary. If you have modified your service worker, please check to ensure compatibility.
 * The `sapper-noscroll` attribute was renamed to `sapper:noscroll` ([#1320](https://github.com/sveltejs/sapper/pull/1320))
-* Rollup users should update the `onwarn` filter in `rollup.config.js` ((sapper-template#246)[https://github.com/sveltejs/sapper-template/pull/246])
+* Rollup users should update the `onwarn` filter in `rollup.config.js` ([sapper-template#246](https://github.com/sveltejs/sapper-template/pull/246))
 
 ### 0.25 to 0.26
 

--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -13,7 +13,7 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 	* IE 9 support was dropped since IE9 may interleave deferred script execution.
 	* `%sapper.scripts%` can be moved to the `<head>` section for slightly better performance
 * You must set `hydratable: true` to hydrate `<head>` elements ([#1067](https://github.com/sveltejs/sapper/pull/1067))
-* The files in the generated `service-worker.js` file are now prefixed with a `/` ([#1244](https://github.com/sveltejs/sapper/pull/1244)).
+* The files in the generated `service-worker.js` file are now prefixed with a `/` ([#1244](https://github.com/sveltejs/sapper/pull/1244)). If you are using the `service-worker.js` from the default template, no changes will be necessary. If you have modified your service worker, please check to ensure compatibility.
 * The `sapper-noscroll` attribute was renamed to `sapper:noscroll` ([#1320](https://github.com/sveltejs/sapper/pull/1320))
 * Rollup users should update the `onwarn` filter in `rollup.config.js` ((sapper-template#246)[https://github.com/sveltejs/sapper-template/pull/246])
 

--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -9,7 +9,7 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 ### 0.27 to 0.28
 
 * Sapper dropped support for Rollup 0.x.x. <br>Any version greater than 1.x is supported but the latest (currently 2.x) is strongly recommended.
-* `script` tag will now be loaded with `defer` attribute ([#1123](https://github.com/sveltejs/sapper/pull/1123)) which means:
+* `script` tags will now be loaded with the `defer` attribute ([#1123](https://github.com/sveltejs/sapper/pull/1123)) which means:
 	* IE 9 support wasdropped since IE9 may interleave deferred script execution.
 	* `%sapper.scripts%` can be moved to the `<head>` section for slightly better performance
 * You must set `hydratable: true` to hydrate `<head>` elements ([#1067](https://github.com/sveltejs/sapper/pull/1067))

--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -13,8 +13,9 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 	* IE 9 support wasdropped since IE9 may interleave deferred script execution.
 	* `%sapper.scripts%` can be moved to the `<head>` section for slightly better performance
 * You must set `hydratable: true` to hydrate `<head>` elements ([#1067](https://github.com/sveltejs/sapper/pull/1067))
-* The files in the generated `service-worker.js` file are now prefixed with a `/` ([#1244](https://github.com/sveltejs/sapper/pull/1244))
+* The files in the generated `service-worker.js` file are now prefixed with a `/` ([#1244](https://github.com/sveltejs/sapper/pull/1244)).
 * The `sapper-noscroll` attribute was renamed to `sapper:noscroll` ([#1320](https://github.com/sveltejs/sapper/pull/1320))
+* Rollup users should update the `onwarn` filter in `rollup.config.js` ((sapper-template#246)[https://github.com/sveltejs/sapper-template/pull/246])
 
 ### 0.25 to 0.26
 

--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -8,7 +8,7 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 
 ### 0.27 to 0.28
 
-* Sapper dropped support for Rollup 0.x.x. <br>Any version greater than 1.x is supported but the latest (currently 2.x) is strongly recommended.
+* Sapper dropped support for Rollup 0.x.x  ([#1326](https://github.com/sveltejs/sapper/pull/1326)). <br>Any version greater than 1.x is supported but the latest (currently 2.x) is strongly recommended.
 * `<script>` tags will now be loaded with the `defer` attribute ([#1123](https://github.com/sveltejs/sapper/pull/1123)), which means:
 	* IE9 support was dropped since IE9 may interleave deferred script execution. 
 	* `%sapper.scripts%` can be moved to the `<head>` section for slightly better performance

--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -10,7 +10,7 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 
 * Sapper dropped support for Rollup 0.x.x. <br>Any version greater than 1.x is supported but the latest (currently 2.x) is strongly recommended.
 * `script` tags will now be loaded with the `defer` attribute ([#1123](https://github.com/sveltejs/sapper/pull/1123)) which means:
-	* IE 9 support wasdropped since IE9 may interleave deferred script execution.
+	* IE 9 support was dropped since IE9 may interleave deferred script execution.
 	* `%sapper.scripts%` can be moved to the `<head>` section for slightly better performance
 * You must set `hydratable: true` to hydrate `<head>` elements ([#1067](https://github.com/sveltejs/sapper/pull/1067))
 * The files in the generated `service-worker.js` file are now prefixed with a `/` ([#1244](https://github.com/sveltejs/sapper/pull/1244)).

--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -8,7 +8,7 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 
 ### 0.27 to 0.28
 
-* Sapper dropped support for Rollup 0.x.x  ([#1326](https://github.com/sveltejs/sapper/pull/1326)). <br>Any version greater than 1.x is supported but the latest (currently 2.x) is strongly recommended.
+* Rollup 0.x.x is no longer supported. ([#1326](https://github.com/sveltejs/sapper/pull/1326)). Any version greater than 1.x is supported, but the latest (currently 2.x) is strongly recommended.
 * `<script>` tags will now be loaded with the `defer` attribute ([#1123](https://github.com/sveltejs/sapper/pull/1123)), which means:
 	* IE9 support was dropped since IE9 may interleave deferred script execution. 
 	* `%sapper.scripts%` can be moved to the `<head>` section for slightly better performance


### PR DESCRIPTION
I thought it might be better to put all the info related to migrating and breaking changes in one place

I also added a not about silencing the Rollup warnings