### PR TITLE
Set scroll position to 0,0 after a redirect

### DIFF
--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -222,7 +222,9 @@ export async function navigate(dest: Target, id: number, noscroll?: boolean, has
 		}
 
 		scroll_history[cid] = scroll;
-		if (scroll) scrollTo(scroll.x, scroll.y);
+		if (scroll) {
+			redirect ? scrollTo(0, 0) : scrollTo(scroll.x, scroll.y);
+		}
 	}
 }
 

--- a/test/apps/scroll/src/routes/redirect.svelte
+++ b/test/apps/scroll/src/routes/redirect.svelte
@@ -1,0 +1,5 @@
+<script context="module">
+	export function preload() {
+        this.redirect(301, 'another-tall-page')
+    }
+</script>

--- a/test/apps/scroll/src/routes/tall-page.svelte
+++ b/test/apps/scroll/src/routes/tall-page.svelte
@@ -19,4 +19,5 @@
 	{#if barLink}
 		<a href="another-tall-page#bar">link</a>
 	{/if}
+	<a href="redirect">redirected link</a>
 </div>

--- a/test/apps/scroll/test.ts
+++ b/test/apps/scroll/test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import { build } from '../../../api';
 import { AppRunner } from '../AppRunner';
+import { wait } from '../../utils';
 
 describe('scroll', function() {
 	this.timeout(10000);
@@ -99,33 +100,45 @@ describe('scroll', function() {
 		const secondScrollY = await r.page.evaluate(() => window.scrollY);
 
 		assert.equal(firstScrollY, secondScrollY);
-  });
+	});
 
-  it('scrolls to the top when navigating with goto', async () => {
-	  await r.load(`/search-form#search`);
-	  await r.sapper.start();
+	it('scrolls to the top when navigating with goto', async () => {
+		await r.load(`/search-form#search`);
+		await r.sapper.start();
 
-	  const initialScrollY = await r.page.evaluate(() => window.scrollY);
-	  assert.ok(initialScrollY > 0, String(initialScrollY));
+		const initialScrollY = await r.page.evaluate(() => window.scrollY);
+		assert.ok(initialScrollY > 0, String(initialScrollY));
 
-	  await r.page.click(`button#scroll`);
+		await r.page.click(`button#scroll`);
 
-	  const scrollY = await r.page.evaluate(() => window.scrollY);
-	  assert.ok(scrollY === 0, String(scrollY));
-  });
+		const scrollY = await r.page.evaluate(() => window.scrollY);
+		assert.ok(scrollY === 0, String(scrollY));
+	});
 
-  it('preserves scroll when noscroll: true is passed to goto', async () => {
-	  await r.load(`/search-form#search`);
-	  await r.sapper.start();
+	it('preserves scroll when noscroll: true is passed to goto', async () => {
+		await r.load(`/search-form#search`);
+		await r.sapper.start();
 
-	  const initialScrollY = await r.page.evaluate(() => window.scrollY);
-	  assert.ok(initialScrollY > 0, String(initialScrollY));
+		const initialScrollY = await r.page.evaluate(() => window.scrollY);
+		assert.ok(initialScrollY > 0, String(initialScrollY));
 
-	  await r.page.click(`button#preserve`);
+		await r.page.click(`button#preserve`);
 
-	  const scrollY = await r.page.evaluate(() => window.scrollY);
-	  assert.ok(scrollY === initialScrollY, String(scrollY));
-  });
+		const scrollY = await r.page.evaluate(() => window.scrollY);
+		assert.ok(scrollY === initialScrollY, String(scrollY));
+	});
+
+	it('scrolls to the top after redirecting', async () => {
+		await r.load(`/tall-page#foo`);
+		await r.sapper.start();
+
+		await r.page.click('[href="redirect"]');
+		await r.wait();
+
+		const scrollY = await r.page.evaluate(() => window.scrollY);
+
+		assert.ok(scrollY === 0);
+	});
 
 	it('survives the tests with no server errors', () => {
 		assert.deepEqual(r.errors, []);


### PR DESCRIPTION
This resolves this issue: https://github.com/sveltejs/sapper/issues/1470

Note: It looks like I munged the spacing in `scrolls/test.ts`, but the lines I changed were previously spaces whereas the rest of the document is tabs. I just converted it all to tabs. I just added a single `scrolls to the top after redirecting` test at the bottom.