### PR TITLE
Store `error` in page store (when an error page is triggered)

### DIFF
--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -18,9 +18,9 @@ import {
 	HydratedTarget,
 	Target,
 	Redirect,
+	Branch,
 	Page,
-	PageContext,
-	Branch
+	PageContext
 } from './types';
 import goto from './goto';
 import { page_store } from './stores';

--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -57,7 +57,7 @@ stores.session.subscribe(async value => {
 	if (redirect) {
 		await goto(redirect.location, { replaceState: true });
 	} else {
-		await render(branch, props, dest.page);
+		await render(branch, props, Object.assign({error: props.error}, dest.page));
 	}
 });
 
@@ -110,7 +110,7 @@ function handle_error(url: URL) {
 
 	};
 	const query = extract_query(search);
-	render([], props, { host, path: pathname, query, params: {} });
+	render([], props, { host, path: pathname, query, params: {}, error });
 }
 
 async function handle_target(dest: Target): Promise<void> {
@@ -127,7 +127,7 @@ async function handle_target(dest: Target): Promise<void> {
 		await goto(redirect.location, { replaceState: true });
 	} else {
 		const { props, branch } = hydrated_target;
-		await render(branch, props, dest.page);
+		await render(branch, props, Object.assign({error: props.error}, dest.page));
 	}
 }
 

--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -18,9 +18,9 @@ import {
 	HydratedTarget,
 	Target,
 	Redirect,
-	Branch,
 	Page,
-	PageContext
+	PageContext,
+	Branch
 } from './types';
 import goto from './goto';
 import { page_store } from './stores';

--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -112,14 +112,14 @@ function handle_error(url: URL) {
 
 	};
 	const query = extract_query(search);
