### PR TITLE
docs: mention that exporting now follows images

### DIFF
--- a/site/content/docs/10-exporting.md
+++ b/site/content/docs/10-exporting.md
@@ -44,7 +44,7 @@ You can also add a script to your package.json...
 
 When you run `sapper export`, Sapper first builds a production version of your app, as though you had run `sapper build`, and copies the contents of your `static` folder to the destination. It then starts the server, and navigates to the root of your app. From there, it follows any `<a>`, `<img>` and `<source>` elements it finds, and captures any data served by the app.
 
-Because of this, any pages you want to be included in the exported site must either be reachable by `<a>`, `<img>` or `<source>` elements or added to the `--entry` option of the `sapper export` command.
+Because of this, any pages you want to be included in the exported site must either be reachable by `<a>` elements or added to the `--entry` option of the `sapper export` command.
 
 The `--entry` option expects a string of space-separated values. Examples:
 

--- a/site/content/docs/10-exporting.md
+++ b/site/content/docs/10-exporting.md
@@ -42,7 +42,7 @@ You can also add a script to your package.json...
 
 ### How it works
 
-When you run `sapper export`, Sapper first builds a production version of your app, as though you had run `sapper build`, and copies the contents of your `static` folder to the destination. It then starts the server, and navigates to the root of your app. From there, it follows any `<a>`, `<img>` and `<source>` elements it finds, and captures any data served by the app.
+When you run `sapper export`, Sapper first builds a production version of your app, as though you had run `sapper build`, and copies the contents of your `static` folder to the destination. It then starts the server, and navigates to the root of your app. From there, it follows any `<a>`, `<img>`, `<link>` and `<source>` elements it finds pointing to local URLs, and captures any data served by the app.
 
 Because of this, any pages you want to be included in the exported site must either be reachable by `<a>` elements or added to the `--entry` option of the `sapper export` command.
 

--- a/site/content/docs/10-exporting.md
+++ b/site/content/docs/10-exporting.md
@@ -42,9 +42,9 @@ You can also add a script to your package.json...
 
 ### How it works
 
-When you run `sapper export`, Sapper first builds a production version of your app, as though you had run `sapper build`, and copies the contents of your `static` folder to the destination. It then starts the server, and navigates to the root of your app. From there, it follows any `<a>` elements it finds, and captures any data served by the app.
+When you run `sapper export`, Sapper first builds a production version of your app, as though you had run `sapper build`, and copies the contents of your `static` folder to the destination. It then starts the server, and navigates to the root of your app. From there, it follows any `<a>`, `<img>` and `<source>` elements it finds, and captures any data served by the app.
 
-Because of this, any pages you want to be included in the exported site must either be reachable by `<a>` elements or added to the `--entry` option of the `sapper export` command.
+Because of this, any pages you want to be included in the exported site must either be reachable by `<a>`, `<img>` or `<source>` elements or added to the `--entry` option of the `sapper export` command.
 
 The `--entry` option expects a string of space-separated values. Examples:
 


### PR DESCRIPTION
On master, exporting now also follows images, and the docs should be updated to match. This shouldn't be merged (or at least shouldn't be deployed) until the next version gets released.