### PR TITLE
Refactored prefetching code to reduce dependencies

### DIFF
--- a/runtime/src/app/prefetch/index.ts
+++ b/runtime/src/app/prefetch/index.ts
@@ -1,14 +1,51 @@
-import { prefetching, set_prefetching, hydrate_target } from '../app';
+import { hydrate_target } from '../app';
 import { select_target } from '../router';
+import find_anchor from '../router/find_anchor';
+import { HydratedTarget, Target } from '../types';
+
+let prefetching: {
+	href: string;
+	promise: Promise<HydratedTarget>;
+} = null;
+
+let mousemove_timeout: NodeJS.Timer;
+
+export function start() {
+	addEventListener('touchstart', trigger_prefetch);
+	addEventListener('mousemove', handle_mousemove);
+}
 
 export default function prefetch(href: string) {
 	const target = select_target(new URL(href, document.baseURI));
 
 	if (target) {
 		if (!prefetching || href !== prefetching.href) {
-			set_prefetching(href, hydrate_target(target));
+			prefetching = { href, promise: hydrate_target(target) };
 		}
 
 		return prefetching.promise;
 	}
+}
+
+export function get_prefetched(target: Target): Promise<HydratedTarget> {
+	if (prefetching && prefetching.href === target.href) {
+		return prefetching.promise;
+	} else {
+		return hydrate_target(target);
+	}
+}
+
+function trigger_prefetch(event: MouseEvent | TouchEvent) {
+	const a: HTMLAnchorElement = <HTMLAnchorElement>find_anchor(<Node>event.target);
+
+	if (a && a.rel === 'prefetch') {
+		prefetch(a.href);
+	}
+}
+
+function handle_mousemove(event: MouseEvent) {
+	clearTimeout(mousemove_timeout);
+	mousemove_timeout = setTimeout(() => {
+		trigger_prefetch(event);
+	}, 20);
 }

--- a/runtime/src/app/router/find_anchor.ts
+++ b/runtime/src/app/router/find_anchor.ts
@@ -1,0 +1,4 @@
+export default function find_anchor(node: Node) {
+	while (node && node.nodeName.toUpperCase() !== 'A') node = node.parentNode; // SVG <a> elements have a lowercase name
+	return node;
+}

--- a/runtime/src/app/router/index.ts
+++ b/runtime/src/app/router/index.ts
@@ -2,12 +2,12 @@ import {
 	ScrollPosition,
 	Target
 } from '../types';
-import prefetch from '../prefetch/index';
 import {
 	ignore,
 	routes
 } from '@sapper/internal/manifest-client';
 import { Query } from '@sapper/internal/shared';
+import find_anchor from './find_anchor';
 
 export let uid = 1;
 export function set_uid(n: number) {
@@ -49,7 +49,7 @@ export function init(base: string, handler: (dest: Target) => Promise<void>): vo
 	if ('scrollRestoration' in _history) {
 		_history.scrollRestoration = 'manual';
 	}
-	
+
 	// Adopted from Nuxt.js
 	// Reset scrollRestoration to auto when leaving page, allowing page reload
 	// and back-navigation from other pages to use the browser to restore the
@@ -65,10 +65,6 @@ export function init(base: string, handler: (dest: Target) => Promise<void>): vo
 
 	addEventListener('click', handle_click);
 	addEventListener('popstate', handle_popstate);
-
-	// prefetch
-	addEventListener('touchstart', trigger_prefetch);
-	addEventListener('mousemove', handle_mousemove);
 }
 
 export function extract_query(search: string) {
@@ -112,22 +108,6 @@ export function select_target(url: URL): Target {
 			return { href: url.href, route, match, page };
 		}
 	}
-}
-
-let mousemove_timeout: NodeJS.Timer;
-
-function handle_mousemove(event: MouseEvent) {
-	clearTimeout(mousemove_timeout);
-	mousemove_timeout = setTimeout(() => {
-		trigger_prefetch(event);
-	}, 20);
-}
-
-function trigger_prefetch(event: MouseEvent | TouchEvent) {
-	const a: HTMLAnchorElement = <HTMLAnchorElement>find_anchor(<Node>event.target);
-	if (!a || a.rel !== 'prefetch') return;
-
-	prefetch(a.href);
 }
 
 function handle_click(event: MouseEvent) {
@@ -176,11 +156,6 @@ function handle_click(event: MouseEvent) {
 
 function which(event: MouseEvent) {
 	return event.which === null ? event.button : event.which;
-}
-
-function find_anchor(node: Node) {
-	while (node && node.nodeName.toUpperCase() !== 'A') node = node.parentNode; // SVG <a> elements have a lowercase name
-	return node;
 }
 
 function scroll_state() {


### PR DESCRIPTION
I moved the prefetching code that was distributed over `app.ts` and `router/index.ts` into one place (`prefetch/index.ts`).

This removes the dependency from router on prefetching. Unfortunately, there is still a circular dependency between `app.ts` and `prefetch` but breaking it makes the code more complicated so I dropped that.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
