### PR TITLE
Fixed broken error page in encoding tests

### DIFF
--- a/test/apps/encoding/src/routes/_error.html
+++ b/test/apps/encoding/src/routes/_error.html
@@ -1,3 +1,0 @@
-<h1>{status}</h1>
-
-<p>{error.message}</p>

--- a/test/apps/encoding/src/routes/_error.svelte
+++ b/test/apps/encoding/src/routes/_error.svelte
@@ -1,0 +1,8 @@
+<script>
+	export let status;
+	export let error;
+</script>
+
+<h1>{status}</h1>
+
+<p>{error.message}</p>

--- a/test/apps/encoding/src/routes/_error.svelte
+++ b/test/apps/encoding/src/routes/_error.svelte
@@ -1,6 +1,6 @@
 <script>
-	export let status;
 	export let error;
+	export let status;
 </script>
 
 <h1>{status}</h1>


### PR DESCRIPTION
An error page in the tests causes a stack trace when running the tests.

Before this change, you got the following output when running the tests (though they still pass). After it, they pass cleanly.

```
  encoding
ReferenceError: status is not defined
    at /projects/svelte/sapper/test/apps/encoding/__sapper__/build/server/server.js:262:23
    at Object.$$render (/projects/svelte/sapper/test/apps/encoding/__sapper__/build/server/server.js:138:22)
    at Object.default (/projects/svelte/sapper/test/apps/encoding/__sapper__/build/server/server.js:292:45)
    at /projects/svelte/sapper/test/apps/encoding/__sapper__/build/server/server.js:251:45
    at Object.$$render (/projects/svelte/sapper/test/apps/encoding/__sapper__/build/server/server.js:138:22)
    at /projects/svelte/sapper/test/apps/encoding/__sapper__/build/server/server.js:290:40
    at $$render (/projects/svelte/sapper/test/apps/encoding/__sapper__/build/server/server.js:138:22)
    at Object.render (/projects/svelte/sapper/test/apps/encoding/__sapper__/build/server/server.js:146:26)
    at /projects/svelte/sapper/test/apps/encoding/__sapper__/build/server/server.js:5220:49
    at Generator.next (<anonymous>)
    ✓ encodes routes (197ms)
    ✓ encodes req.params and req.query for server-rendered pages (180ms)
    ✓ encodes req.params and req.query for client-rendered pages (271ms)
    ✓ encodes req.params for server routes (39ms)
    ✓ survives the tests with no server errors
```

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
