### PR TITLE
Dynamically set the protocol to connect to the dev server

### DIFF
--- a/sapper-dev-client.js
+++ b/sapper-dev-client.js
@@ -13,7 +13,7 @@ function check() {
 export function connect(port) {
 	if (source || !window.EventSource) return;
 
-	source = new EventSource(`http://${window.location.hostname}:${port}/__sapper__`);
+	source = new EventSource(`${window.location.protocol}://${window.location.hostname}:${port}/__sapper__`);
 
 	window.source = source;
 


### PR DESCRIPTION
This PR relates to https://github.com/sveltejs/sapper/issues/384. It does not address the broader issue of a full https setup, as it may be out of scope or the design warrants further discussion before the implementation can be started, but makes it at least possible to access the dev server when loading the app through an https proxy, by avoiding requests being blocked due to mixed content.
