### PR TITLE
Add TypeScript declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Provide TypeScript declarations ([#1402](https://github.com/sveltejs/sapper/pull/1402))
 * Fix exporting server routes which return binary files ([#1103](https://github.com/sveltejs/sapper/issues/1103))
 * Follow `<img src>`, `<source src>`, and `<source srcset>` when crawling site during export ([#1104](https://github.com/sveltejs/sapper/issues/1104))
 * Apply source map to stack traces ([#1357](https://github.com/sveltejs/sapper/pull/1357))

--- a/runtime/index.d.ts
+++ b/runtime/index.d.ts
@@ -1,0 +1,44 @@
+declare module "@sapper/app"
+declare module "@sapper/server"
+declare module "@sapper/service-worker"
+
+declare module "@sapper/app" {
+	interface Redirect {
+		statusCode: number
+		location: string
+	}
+
+	function goto(href: string, opts: { noscroll?: boolean, replaceState?: boolean }): Promise<unknown>
+	function prefetch(href: string): Promise<{ redirect?: Redirect; data?: unknown }>
+	function prefetchRoutes(pathnames: string[]): Promise<unknown>
+	function start(opts: { target: Node }): Promise<unknown>
+	const stores: () => unknown;
+
+	export {
+		goto, prefetch, prefetchRoutes, start, stores
+	};
+}
+
+declare module "@sapper/server" {
+	import { Handler, Req, Res } from '@sapper/internal/manifest-server';
+
+	interface MiddlewareOptions {
+		session?: (req: Req, res: Resp) => unknown
+		ignore?: unknown
+	}
+
+	function middleware(opts: MiddlewareOptions): Handler
+
+	export { middleware };
+}
+
+declare module "@sapper/service-worker" {
+	const timestamp: number;
+	const files: string[];
+	const shell: string[];
+	const routes: Array<{ pattern: RegExp }>;
+
+	export {
+		timestamp, files, files as assets, shell, routes
+	};
+}

--- a/runtime/index.d.ts
+++ b/runtime/index.d.ts
@@ -3,42 +3,35 @@ declare module "@sapper/server"
 declare module "@sapper/service-worker"
 
 declare module "@sapper/app" {
-	interface Redirect {
+	export interface Redirect {
 		statusCode: number
 		location: string
 	}
 
-	function goto(href: string, opts: { noscroll?: boolean, replaceState?: boolean }): Promise<unknown>
-	function prefetch(href: string): Promise<{ redirect?: Redirect; data?: unknown }>
-	function prefetchRoutes(pathnames: string[]): Promise<unknown>
-	function start(opts: { target: Node }): Promise<unknown>
-	const stores: () => unknown;
-
-	export {
-		goto, prefetch, prefetchRoutes, start, stores
-	};
+	export function goto(href: string, opts: { noscroll?: boolean, replaceState?: boolean }): Promise<void>;
+	export function prefetch(href: string): Promise<{ redirect?: Redirect; data?: unknown }>;
+	export function prefetchRoutes(pathnames: string[]): Promise<void>;
+	export function start(opts: { target: Node }): Promise<void>;
+	export const stores: () => unknown;
 }
 
 declare module "@sapper/server" {
 	import { Handler, Req, Res } from '@sapper/internal/manifest-server';
 
-	interface MiddlewareOptions {
-		session?: (req: Req, res: Resp) => unknown
-		ignore?: unknown
+	export type Ignore = string | RegExp | ((uri: string) => boolean) | Ignore[];
+
+	export interface MiddlewareOptions {
+		session?: (req: Req, res: Res) => unknown
+		ignore?: Ignore
 	}
 
-	function middleware(opts: MiddlewareOptions): Handler
-
-	export { middleware };
+	export function middleware(opts: MiddlewareOptions): Handler;
 }
 
 declare module "@sapper/service-worker" {
-	const timestamp: number;
-	const files: string[];
-	const shell: string[];
-	const routes: Array<{ pattern: RegExp }>;
-
-	export {
-		timestamp, files, files as assets, shell, routes
-	};
+	export const timestamp: number;
+	export const files: string[];
+	export const assets: string[];
+	export const shell: string[];
+	export const routes: Array<{ pattern: RegExp }>;
 }

--- a/runtime/src/app/goto/index.ts
+++ b/runtime/src/app/goto/index.ts
@@ -1,6 +1,9 @@
 import { history, select_target, navigate, cid } from '../app';
 
-export default function goto(href: string, opts: { noscroll?: boolean, replaceState?: boolean } = { noscroll: false, replaceState: false }) {
+export default function goto(
+		href: string,
+		opts: { noscroll?: boolean, replaceState?: boolean } = { noscroll: false, replaceState: false }): Promise<void> {
+
 	const target = select_target(new URL(href, document.baseURI));
 
 	if (target) {

--- a/runtime/src/app/prefetchRoutes/index.ts
+++ b/runtime/src/app/prefetchRoutes/index.ts
@@ -1,7 +1,7 @@
 import { components, routes } from '@sapper/internal/manifest-client';
 import { load_component } from '../app';
 
-export default function prefetchRoutes(pathnames: string[]) {
+export default function prefetchRoutes(pathnames: string[]): Promise<void> {
 	return routes
 		.filter(pathnames
 			? route => pathnames.some(pathname => route.pattern.test(pathname))

--- a/runtime/src/app/start/index.ts
+++ b/runtime/src/app/start/index.ts
@@ -16,7 +16,7 @@ import prefetch from '../prefetch/index';
 
 export default function start(opts: {
 	target: Node
-}) {
+}): Promise<void> {
 	if ('scrollRestoration' in history) {
 		history.scrollRestoration = 'manual';
 	}

--- a/src/api/utils/copy_runtime.ts
+++ b/src/api/utils/copy_runtime.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { mkdirp } from './fs_utils';
 
 const runtime = [
+	'index.d.ts',
 	'app.mjs',
 	'server.mjs',
 	'internal/shared.mjs',


### PR DESCRIPTION
Closes https://github.com/sveltejs/sapper/issues/1381

This is one of the biggest blockers to getting people started with TypeScript

This declaration file was posted in https://github.com/sveltejs/sapper/issues/760 and has been used by the community for several months, so it's fairly battle tested and a pretty good starting point even if there's probably room for further improvements. I copied it out of one of the template projects here: https://github.com/babichjacob/sapper-typescript-graphql-template/blob/main/types/%40sapper/index.d.ts

This also enables linting against the test code on my local machine, which was previously blocked by having the types available. It's not yet working on Github Actions though, so I'll have to do some debugging and follow up on enabling it in another change