### PR TITLE
Support IDE-friendly custom extensions for sapper, extensions with multiple "." dots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __sapper__
 dist
 /runtime/app.mjs
 /runtime/server.mjs
+/.vscode/settings.json

--- a/src/core/create_manifest_data.ts
+++ b/src/core/create_manifest_data.ts
@@ -57,15 +57,19 @@ export default function create_manifest_data(cwd: string, extensions: string = '
 				const file = path.relative(cwd, resolved);
 				const is_dir = fs.statSync(resolved).isDirectory();
 
-				const ext = path.extname(basename);
+				const file_ext = path.extname(basename);
 
 				if (basename[0] === '_') return null;
 				if (basename[0] === '.' && basename !== '.well-known') return null;
-				if (!is_dir && !/^\.[a-z]+$/i.test(ext)) return null; // filter out tmp files etc
+				if (!is_dir && !/^\.[a-z]+$/i.test(file_ext)) return null; // filter out tmp files etc
 
-				const segment = is_dir
-					? basename
-					: basename.slice(0, -ext.length);
+				const component_extension = component_extensions.find((ext) =>
+					basename.endsWith(ext)
+				);
+				const ext = component_extension || file_ext;
+				const is_page = component_extension != null;
+				const segment = is_dir ? basename : basename.slice(0, -ext.length);
+
 
 				if (/\]\[/.test(segment)) {
 					throw new Error(`Invalid route ${file} — parameters must be separated`);
@@ -73,7 +77,6 @@ export default function create_manifest_data(cwd: string, extensions: string = '
 
 				const parts = get_parts(segment);
 				const is_index = is_dir ? false : basename.startsWith('index.');
-				const is_page = component_extensions.indexOf(ext) !== -1;
 				const route_suffix = basename.slice(basename.indexOf('.'), -ext.length);
 
 				parts.forEach(part => {

--- a/src/core/create_manifest_data.ts
+++ b/src/core/create_manifest_data.ts
@@ -63,9 +63,7 @@ export default function create_manifest_data(cwd: string, extensions: string = '
 				if (basename[0] === '.' && basename !== '.well-known') return null;
 				if (!is_dir && !/^\.[a-z]+$/i.test(file_ext)) return null; // filter out tmp files etc
 
-				const component_extension = component_extensions.find((ext) =>
-					basename.endsWith(ext)
-				);
+				const component_extension = component_extensions.find((ext) => basename.endsWith(ext));
 				const ext = component_extension || file_ext;
 				const is_page = component_extension != null;
 				const segment = is_dir ? basename : basename.slice(0, -ext.length);

--- a/test/apps/custom-extension/src/routes/ide-friendly.route.svelte
+++ b/test/apps/custom-extension/src/routes/ide-friendly.route.svelte
@@ -1,0 +1,2 @@
+<h1>Great success, IDE friendly custom extensions!</h1>
+

--- a/test/apps/custom-extension/test.ts
+++ b/test/apps/custom-extension/test.ts
@@ -8,7 +8,7 @@ describe('custom extensions', function() {
 	let r: AppRunner;
 
 	// hooks
-	before('build app', () => build({ cwd: __dirname , ext: '.jesuslivesineveryone .whokilledthemuffinman .mdx .svelte' }));
+	before('build app', () => build({ cwd: __dirname , ext: '.jesuslivesineveryone .whokilledthemuffinman .route.svelte .mdx .svelte' }));
 	before('start runner', async () => {
 		r = await new AppRunner().start(__dirname);
 	});
@@ -54,6 +54,13 @@ describe('custom extensions', function() {
 		assert.equal(
 			await r.text('h1'),
 			'Bazooom!'
+		);
+
+		await r.load(`/ide-friendly`);
+
+		assert.equal(
+			await r.text('h1'), 
+			"Great success, IDE friendly custom extensions!"
 		);
 	});
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

TL;DR there's a bug / feature missing in the sapper route walking logic that means you can't use custom extensions with multiple "." dots in them ex. ".route.svelte"

Sometimes it's nice to keep some components that are only used within a single route under that routes folder, so for example if you use `ProductItem.svelte` under `routes/products/index.svelte` it may make sense to keep it under `routes/products/ProductItem.svelte`. Of course, that will also create a route ProductItem.svelte which isn't what we want.

Sapper supports custom extensions, so you could use `.route` so you have `products/ProductItem.svelte` and `product/index.route`, now you can safely keep components wherever you'd like. However, at our organization we've noticed that having svelte files not ending with `.svelte` causes a number of issues for IDEs and prettier for example, usually this can be resolved with additional configuration but it's ideal and clearer if everything uses the same extension, so instead of using `.route` we wanted to use `.route.svelte` to have our cake and eat it too. 

However svelte identified routes using the custom extensions by using `path.extname`, which only returns the last extension segment, meaning we couldn't use extensions with multiple "." dots. In this PR I changed the logic to use `basename.endsWith` instead.

Thank you very much, let me know if there's any additional reasons that this feature may cause an issue or if there's any feedback on the PR.