### PR TITLE
feat: change server output from commonjs to esm

### DIFF
--- a/src/config/rollup.ts
+++ b/src/config/rollup.ts
@@ -35,7 +35,9 @@ export default {
 		output: (): OutputOptions => {
 			return {
 				dir: `${dest}/server`,
-				format: 'cjs',
+				format: 'esm',
+				entryFileNames: '[name].mjs',
+				chunkFileNames: '[name].mjs',
 				sourcemap
 			};
 		}

--- a/src/config/webpack.ts
+++ b/src/config/webpack.ts
@@ -30,10 +30,10 @@ export default {
 		output: () => {
 			return {
 				path: `${dest}/server`,
-				filename: '[name].js',
-				chunkFilename: '[hash]/[name].[id].js',
+				filename: '[name].mjs',
+				chunkFilename: '[hash]/[name].[id].mjs',
 				publicPath: `client/`,
-				libraryTarget: 'commonjs2'
+				module: true
 			};
 		}
 	},


### PR DESCRIPTION
This pull request addresses my feature suggestion in #1459.
However, the changes implemented in the first commit break sapper, something is trying to reference the old `server.js` file. Help would be appreciated.