### PR TITLE
Proposal for configurable error handling

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -13,7 +13,7 @@ import { OnError, sendErrorResponse, RouteType } from './on_error';
 
 export function get_page_handler(
 	manifest: Manifest,
-	session_getter: (req: Req, res: Res) => Promise<any>, 
+	session_getter: (req: Req, res: Res) => Promise<any>,
 	onError?: OnError
 ) {
 	const get_build_info = dev
@@ -32,10 +32,10 @@ export function get_page_handler(
 		console.error(error);
 
 		sendErrorResponse({
-			
-			defaultResponse: () => {				
+
+			defaultResponse: () => {
 				const message = dev ? escape_html(error.message) : 'Internal server error';
-				
+
 				res.statusCode = 500;
 				res.end(`<pre>${message}</pre>`);
 			},
@@ -55,7 +55,7 @@ export function get_page_handler(
 					parts: [
 						{ name: null, component: { default: error_route } }
 					]
-				}, req, res, statusCode, error);	
+				}, req, res, statusCode, error);
 			},
 			routeType: RouteType.Page,
 			statusCode: 500,

--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -4,14 +4,16 @@ import mime from 'mime/lite';
 import { Handler, Req, Res, build_dir, dev, manifest } from '@sapper/internal/manifest-server';
 import { get_server_route_handler } from './get_server_route_handler';
 import { get_page_handler } from './get_page_handler';
+import { OnError } from './on_error';
 
 type IgnoreValue = IgnoreValue[] | RegExp | ((uri: string) => boolean) | string;
 
 export default function middleware(opts: {
 	session?: (req: Req, res: Res) => any,
-	ignore?: IgnoreValue
+	ignore?: IgnoreValue,
+	onError?: OnError
 } = {}) {
-	const { session, ignore } = opts;
+	const { session, ignore, onError } = opts;
 
 	let emitted_basepath = false;
 
@@ -60,9 +62,9 @@ export default function middleware(opts: {
 			cache_control: dev ? 'no-cache' : 'max-age=31536000, immutable'
 		}),
 
-		get_server_route_handler(manifest.server_routes),
+		get_server_route_handler(manifest.server_routes, onError),
 
-		get_page_handler(manifest, session || noop)
+		get_page_handler(manifest, session || noop, onError)
 	].filter(Boolean));
 }
 

