### PR TITLE
Switch call handle_error 404 to next function

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -377,8 +377,11 @@ export function get_page_handler(
 				return;
 			}
 		}
-
-		handle_error(req, res, 404, 'Not found');
+		
+ 		// Pass the 404 error to the user.
+		// Useful if using a non `express` framework such as fastify.
+		next();
+		return;
 	};
 }
 


### PR DESCRIPTION
### Problem

I don't think the sapper needs to handle 404 it himself. Usually express users have their own 404 handler (Response as Page or JSON). Some Fastify users have complained about the difficulty of integrating with Sapper. This is because when the route is not found, the Sapper responds to the 404 page instead of passing it to the next handler.

#### Example:
```js
// Use express middleware in fastify
fastify.register(fastifyExpress)
    .after(() => {
      fastify.use(require('@sapper/server').middleware());
     
      // Will never be executed because svelte will respond to a 404 page
      fastify.use(require('sirv')(path.resolve('public')))
    })
```

### Note: *Some of the tests will fail on my changes. That's because Sapper no longer handles 404 errors.*
