### PR TITLE
Add test for CSS regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sapper",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -161,6 +161,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
       "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
       "dev": true
+    },
+    "@types/puppeteer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-3.0.1.tgz",
+      "integrity": "sha512-t03eNKCvWJXhQ8wkc5C6GYuSqMEdKLOX0GLMGtks25YZr38wKZlKTwGM/BoAPVtdysX7Bb9tdwrDS1+NrW3RRA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/resolve": {
       "version": "1.17.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@sveltejs/eslint-config": "github:sveltejs/eslint-config#v5.0.0",
     "@types/mocha": "^8.0.0",
     "@types/node": "^10.0.0",
+    "@types/puppeteer": "^3.0.1",
     "@typescript-eslint/eslint-plugin": "^3.0.2",
     "@typescript-eslint/parser": "^3.0.2",
     "cheap-watch": "^1.0.2",

--- a/test/apps/css/src/routes/_error.svelte
+++ b/test/apps/css/src/routes/_error.svelte
@@ -1,3 +1,7 @@
-<h1>{status}</h1>
+<style>
+	h1 {
+		color: purple;
+	}
+</style>
 
-<p>{error.message}</p>
+<h1>This is an error page</h1>

--- a/test/apps/css/test.ts
+++ b/test/apps/css/test.ts
@@ -25,6 +25,15 @@ describe('css', function() {
 		);
 	});
 
+	it('includes CSS on error page', async () => {
+		await r.load('/doesnotexist');
+
+		assert.equal(
+			await r.page.$eval('h1', node => getComputedStyle(node).color),
+			'rgb(128, 0, 128)'
+		);
+	});
+
 	it('loads CSS when navigating client-side', async () => {
 		await r.load('/');
 

--- a/test/apps/errors/test.ts
+++ b/test/apps/errors/test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
 import { build } from '../../../api';
 import { AppRunner } from '../AppRunner';
-import { wait } from '../../utils';
 
 describe('errors', function() {
 	this.timeout(10000);


### PR DESCRIPTION
CSS on error pages was broken in 0.28.1 (https://github.com/sveltejs/sapper/issues/1472) and then fixed by https://github.com/sveltejs/sapper/pull/1474. This adds a test to prevent further regressions