### PR TITLE
preload typings

### DIFF
--- a/runtime/index.d.ts
+++ b/runtime/index.d.ts
@@ -1,6 +1,7 @@
 declare module "@sapper/app"
 declare module "@sapper/server"
 declare module "@sapper/service-worker"
+declare module "@sapper/common"
 
 declare module "@sapper/app" {
 	export interface Redirect {
@@ -34,4 +35,23 @@ declare module "@sapper/service-worker" {
 	export const assets: string[];
 	export const shell: string[];
 	export const routes: Array<{ pattern: RegExp }>;
+}
+
+declare module "@sapper/common" {
+	export interface PreloadContext {
+		fetch: (url: string, options?: any) => Promise<any>;
+		error: (statusCode: number, message: Error | string) => void;
+		redirect: (statusCode: number, location: string) => void;
+	}
+
+	export interface PreloadPage {
+		host: string;
+		path: string;
+		params: Record<string, string>;
+		query: Record<string, string | string[]>;
+	}
+
+	export interface PreloadFunction {
+		(this: PreloadContext, page: PreloadPage, session: any): any | Promise<any>;
+	}
 }

--- a/runtime/index.d.ts
+++ b/runtime/index.d.ts
@@ -52,7 +52,7 @@ declare module "@sapper/common" {
 		error?: Error;
 	}
 
-	export interface PreloadFunction {
+	export interface Preload {
 		(this: PreloadContext, page: Page, session: any): object | Promise<object>;
 	}
 }

--- a/runtime/index.d.ts
+++ b/runtime/index.d.ts
@@ -44,7 +44,7 @@ declare module "@sapper/common" {
 		redirect: (statusCode: number, location: string) => void;
 	}
 
-	export interface PreloadPage {
+	export interface Page {
 		host: string;
 		path: string;
 		params: Record<string, string>;
@@ -53,6 +53,6 @@ declare module "@sapper/common" {
 	}
 
 	export interface PreloadFunction {
-		(this: PreloadContext, page: PreloadPage, session: any): object | Promise<object>;
+		(this: PreloadContext, page: Page, session: any): object | Promise<object>;
 	}
 }

--- a/runtime/index.d.ts
+++ b/runtime/index.d.ts
@@ -49,9 +49,10 @@ declare module "@sapper/common" {
 		path: string;
 		params: Record<string, string>;
 		query: Record<string, string | string[]>;
+		error?: Error;
 	}
 
 	export interface PreloadFunction {
-		(this: PreloadContext, page: PreloadPage, session: any): any | Promise<any>;
+		(this: PreloadContext, page: PreloadPage, session: any): object | Promise<object>;
 	}
 }

--- a/site/content/docs/04-preloading.md
+++ b/site/content/docs/04-preloading.md
@@ -139,7 +139,7 @@ If you use TypeScript and want to access the above context methods, TypeScript w
 
 ```html
 <script context="module">
-	import { PreloadContext, PreloadPage } from "@sapper/common";
+	import type { PreloadContext, PreloadPage } from "@sapper/common";
 
 	export async function preload(this: PreloadContext, page: PreloadPage, session: any) {
 		const { user } = session;

--- a/site/content/docs/04-preloading.md
+++ b/site/content/docs/04-preloading.md
@@ -139,7 +139,7 @@ If you use TypeScript and want to access the above context methods, TypeScript w
 
 ```html
 <script context="module">
-	import type { PreloadContext, Page } from "@sapper/common";
+	import type { Page, PreloadContext } from "@sapper/common";
 
 	export async function preload(this: PreloadContext, page: Page, session: any) {
 		const { user } = session;

--- a/site/content/docs/04-preloading.md
+++ b/site/content/docs/04-preloading.md
@@ -141,7 +141,7 @@ If you use TypeScript and want to access the above context methods, TypeScript w
 <script context="module">
 	import type { PreloadContext, Page } from "@sapper/common";
 
-	export async function preload(this: PreloadContext, page: PreloadPage, session: any) {
+	export async function preload(this: PreloadContext, page: Page, session: any) {
 		const { user } = session;
 
 		if (!user) {

--- a/site/content/docs/04-preloading.md
+++ b/site/content/docs/04-preloading.md
@@ -135,7 +135,7 @@ You can abort rendering and redirect to a different location with `this.redirect
 
 #### Typing the function
 
-If you use TypeScript, you need to type the `this` context. You can type the function like this:
+If you use TypeScript and want to access the above context methods, TypeScript will thow an error and tell you that it does not know the type of `this`. To fix it, you need to specify the type of `this` (see the [official TypeScript documentation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#specifying-the-type-of-this-for-functions)). We provide you with helper interfaces so you can type the function like this:
 
 ```html
 <script context="module">

--- a/site/content/docs/04-preloading.md
+++ b/site/content/docs/04-preloading.md
@@ -132,3 +132,23 @@ You can abort rendering and redirect to a different location with `this.redirect
 	}
 </script>
 ```
+
+#### Typing the function
+
+If you use TypeScript, you need to type the `this` context. You can type the function like this:
+
+```html
+<script context="module">
+	import { PreloadContext, PreloadPage } from "@sapper/common";
+
+	export async function preload(this: PreloadContext, page: PreloadPage, session: any) {
+		const { user } = session;
+
+		if (!user) {
+			return this.redirect(302, 'login'); // TypeScript will know the type of `this` now
+		}
+
+		return { user };
+	}
+</script>
+```

--- a/site/content/docs/04-preloading.md
+++ b/site/content/docs/04-preloading.md
@@ -139,7 +139,7 @@ If you use TypeScript and want to access the above context methods, TypeScript w
 
 ```html
 <script context="module">
-	import type { PreloadContext, PreloadPage } from "@sapper/common";
+	import type { PreloadContext, Page } from "@sapper/common";
 
 	export async function preload(this: PreloadContext, page: PreloadPage, session: any) {
 		const { user } = session;

--- a/site/content/docs/04-preloading.md
+++ b/site/content/docs/04-preloading.md
@@ -141,7 +141,7 @@ If you use TypeScript and want to access the above context methods, TypeScript w
 <script context="module">
 	import type { Page, PreloadContext } from "@sapper/common";
 
-	export async function preload(this: PreloadContext, page: Page, session: any) {
+	export const preload: Preload = async function(this, page, session) {
 		const { user } = session;
 
 		if (!user) {


### PR DESCRIPTION
closes #1463

I added the typings to the `d.ts` file and put it in `@sapper/common` which seemed fitting to me since it is used on both client and server. I also added an alternative way of typing the function like @jasonlyu123 suggested, but did not mention it in the docs (I can add that if you want to).
I also added a doc entry. 