### PR TITLE
fix for usage of baseURI which doesn't work in IE11

### DIFF
--- a/runtime/src/app/baseuri_helper.ts
+++ b/runtime/src/app/baseuri_helper.ts
@@ -1,10 +1,10 @@
-export function get_base_uri (window_document) {
-  let baseURI = window_document.baseURI;
+export function get_base_uri(window_document) {
+	let baseURI = window_document.baseURI;
 
-  if (!baseURI) {
-    const baseTags = window_document.getElementsByTagName('base');
-    baseURI = baseTags.length ? baseTags[0].href : window_document.URL;
-  }
+	if (!baseURI) {
+		const baseTags = window_document.getElementsByTagName('base');
+		baseURI = baseTags.length ? baseTags[0].href : window_document.URL;
+	}
 
-  return baseURI;
+	return baseURI;
 }

--- a/runtime/src/app/baseuri_helper.ts
+++ b/runtime/src/app/baseuri_helper.ts
@@ -1,9 +1,9 @@
-export function get_base_uri () {
-  let baseURI = document.baseURI;
+export function get_base_uri (window_document) {
+  let baseURI = window_document.baseURI;
 
   if (!baseURI) {
-    const baseTags = document.getElementsByTagName('base');
-    baseURI = baseTags.length ? baseTags[0].href : document.URL;
+    const baseTags = window_document.getElementsByTagName('base');
+    baseURI = baseTags.length ? baseTags[0].href : window_document.URL;
   }
 
   return baseURI;

--- a/runtime/src/app/baseuri_helper.ts
+++ b/runtime/src/app/baseuri_helper.ts
@@ -1,0 +1,10 @@
+export function get_base_uri () {
+  let baseURI = document.baseURI;
+
+  if (!baseURI) {
+    const baseTags = document.getElementsByTagName('base');
+    baseURI = baseTags.length ? baseTags[0].href : document.URL;
+  }
+
+  return baseURI;
+}

--- a/runtime/src/app/goto/index.ts
+++ b/runtime/src/app/goto/index.ts
@@ -5,7 +5,7 @@ export default function goto(
 		href: string,
 		opts: { noscroll?: boolean, replaceState?: boolean } = { noscroll: false, replaceState: false }): Promise<void> {
 
-	const target = select_target(new URL(href, get_base_uri()));
+	const target = select_target(new URL(href, get_base_uri(document)));
 
 	if (target) {
 		history[opts.replaceState ? 'replaceState' : 'pushState']({ id: cid }, '', href);

--- a/runtime/src/app/goto/index.ts
+++ b/runtime/src/app/goto/index.ts
@@ -1,10 +1,11 @@
 import { cid, history, navigate, select_target } from '../router';
+import { get_base_uri } from '../baseuri_helper';
 
 export default function goto(
 		href: string,
 		opts: { noscroll?: boolean, replaceState?: boolean } = { noscroll: false, replaceState: false }): Promise<void> {
 
-	const target = select_target(new URL(href, document.baseURI));
+	const target = select_target(new URL(href, get_base_uri()));
 
 	if (target) {
 		history[opts.replaceState ? 'replaceState' : 'pushState']({ id: cid }, '', href);

--- a/runtime/src/app/prefetch/index.ts
+++ b/runtime/src/app/prefetch/index.ts
@@ -2,6 +2,7 @@ import { hydrate_target } from '../app';
 import { select_target } from '../router';
 import find_anchor from '../router/find_anchor';
 import { HydratedTarget, Target } from '../types';
+import { get_base_uri } from '../baseuri_helper';
 
 let prefetching: {
 	href: string;
@@ -16,7 +17,7 @@ export function start() {
 }
 
 export default function prefetch(href: string) {
-	const target = select_target(new URL(href, document.baseURI));
+	const target = select_target(new URL(href, get_base_uri()));
 
 	if (target) {
 		if (!prefetching || href !== prefetching.href) {

--- a/runtime/src/app/prefetch/index.ts
+++ b/runtime/src/app/prefetch/index.ts
@@ -17,7 +17,7 @@ export function start() {
 }
 
 export default function prefetch(href: string) {
-	const target = select_target(new URL(href, get_base_uri()));
+	const target = select_target(new URL(href, get_base_uri(document)));
 
 	if (target) {
 		if (!prefetching || href !== prefetching.href) {

--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -25,7 +25,14 @@ const inject_styles = `
 export default function(files) {
 	return Promise.all(files.map(function(file) { return new Promise(function(fulfil, reject) {
 		var href = new URL(file, import.meta.url);
-		var relative = ('' + href).substring(document.baseURI.length);
+		var baseURI = document.baseURI;
+
+		if (!baseURI) {
+			var baseTags = document.getElementsByTagName('base');
+			baseURI = baseTags.length ? baseTags[0].href : document.URI;
+		}
+
+		var relative = ('' + href).substring(baseURI.length);
 		var link = document.querySelector('link[rel=stylesheet][href="' + relative + '"]')
 			|| document.querySelector('link[rel=stylesheet][href="' + href + '"]');
 		if (!link) {

--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -29,7 +29,7 @@ export default function(files) {
 
 		if (!baseURI) {
 			var baseTags = document.getElementsByTagName('base');
-			baseURI = baseTags.length ? baseTags[0].href : document.URI;
+			baseURI = baseTags.length ? baseTags[0].href : document.URL;
 		}
 
 		var relative = ('' + href).substring(baseURI.length);

--- a/test/unit/baseuri_helper/test.ts
+++ b/test/unit/baseuri_helper/test.ts
@@ -1,0 +1,59 @@
+import * as assert from 'assert';
+import { get_base_uri } from '../../../runtime/src/app/baseuri_helper';
+
+interface MockDocument {
+	baseURI?: string;
+	getElementsByTagName?: Function;
+	URL?: string;
+}
+
+interface MockWindow {
+	baseURI: string;
+}
+
+interface CustomNodeJsGlobal extends NodeJS.Global {
+	document: MockDocument;
+	window: MockWindow;
+}
+
+declare const global: CustomNodeJsGlobal;
+
+describe('get_base_uri', () => {
+	it('document.baseURI exists', () => {
+		const baseUri = 'https://baseuri.example.com';
+		global.document = {
+			baseURI: baseUri
+		};
+		assert.strictEqual(get_base_uri(), baseUri);
+	});
+
+	it('document.baseURI does not exist, with <base /> tag', () => {
+		const baseUri = 'https://bytag.example.com';
+		global.document = {
+			getElementsByTagName: () => [
+				{ href: baseUri }
+			]
+		};
+		assert.strictEqual(get_base_uri(), baseUri);
+	});
+
+	it('document.baseURI does not exist, with multiple <base /> tag', () => {
+		const baseUri = 'https://fromtag.example.com';
+		global.document = {
+			getElementsByTagName: () => [
+				{ href: baseUri },
+				{ href: 'https://ignoreme.example.com' }
+			]
+		};
+		assert.strictEqual(get_base_uri(), baseUri);
+	});
+
+	it('document.baseURI does not exist, without <base /> tag', () => {
+		const baseUri = 'https://byurl.example.com';
+		global.document = {
+			getElementsByTagName: () => [],
+			URL: baseUri
+		};
+		assert.strictEqual(get_base_uri(), baseUri);
+	});
+});

--- a/test/unit/baseuri_helper/test.ts
+++ b/test/unit/baseuri_helper/test.ts
@@ -1,59 +1,42 @@
 import * as assert from 'assert';
 import { get_base_uri } from '../../../runtime/src/app/baseuri_helper';
 
-interface MockDocument {
-	baseURI?: string;
-	getElementsByTagName?: Function;
-	URL?: string;
-}
-
-interface MockWindow {
-	baseURI: string;
-}
-
-interface CustomNodeJsGlobal extends NodeJS.Global {
-	document: MockDocument;
-	window: MockWindow;
-}
-
-declare const global: CustomNodeJsGlobal;
-
 describe('get_base_uri', () => {
 	it('document.baseURI exists', () => {
 		const baseUri = 'https://baseuri.example.com';
-		global.document = {
+		const document = {
 			baseURI: baseUri
 		};
-		assert.strictEqual(get_base_uri(), baseUri);
+		assert.strictEqual(get_base_uri(document), baseUri);
 	});
 
 	it('document.baseURI does not exist, with <base /> tag', () => {
 		const baseUri = 'https://bytag.example.com';
-		global.document = {
+		const document = {
 			getElementsByTagName: () => [
 				{ href: baseUri }
 			]
 		};
-		assert.strictEqual(get_base_uri(), baseUri);
+		assert.strictEqual(get_base_uri(document), baseUri);
 	});
 
 	it('document.baseURI does not exist, with multiple <base /> tag', () => {
 		const baseUri = 'https://fromtag.example.com';
-		global.document = {
+		const document = {
 			getElementsByTagName: () => [
 				{ href: baseUri },
 				{ href: 'https://ignoreme.example.com' }
 			]
 		};
-		assert.strictEqual(get_base_uri(), baseUri);
+		assert.strictEqual(get_base_uri(document), baseUri);
 	});
 
 	it('document.baseURI does not exist, without <base /> tag', () => {
 		const baseUri = 'https://byurl.example.com';
-		global.document = {
+		const document = {
 			getElementsByTagName: () => [],
 			URL: baseUri
 		};
-		assert.strictEqual(get_base_uri(), baseUri);
+		assert.strictEqual(get_base_uri(document), baseUri);
 	});
 });


### PR DESCRIPTION
`document.baseURI` doesn't exist in IE and causes errors. This attempts to get it and then falls back to looking at the base tag if present.

Fixes https://github.com/sveltejs/sapper/issues/1561 and https://github.com/sveltejs/sapper/issues/1034 as well as an issue where prefetch would also fail in IE as it also depends on baseURI.

Opening in draft because:

- [x] I've not tested it, I will do tomorrow.
- [x] I haven't written any tests for the helper(s)

### Before submitting the PR, please make sure you do the following
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
