### PR TITLE
Update 11-deploying.md

### DIFF
--- a/site/content/docs/11-deploying.md
+++ b/site/content/docs/11-deploying.md
@@ -16,6 +16,10 @@ node __sapper__/build
 
 We can use a third-party library like [the `vercel-sapper` builder](https://www.npmjs.com/package/vercel-sapper) to deploy our projects to [Vercel] ([formerly ZEIT Now](https://vercel.com/blog/zeit-is-now-vercel)). See [that project's readme](https://github.com/thgh/vercel-sapper#readme) for more details regarding [Vercel] deployments.
 
+### Deploying to the Moovweb XDN
+
+The [Moovweb XDN](https://www.moovweb.com/) is a serverless platform focused on site speed, predictive prefetching, and ease of deployment. It provides direct support for Sapper. See the [Sapper Deployment Guide](https://developer.moovweb.com/guides/sapper) for details.
+
 ### Deploying service workers
 
 Sapper makes the Service Worker file (`service-worker.js`) unique by including a timestamp in the source code


### PR DESCRIPTION
Adds a link to the guide for deploying on the Moovweb XDN. This is just a documentation change.

Full Disclosure:
I'm the head of the platform team at Moovweb.  We love svelte and sapper!  We're actually building our developer tools in svelte right now. Sapper was one of the easiest frameworks to get working on our serverless platform, the Moovweb XDN. The XDN makes it easy to deploy sapper apps to super fast infrastructure.  We'd love to see the XDN listed along side Vercel as an alternative.