### PR TITLE
Add a safety guard to get_route_entry_chunks

### DIFF
--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -185,6 +185,7 @@ export default class RollupCompiler {
 
 				function get_route_entry_chunks(main_entry_chunk: RenderedChunk) {
 					return js_deps(main_entry_chunk, { filter: ctx => ctx.dynamicImport
+						&& ctx.chunk.facadeModuleId
 						&& ctx.chunk.facadeModuleId.includes(that.routes)
 						&& !ctx.chunk.facadeModuleId.includes(path.sep + '_') });
 				}


### PR DESCRIPTION
Closes #1466 

In RollupCompiler.ts, when the chunk's facadeModuleId is null, get_route_entry_chunks breaks. This came up when importing RecordRTC in a dynamic import. Fix suggested by @benmccann.

