### PR TITLE
Make dev mode reflect changes to css

### DIFF
--- a/src/core/create_compilers/RollupResult.ts
+++ b/src/core/create_compilers/RollupResult.ts
@@ -14,7 +14,6 @@ export default class RollupResult implements CompileResult {
 	chunks: Chunk[];
 	assets: Record<string, string>;
 	dependencies: Record<string, string[]>;
-	css_files: CssFile[];
 	sourcemap: boolean | 'inline';
 	summary: string;
 
@@ -31,7 +30,6 @@ export default class RollupResult implements CompileResult {
 			modules: Object.keys(chunk.modules).map(m => normalize_path(m))
 		}));
 
-		this.css_files = compiler.css_files;
 		this.dependencies = compiler.dependencies;
 
 		this.assets = {};

--- a/src/core/create_compilers/interfaces.ts
+++ b/src/core/create_compilers/interfaces.ts
@@ -22,7 +22,6 @@ export interface CompileResult {
 	warnings: CompileError[];
 	chunks: Chunk[];
 	assets: Record<string, string>;
-	css_files: CssFile[];
 	print: () => void;
 
 	to_json: (manifest_data: ManifestData, dirs: Dirs) => BuildInfo;


### PR DESCRIPTION
When you make a change to a css file the change isn't showing up. The issue was in the lines:

```
that.css_files.push({ id, code });
.
.
.
const f = that.css_files.find(file => file.id === css_module);
```

When a change was encountered it would push the updated code to the end of the array, but then we'd find the first version. I changed it to a map instead and it works now.

Ironically this was pretty much the only line of css handling that didn't change in https://github.com/sveltejs/sapper/pull/1415. This sounded like a new issue from the bug reporter in Discord, but I'm not quite sure why it wouldn't have been happening before since it didn't change. Possibly the duplicate CSS bug covered it up if the original CSS didn't change and the duplicate did.