### PR TITLE
follow <link href> during export

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -241,14 +241,14 @@ async function _export({
 				const base = resolve(url.href, base_href);
 
 				let match;
-				const pattern = /<(a|img|source)\s+([\s\S]+?)>/gm;
+				const pattern = /<(a|img|link|source)\s+([\s\S]+?)>/gm;
 
 				while (match = pattern.exec(cleaned)) {
 					let hrefs: string[] = [];
 					const element = match[1];
 					const attrs = match[2];
 
-					if (element === 'a') {
+					if (element === 'a' || element === 'link') {
 						hrefs.push(get_href(attrs));
 					} else {
 						if (element === 'img') {

--- a/test/apps/export/src/routes/index.svelte
+++ b/test/apps/export/src/routes/index.svelte
@@ -1,3 +1,7 @@
+<svelte:head>
+	<link rel='manifest' href='manifest.json'>
+</svelte:head>
+
 <h1>Great success!</h1>
 
 <a href="blog">blog</a>

--- a/test/apps/export/src/routes/manifest.json.js
+++ b/test/apps/export/src/routes/manifest.json.js
@@ -1,0 +1,4 @@
+export function get(req, res) {
+	res.writeHead(200, { 'Content-Type': 'application/json' });
+	res.end('{}');
+}

--- a/test/apps/export/test.ts
+++ b/test/apps/export/test.ts
@@ -45,6 +45,7 @@ describe('export', function() {
 			'img/example-192.png',
 			'img/example-512.png',
 			'pdfs/test.pdf',
+			'manifest.json',
 			...boom
 		].sort());
 	});


### PR DESCRIPTION
This would make something I'm doing at work easier. I can see a worry about a slippery slope here (do we follow `<object>`? `<embed>`? `<iframe>`?) but `<link href>` is pretty standard stuff.

This PR includes a new test case in the existing export test.