### PR TITLE
Cleaned up documentation on `session`

### DIFF
--- a/site/content/docs/04-preloading.md
+++ b/site/content/docs/04-preloading.md
@@ -39,15 +39,7 @@ So if the example above was `src/routes/blog/[slug].svelte` and the URL was `/bl
 * `page.query.foo === 'bar'`
 * `page.query.baz === true`
 
-`session` is generated on the server by the `session` option passed to `sapper.middleware`. For example:
-
-```js
-sapper.middleware({
-	session: (req, res) => ({
-		user: req.user
-	})
-})
-```
+`session` can be used to pass data from the server related to the current request, e.g. the current user. By default it is `undefined`. [Seeding session data](docs#Seeding_session_data) describes how to add data to it.
 
 
 ### Return value

--- a/site/content/docs/07-state-management.md
+++ b/site/content/docs/07-state-management.md
@@ -22,14 +22,13 @@ A component can retrieve the stores using the `stores` function:
 
 `session` is `undefined` by default. To populate it with data, implement a function that returns session data given an HTTP request. Pass it as an option to `sapper.middleware` when the server is started.
 
-As an example, here is how to populate the session with the current user:
+As an example, let's look at how to populate the session with the current user. First, add the `session` parameter to the Sapper middleware:
 
 ```js
 // src/server.js
-express()
+polka()
 	.use(
-		serve('static'),
-		authenticationMiddleware(),
+		// ...
 		sapper.middleware({
 			// customize the session
 			session: (req, res) => ({
@@ -37,12 +36,11 @@ express()
 			})
 		})
 	)
-	.listen(process.env.PORT);
 ```
 
 `req` is an `http.ClientRequest` and `res` an `http.ServerResponse`.
 
-The session data must be serializable. This means it must not contain functions or custom classes, just built-in JavaScript data types. [devalue](https://github.com/Rich-Harris/devalue) is used for serialization.
+The session data must be serializable. This means it must not contain functions or custom classes, just built-in JavaScript data types.
 
 The `session` function may return a `Promise` (or, equivalently, be `async`).
 

--- a/site/content/docs/07-state-management.md
+++ b/site/content/docs/07-state-management.md
@@ -14,7 +14,7 @@ A component can retrieve the stores using the `stores` function:
 ```
 
 * `preloading` contains a read-only boolean value, indicating whether or not a navigation is pending
-* `page` contains information on the current address. See [preloading](docs#Arguments) for details. This store is read-only.
+* `page` contains read-only information about the current route. See [preloading](docs#Arguments) for details.
 * `session` can be used to pass data from the server related to the current request. It is a [writable store](https://svelte.dev/tutorial/writable-stores), meaning you can update it with new data. If, for example, you populate the session with the current user on the server, you can update the store when the user logs in. Your components will refresh to reflect the new state
 
 

--- a/site/content/docs/07-state-management.md
+++ b/site/content/docs/07-state-management.md
@@ -44,4 +44,4 @@ The session data must be serializable. This means it must not contain functions 
 
 The `session` function may return a `Promise` (or, equivalently, be `async`).
 
-> If `session` returns a `Promise`, every server-rendered page route will wait for it to resolve. This can slow down your application significantly.
+> Note that if `session` returns a `Promise` (or is `async`), it will be re-awaited for on **every** server-rendered page route.


### PR DESCRIPTION
I didn't understand the purpose of `session` the first time I read the documentation, so I wanted to make that a little bit clearer. I found it particularly confusing that the first reference you find is "preloading" where there is only a slightly cryptic code sample and no reference to the main section that describes sessions. But also, importantly, the actual purpose of the session was never explicitly stated.

I also did some stylistic changes in that chapter of the documentation while I was at it.

-  [x] lint the project with `npm run lint`
