### PR TITLE
Clarify onwarn migration for 0.27 -> 0.28

### DIFF
--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -16,7 +16,7 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 * You must set `hydratable: true` in your server build as well in order to properly hydrate `<head>` elements ([#1067](https://github.com/sveltejs/sapper/pull/1067))
 * The files in the generated `service-worker.js` file are now prefixed with a `/` ([#1244](https://github.com/sveltejs/sapper/pull/1244)). If you are using the `service-worker.js` from the default template, no changes will be necessary. If you have modified your service worker, please check to ensure compatibility.
 * The `sapper-noscroll` attribute was renamed to `sapper:noscroll` ([#1320](https://github.com/sveltejs/sapper/pull/1320))
-* Rollup users should update the `onwarn` filter in `rollup.config.js` to match the [following change](https://github.com/sveltejs/sapper-template/pull/246/files). 
+* Rollup users should update the `onwarn` filter in `rollup.config.js` to match [the change made in `sapper-template`](https://github.com/sveltejs/sapper-template/pull/246/files). 
 
 ### 0.25 to 0.26
 

--- a/site/content/migrating/01-migrating.md
+++ b/site/content/migrating/01-migrating.md
@@ -16,7 +16,7 @@ Until we reach version 1.0, there may be occasional changes to the project struc
 * You must set `hydratable: true` in your server build as well in order to properly hydrate `<head>` elements ([#1067](https://github.com/sveltejs/sapper/pull/1067))
 * The files in the generated `service-worker.js` file are now prefixed with a `/` ([#1244](https://github.com/sveltejs/sapper/pull/1244)). If you are using the `service-worker.js` from the default template, no changes will be necessary. If you have modified your service worker, please check to ensure compatibility.
 * The `sapper-noscroll` attribute was renamed to `sapper:noscroll` ([#1320](https://github.com/sveltejs/sapper/pull/1320))
-* Rollup users should update the `onwarn` filter in `rollup.config.js` ([sapper-template#246](https://github.com/sveltejs/sapper-template/pull/246))
+* Rollup users should update the `onwarn` filter in `rollup.config.js` to match the [following change](https://github.com/sveltejs/sapper-template/pull/246/files). 
 
 ### 0.25 to 0.26
 


### PR DESCRIPTION
https://github.com/sveltejs/sapper/issues/1380