--- a/runtime/src/server/middleware/on_error.ts
+++ b/runtime/src/server/middleware/on_error.ts
@@ -29,9 +29,9 @@ export function sendErrorResponse({
 	onError?: OnError;
 	defaultResponse: () => void;
 }) {
-	if (onError) {
-		let sendDefaultResponse = true;
+	let sendDefaultResponse = true;
 
+	if (onError) {
 		function customizeResponse(handler: (res: Res) => void) {
 			handler(res);
 			sendDefaultResponse = false;
@@ -44,9 +44,9 @@ export function sendErrorResponse({
 			error,
 			customizeResponse
 		});
+	}
 
-		if (sendDefaultResponse) {
-			defaultResponse();
-		}
+	if (sendDefaultResponse) {
+		defaultResponse();
 	}
 }

--- a/runtime/src/server/middleware/on_error.ts
+++ b/runtime/src/server/middleware/on_error.ts
@@ -1,0 +1,52 @@
+import { Req, Res } from '@sapper/internal/manifest-server';
+
+export type OnError = (ctx: {
+	req: Req;
+	statusCode: number;
+	error: Error | string;
+	routeType: RouteType;
+	customizeResponse: (handler: (res: Res) => void) => void;
+}) => any;
+
+export enum RouteType {
+	ServerRoute = 0,
+	Page = 1
+}
+
+export function sendErrorResponse({
+	onError,
+	defaultResponse,
+	req,
+	res,
+	routeType,
+	error
+}: {
+	req: Req;
+	res: Res;
+	routeType: RouteType;
+	statusCode: number;
+	error: Error | string;
+	onError?: OnError;
+	defaultResponse: () => void;
+}) {
+	if (onError) {
+		let sendDefaultResponse = true;
+
+		function customizeResponse(handler: (res: Res) => void) {
+			handler(res);
+			sendDefaultResponse = false;
+		}
+
+		onError({
+			req,
+			statusCode: 500,
+			routeType,
+			error,
+			customizeResponse
+		});
+
+		if (sendDefaultResponse) {
+			defaultResponse();
+		}
+	}
+}

--- a/test/apps/errors/src/routes/logged-errors.json.js
+++ b/test/apps/errors/src/routes/logged-errors.json.js
@@ -1,0 +1,9 @@
+import { loggedErrors } from '../server';
+
+export function get(req, res) {
+	res.writeHead(200, {
+		'Content-Type': 'application/json'
+	});
+
+	res.end(JSON.stringify(loggedErrors));
+}

--- a/test/apps/errors/src/server.js
+++ b/test/apps/errors/src/server.js
@@ -1,9 +1,34 @@
 import polka from 'polka';
 import * as sapper from '@sapper/server';
+import url from 'url';
 
 import { start } from '../../common.js';
 
-const app = polka()
-	.use(sapper.middleware());
+export const loggedErrors = {};
+
+function onError({ req, customizeResponse, statusCode, error }) {
+	const parsedUrl = url.parse(req.url, true);
+	const onError = parsedUrl.query['onerror'];
+
+	if (onError == 'custom') {
+		// replace normal error response with JSON response
+		customizeResponse((res) => {
+			res.writeHead(statusCode, {
+				'Content-Type': 'application/json',
+			});
+
+			res.end(JSON.stringify({ error: error.message, custom: true }));
+		});
+	} else if (onError == 'log') {
+		// log error so the caller can check we saw it
+		loggedErrors[url.parse(req.url, true).pathname] = true;
+	}
+}
+
+const app = polka().use(
+	sapper.middleware({
+		onError,
+	})
+);
 
 start(app);

--- a/test/apps/errors/src/server.js
+++ b/test/apps/errors/src/server.js
@@ -14,7 +14,7 @@ function onError({ req, customizeResponse, statusCode, error }) {
 		// replace normal error response with JSON response
 		customizeResponse((res) => {
 			res.writeHead(statusCode, {
-				'Content-Type': 'application/json',
+				'Content-Type': 'application/json'
 			});
 
 			res.end(JSON.stringify({ error: error.message, custom: true }));
@@ -27,7 +27,7 @@ function onError({ req, customizeResponse, statusCode, error }) {
 
 const app = polka().use(
 	sapper.middleware({
-		onError,
+		onError
 	})
 );
 

--- a/test/apps/errors/test.ts
+++ b/test/apps/errors/test.ts
@@ -71,7 +71,6 @@ describe('errors', function () {
 			await r.text('h1'),
 			'404'
 		);
-		assert.equal(await r.text('h1'), '404');
 	});
 
 	it('handles explicit 4xx on server', async () => {
@@ -104,8 +103,6 @@ describe('errors', function () {
 	it('handles error on server', async () => {
 		const url = '/throw';
 		await r.load(url);
-
-		assert.equal(await r.text('h1'), '500');
 
 		assert.strictEqual(
 			await r.text('h1'),

--- a/test/apps/errors/test.ts
+++ b/test/apps/errors/test.ts
@@ -97,7 +97,6 @@ describe('errors', function () {
 			await r.text('h1'),
 			'404'
 		);
-		assert.equal(await r.text('h1'), '404');
 	});
 
 	it('handles error on server', async () => {


### PR DESCRIPTION
This is a proposal that fixes #955, fixes #812, fixes #993, fixes #960, and fixes #742 

The suggestion is to allow for an `onError` parameter to the `middleware` function. `onError` is a function that is notified on any server-side error. It receives the request, the status code, the error and whether the error was in a server route or a page.

It can be used to log errors on the server side, e.g. in Sentry, but it can also be used to replace the standard error response, if desired. To do this, it receives a function called `customizeResponse`. If called, the response can be modified and the standard response (which is either `_error.svelte` for pages or a plain JSON response for server routes) is not generated.

See the tests for an [example of how to use `onError`](https://github.com/sveltejs/sapper/blob/f6417d42ee690a4d633bf91186b407b0326c13c1/test/apps/errors/src/server.js#L9)

I added tests, but did not update documentation, since I assume there will be change requests and it's better to update it if/when there is agreement on the functionality.

This is quite similar to #813 but a bit more flexible in that it
 * works for both server routes and pages
 * can be explicitly used to just listen to errors rather than modifying the response
 * adds tests :)

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
