### PR TITLE
Compile to ES6

### DIFF
--- a/src/api/build.ts
+++ b/src/api/build.ts
@@ -32,9 +32,9 @@ export async function build({
 	static: static_files = 'static',
 	dest = '__sapper__/build',
 
-	bundler,
+	bundler = undefined,
 	legacy = false,
-	ext,
+	ext = undefined,
 	oncompile = noop
 }: Opts = {}) {
 	bundler = validate_bundler(bundler);

--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -81,7 +81,7 @@ async function _export({
 	build_dir = '__sapper__/build',
 	export_dir = '__sapper__/export',
 	basepath = '',
-	host_header,
+	host_header = undefined,
 	timeout = 5000,
 	concurrent = 8,
 	oninfo = noop,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,13 +4,12 @@
 		"noEmitOnError": true,
 		"allowJs": true,
 		"allowSyntheticDefaultImports": true,
-		"downlevelIteration": true,
 		"moduleResolution": "Node",
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"lib": ["es5", "es6", "dom"],
 		"importHelpers": true,
-		"target": "ES5",
+		"target": "ES6",
 		"baseUrl": ".",
 		"paths": {
 			"@sapper/*": ["runtime/src/*"]


### PR DESCRIPTION
This should result in a smaller bundle for modern browsers. For older browsers, the template includes Babel

My main reason for wanting this though is because VS Code doesn't seem to recognize `downlevelIteration` and shows errors everywhere we iterate over a `Set`, which is super annoying. That's fixed if you treat the code as ES6