### PR TITLE
Fix support for legacy browsers

### DIFF
--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -21,8 +21,19 @@ let rollup: any;
 const inject_styles = `
 export default files => {
 	return Promise.all(files.map(file => new Promise((fulfil, reject) => {
-		const href = new URL(file, import.meta.url);
-		let link = document.querySelector('link[rel=stylesheet][href="' + href + '"]');
+		var scriptPath = document.currentScript;
+		if (!scriptPath) {
+			var stackLines = e.stack.split('\\n');
+			var callerIndex = 0;
+			for (var i in stackLines) {
+				if (!stackLines[i].match(/http[s]?:\\/\\//)) continue;
+				callerIndex = Number(i) + 2;
+				break;
+			}
+			scriptPath = stackLines[callerIndex].match(/((http[s]?:\\/\\/.+\\/)([^\\/]+\\.js)):/)[3];
+		}
+		var href = new URL(file, scriptPath);
+		var link = document.querySelector('link[rel=stylesheet][href="' + href + '"]');
 		if (!link) {
 			link = document.createElement('link');
 			link.rel = 'stylesheet';


### PR DESCRIPTION
Hopefully fixes https://github.com/sveltejs/sapper/issues/1505

I had some difficulty testing this. It fixes the original error, but I'm getting a new one that I think is unrelated and a result of the template not being setup to support legacy browsers by default. @rodoch @antony would you be able to test this one?