### PR TITLE
Eliminating the rollup warning "'preload' is not exported"

### DIFF
--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -209,7 +209,7 @@ export async function hydrate_target(dest: Target): Promise<HydratedTarget> {
 	};
 
 	if (!root_preloaded) {
-		const root_preload = root_comp.preload || (() => ({}));
+		const { preload: root_preload = (() => ({})) } = root_comp;
 		root_preloaded = initial_data.preloaded[0] || root_preload.call(preload_context, {
 			host: page.host,
 			path: page.path,


### PR DESCRIPTION
This eliminates the `'preload' is not exported by 'src/routes/_layout.svelte'` warning that Rollup produces on the template project.

Once this has been released the line https://github.com/sveltejs/sapper-template/blob/master/rollup.config.js#L15 that currently suppresses the message can be removed.