### PR TITLE
Let `this.fetch` forward cookies received on the server

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -112,7 +112,7 @@ export function get_page_handler(
 			error: (statusCode: number, message: Error | string) => {
 				preload_error = { statusCode, message };
 			},
-			fetch: (url: string, opts?: any) => {
+			fetch: async (url: string, opts?: any) => {
 				const protocol = req.socket.encrypted ? 'https' : 'http';
 				const parsed = new URL.URL(url, `${protocol}://127.0.0.1:${process.env.PORT}${req.baseUrl ? req.baseUrl + '/' :''}`);
 
@@ -149,7 +149,15 @@ export function get_page_handler(
 					}
 				}
 
-				return fetch(parsed.href, opts);
+				const response = await fetch(parsed.href, opts);
+
+				const header = response.headers.get('Set-Cookie');
+
+				if (header !== null) {
+					res.setHeader('Set-Cookie', header);
+				}
+
+				return response;
 			}
 		};
 


### PR DESCRIPTION
## What does this solve?

Requests performed in preload functions might set cookies in their response headers.
When executed on the server, this data is lost as headers are not forwarded to the client.
Current work-around requires code duplication: one part in a script tag, the other in a middleware to have access to a `res` object.

## How does it solve it?

This PR adds an option to `this.fetch` to let callers ensure cookies are forwarded in the response if run server-side.