### PR TITLE
Consistently output build.json in dev and prod modes

### DIFF
--- a/src/api/build.ts
+++ b/src/api/build.ts
@@ -104,7 +104,7 @@ export async function build({
 		delete process.env.SAPPER_LEGACY_BUILD;
 	}
 
-	fs.writeFileSync(path.join(dest, 'build.json'), JSON.stringify(build_info));
+	fs.writeFileSync(path.join(dest, 'build.json'), JSON.stringify(build_info, null, '  '));
 	if (bundler === 'rollup') {
 		inject_resources(path.join(dest, 'build.json'), path.join(dest, 'client'));
 	}


### PR DESCRIPTION
This pretty prints in prod mode as well. It's useful for this file to be human readable for many reasons. It's a consistent annoyance to me during debugging and development that it's hard to read, so this will make me much happier. I think there's not much advantage to minifying it since it's not shipped to the client