-	render([], props, { host, path: pathname, query, params: {}, error, status });
+	render([], props, { host, path: pathname, query, params: {}, error });
 }
 
 
 function buildPageContext(props: any, page: Page): PageContext {
-  const { error, status } = props;
+  const { error } = props;
 
-  return { error, status, ...page };
+  return { error, ...page };
 }
 
 async function handle_target(dest: Target): Promise<void> {

--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -119,7 +119,7 @@ function handle_error(url: URL) {
 function buildPageContext(props: any, page: Page): PageContext {
   const { error, status } = props;
 
-  return Object.assign({ error, status }, page);
+  return { error, status, ...page };
 }
 
 async function handle_target(dest: Target): Promise<void> {

--- a/runtime/src/app/types.ts
+++ b/runtime/src/app/types.ts
@@ -8,9 +8,10 @@ export interface HydratedTarget {
 }
 
 export type Branch = Array<{
-  Component: DOMComponentConstructor;
-  preload: (page) => Promise<any>;
-  segment: string;
+	segment: string;
+	match?: RegExpExecArray;
+	component?: DOMComponentConstructor;
+	part?: number;
 }>;
 
 export interface ScrollPosition {
@@ -43,5 +44,4 @@ export interface Page {
 export interface PageContext extends Page {
 	/** `error` is only set when the error page is being rendered. */
 	error?: Error;
-	status: number;
 }

--- a/runtime/src/app/types.ts
+++ b/runtime/src/app/types.ts
@@ -42,6 +42,6 @@ export interface Page {
  */
 export interface PageContext extends Page {
 	/** `error` is only set when the error page is being rendered. */
-	error?: Error | { message: string; };
+	error?: Error;
 	status: number;
 }

--- a/runtime/src/app/types.ts
+++ b/runtime/src/app/types.ts
@@ -4,8 +4,14 @@ export interface HydratedTarget {
 	redirect?: Redirect;
 	preload_error?: any;
 	props: any;
-	branch: Array<{ Component: DOMComponentConstructor, preload: (page) => Promise<any>, segment: string }>;
+	branch: Branch;
 }
+
+export type Branch = Array<{
+  Component: DOMComponentConstructor;
+  preload: (page) => Promise<any>;
+  segment: string;
+}>;
 
 export interface ScrollPosition {
 	x: number;
@@ -29,6 +35,13 @@ export interface Page {
 	path: string;
 	params: Record<string, string>;
 	query: Record<string, string | string[]>;
+}
+
+/**
+ * Information about the current page in the `page` store.
+ */
+export interface PageContext extends Page {
 	/** `error` is only set when the error page is being rendered. */
-	error?: Error;
+	error?: Error | { message: string; };
+	status: number;
 }

--- a/runtime/src/app/types.ts
+++ b/runtime/src/app/types.ts
@@ -29,4 +29,6 @@ export interface Page {
 	path: string;
 	params: Record<string, string>;
 	query: Record<string, string | string[]>;
+	/** `error` is only set when the error page is being rendered. */
+	error?: Error;
 }

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -232,13 +232,17 @@ export function get_page_handler(
 			}
 
 			const pageContext: PageContext = {
-				host: req.headers.host,
-				path: req.path,
-				query: req.query,
-				params,
-				error: error ? error instanceof Error ? error : { message: error } : null,
-				status: error ? status : 200
-			};
+        host: req.headers.host,
+        path: req.path,
+        query: req.query,
+        params,
+        error: error
+          ? error instanceof Error
+            ? error
+            : { message: error, name: "PreloadError" }
+          : null,
+        status: error ? status : 200
+      };
 
 			const props = {
 				stores: {

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -42,7 +42,7 @@ export function get_page_handler(
 			parts: [
 				{ name: null, component: { default: error_route } }
 			]
-		}, req, res, statusCode, error || new Error('Unknown error in preload function'));
+		}, req, res, statusCode, error || 'Unknown error');
 	}
 
 	async function handle_page(page: ManifestPage, req: Req, res: Res, status = 200, error: Error | string = null) {

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -237,7 +237,8 @@ export function get_page_handler(
 							host: req.headers.host,
 							path: req.path,
 							query: req.query,
-							params
+							params,
+							error
 						}).subscribe
 					},
 					preloading: {

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -240,8 +240,7 @@ export function get_page_handler(
 					? error instanceof Error
 						? error
 						: { message: error, name: "PreloadError" }
-					: null,
-				status: error ? status : 200
+					: null
 			};
 
 			const props = {
@@ -255,7 +254,7 @@ export function get_page_handler(
 					session: writable(session)
 				},
 				segments: layout_segments,
-				status: pageContext.status,
+				status: error ? status : 200,
 				error: pageContext.error,
 				level0: {
 					props: preloaded[0]

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -232,17 +232,17 @@ export function get_page_handler(
 			}
 
 			const pageContext: PageContext = {
-        host: req.headers.host,
-        path: req.path,
-        query: req.query,
-        params,
-        error: error
-          ? error instanceof Error
-            ? error
-            : { message: error, name: "PreloadError" }
-          : null,
-        status: error ? status : 200
-      };
+				host: req.headers.host,
+				path: req.path,
+				query: req.query,
+				params,
+				error: error
+					? error instanceof Error
+						? error
+						: { message: error, name: "PreloadError" }
+					: null,
+				status: error ? status : 200
+			};
 
 			const props = {
 				stores: {

--- a/site/content/docs/02-routing.md
+++ b/site/content/docs/02-routing.md
@@ -130,7 +130,7 @@ There are three simple rules for naming the files that define your routes:
 
 In addition to regular pages, there is a 'special' page that Sapper expects to find — `src/routes/_error.svelte`. This will be shown when an error occurs while rendering a page.
 
-The `error` object is made available to the template along with the HTTP `status` code.
+The `error` object is made available to the template along with the HTTP `status` code. It is also available in the [`page` store](docs#Stores).
 
 
 

--- a/site/content/docs/02-routing.md
+++ b/site/content/docs/02-routing.md
@@ -130,7 +130,7 @@ There are three simple rules for naming the files that define your routes:
 
 In addition to regular pages, there is a 'special' page that Sapper expects to find — `src/routes/_error.svelte`. This will be shown when an error occurs while rendering a page.
 
-The `error` object is made available to the template along with the HTTP `status` code. It is also available in the [`page` store](docs#Stores).
+The `error` object is made available to the template along with the HTTP `status` code. Both are also available in the [`page` store](docs#Stores).
 
 
 

--- a/site/content/docs/02-routing.md
+++ b/site/content/docs/02-routing.md
@@ -130,7 +130,7 @@ There are three simple rules for naming the files that define your routes:
 
 In addition to regular pages, there is a 'special' page that Sapper expects to find — `src/routes/_error.svelte`. This will be shown when an error occurs while rendering a page.
 
-The `error` object is made available to the template along with the HTTP `status` code. Both are also available in the [`page` store](docs#Stores).
+The `error` object is made available to the template along with the HTTP `status` code. `error` is also available in the [`page` store](docs#Stores).
 
 
 

--- a/site/content/docs/07-state-management.md
+++ b/site/content/docs/07-state-management.md
@@ -14,7 +14,7 @@ Inside a component, get references to the stores like so:
 ```
 
 * `preloading` contains a readonly boolean value, indicating whether or not a navigation is pending
-* `page` contains a readonly `{ host, path, params, query }` object, identical to that passed to `preload` functions
+* `page` contains a readonly `{ host, path, params, query, error }` object, identical to that passed to `preload` functions. `error` is only set on error pages.
 * `session` contains whatever data was seeded on the server. It is a [writable store](https://svelte.dev/tutorial/writable-stores), meaning you can update it with new data (for example, after the user logs in) and your app will be refreshed
 
 

--- a/site/content/docs/07-state-management.md
+++ b/site/content/docs/07-state-management.md
@@ -14,7 +14,7 @@ Inside a component, get references to the stores like so:
 ```
 
 * `preloading` contains a readonly boolean value, indicating whether or not a navigation is pending
-* `page` contains a readonly `{ host, path, params, query, error }` object, identical to that passed to `preload` functions. `error` is only set on error pages.
+* `page` contains a readonly `{ host, path, params, query, error, status }` object. The same value is passed to `preload` functions, though `status` is not present at that time and `error` is only set on error pages.
 * `session` contains whatever data was seeded on the server. It is a [writable store](https://svelte.dev/tutorial/writable-stores), meaning you can update it with new data (for example, after the user logs in) and your app will be refreshed
 
 

--- a/site/content/docs/07-state-management.md
+++ b/site/content/docs/07-state-management.md
@@ -14,7 +14,7 @@ Inside a component, get references to the stores like so:
 ```
 
 * `preloading` contains a readonly boolean value, indicating whether or not a navigation is pending
-* `page` contains a readonly `{ host, path, params, query, error, status }` object. The same value is passed to `preload` functions, though `status` is not present at that time and `error` is only set on error pages.
+* `page` contains a readonly `{ host, path, params, query, error }` object. `error` is only set on error pages. This is the same value that is passed to `preload` functions.
 * `session` contains whatever data was seeded on the server. It is a [writable store](https://svelte.dev/tutorial/writable-stores), meaning you can update it with new data (for example, after the user logs in) and your app will be refreshed
 
 

--- a/test/apps/errors/src/routes/_layout.svelte
+++ b/test/apps/errors/src/routes/_layout.svelte
@@ -3,6 +3,6 @@
 	const { page } = stores();
 </script>
 
-<div class:error-layout="{!!$page.error}" class="status-{$page.status}">
+<div class:error-layout="{!!$page.error}">
   <slot></slot>
 </div>

--- a/test/apps/errors/src/routes/_layout.svelte
+++ b/test/apps/errors/src/routes/_layout.svelte
@@ -3,10 +3,6 @@
 	const { page } = stores();
 </script>
 
-{#if $page.error}
-  <div class="error-layout">
-    <slot></slot>
-  </div>
-{:else}
+<div class:error-layout="{!!$page.error}" class="status-{$page.status}">
   <slot></slot>
-{/if}
+</div>

--- a/test/apps/errors/src/routes/_layout.svelte
+++ b/test/apps/errors/src/routes/_layout.svelte
@@ -1,0 +1,12 @@
+<script>
+	import { stores } from '@sapper/app';
+	const { page } = stores();
+</script>
+
+{#if $page.error}
+  <div class="error-layout">
+    <slot></slot>
+  </div>
+{:else}
+  <slot></slot>
+{/if}

--- a/test/apps/errors/test.ts
+++ b/test/apps/errors/test.ts
@@ -25,11 +25,6 @@ describe('errors', function() {
 			await r.page.$eval(".error-layout", (el) => !!el),
 			"Layout did not get error in page store"
 		);
-
-		assert.ok(
-			await r.page.$eval(".status-" + statusCode, (el) => !!el),
-			"Layout did not get status " + statusCode
-		);
 	}
 
 	// tests

--- a/test/apps/errors/test.ts
+++ b/test/apps/errors/test.ts
@@ -16,7 +16,7 @@ describe('errors', function() {
 	after(() => r && r.end());
 
 	async function assertErrorPageRenders(statusCode: number) {
-		assert.equal(
+		assert.strictEqual(
 			await r.text('h1'),
 			statusCode + ''
 		);

--- a/test/apps/errors/test.ts
+++ b/test/apps/errors/test.ts
@@ -15,14 +15,22 @@ describe('errors', function() {
 
 	after(() => r && r.end());
 
+	async function assertErrorPageRenders(statusCode: number) {
+		assert.equal(
+			await r.text('h1'),
+			statusCode + ''
+		);
+
+		const didLayoutGetError = await r.page.$eval('.error-layout', (el) => !!el);
+
+		assert.ok(didLayoutGetError);
+	}
+
 	// tests
 	it('handles missing route on server', async () => {
 		await r.load('/nope');
 
-		assert.strictEqual(
-			await r.text('h1'),
-			'404'
-		);
+		await assertErrorPageRenders(404);
 	});
 
 	it('handles missing route on client', async () => {
@@ -32,19 +40,13 @@ describe('errors', function() {
 		await r.page.click('[href="nope"]');
 		await r.wait();
 
-		assert.strictEqual(
-			await r.text('h1'),
-			'404'
-		);
+		await assertErrorPageRenders(404);
 	});
 
 	it('handles explicit 4xx on server', async () => {
 		await r.load('/blog/nope');
 
-		assert.strictEqual(
-			await r.text('h1'),
-			'404'
-		);
+		await assertErrorPageRenders(404);
 	});
 
 	it('handles explicit 4xx on client', async () => {
@@ -55,19 +57,13 @@ describe('errors', function() {
 		await r.page.click('[href="blog/nope"]');
 		await r.wait();
 
-		assert.strictEqual(
-			await r.text('h1'),
-			'404'
-		);
+		await assertErrorPageRenders(404);
 	});
 
 	it('handles error on server', async () => {
 		await r.load('/throw');
 
-		assert.strictEqual(
-			await r.text('h1'),
-			'500'
-		);
+		await assertErrorPageRenders(500);
 	});
 
 	it('display correct stack trace sequences on server error referring to source file', async () => {
@@ -87,20 +83,18 @@ describe('errors', function() {
 		await r.page.click('[href="throw"]');
 		await r.wait();
 
-		assert.strictEqual(
-			await r.text('h1'),
-			'500'
-		);
+		await assertErrorPageRenders(500);
+
+		const didLayoutGetError = await r.page.$eval('.error-layout', (el) => el);
+
+		assert.ok(didLayoutGetError);
 	});
 
 	it('does not replace server side rendered error', async () => {
 		await r.load('/preload-reject');
 		await r.sapper.start();
 
-		assert.strictEqual(
-			await r.text('h1'),
-			'500'
-		);
+		await assertErrorPageRenders(500);
 	});
 
 	it('does not serve error page for explicit non-page errors', async () => {
@@ -110,6 +104,10 @@ describe('errors', function() {
 			await r.text('body'),
 			'nope'
 		);
+
+		const didLayoutGetError = await r.page.$$eval('.error-layout', (els) => els.length > 0);
+
+		assert.equal(didLayoutGetError, false);
 	});
 
 	it('does not serve error page for thrown non-page errors', async () => {

--- a/test/apps/errors/test.ts
+++ b/test/apps/errors/test.ts
@@ -21,9 +21,15 @@ describe('errors', function() {
 			statusCode + ''
 		);
 
-		const didLayoutGetError = await r.page.$eval('.error-layout', (el) => !!el);
+		assert.ok(
+			await r.page.$eval(".error-layout", (el) => !!el),
+			"Layout did not get error in page store"
+		);
 
-		assert.ok(didLayoutGetError);
+		assert.ok(
+			await r.page.$eval(".status-" + statusCode, (el) => !!el),
+			"Layout did not get status " + statusCode
+		);
 	}
 
 	// tests


### PR DESCRIPTION
To fix #948, store the current error in the `page` store to allow the layout to know whether the current page is an error page (as per [suggestion](https://github.com/sveltejs/sapper/pull/962#issuecomment-637513569) by @Conduitry).

My first PR in this project, so very open to feedback :) 

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
