### PR TITLE
Restore webpack css support

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -316,10 +316,10 @@ export function get_page_handler(
 
 			// TODO make this consistent across apps
 			// TODO embed build_info in placeholder.ts
-			if (build_info.css) {
-				const css_chunks = build_info.css.main ? new Set(build_info.css.main) : new Set();
+			if (build_info.css && build_info.css.main) {
+				const css_chunks = new Set(build_info.css.main);
 				page.parts.forEach(part => {
-					if (!part) return;
+					if (!part || !build_info.dependencies) return;
 					const deps_for_part = build_info.dependencies[part.file];
 
 					if (deps_for_part) {

--- a/src/core/create_compilers/WebpackResult.ts
+++ b/src/core/create_compilers/WebpackResult.ts
@@ -50,10 +50,19 @@ export default class WebpackResult implements CompileResult {
 	}
 
 	to_json(manifest_data: ManifestData, dirs: Dirs): BuildInfo {
+		const extract_css = (assets: string[] | string) => {	
+			assets = Array.isArray(assets) ? assets : [assets];	
+			return assets.find(asset => /\.css$/.test(asset));	
+		};
+		const main_css = extract_css(this.assets.main);
+
 		return {
 			bundler: 'webpack',
 			shimport: null, // webpack has its own loader
-			assets: this.assets
+			assets: this.assets,
+			css: {
+				main: main_css ? [main_css] : null
+			}
 		};
 	}
 

--- a/src/core/create_compilers/interfaces.ts
+++ b/src/core/create_compilers/interfaces.ts
@@ -33,7 +33,7 @@ export type BuildInfo = {
 	assets: Record<string, string>;
 	dependencies?: Record<string, string[]>;
 	legacy_assets?: Record<string, string>;
-	css?: {	
-		main: string[];
+	css: {	
+		main: string[] | null;
 	};
 }


### PR DESCRIPTION
Closes https://github.com/sveltejs/sapper/issues/1454

`WebpackResult` had a bunch of css-related code that was mostly unused that was removed over the past few releases. However, there was a little bit of it that actually was used and was mistakenly removed as well. This restores it.

I'm not exactly sure how this is triggered. I'm relatively sure I tested the template or sample apps against webpack and they worked and had all the CSS inlined. I was able to manually test this code path using the sample app in the attached issue though