### PR TITLE
do not enter an infinite loop if layout's preload crashed on error page

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -27,10 +27,10 @@ export function get_page_handler(
 
 	const { pages, error: error_route } = manifest;
 
-	function bail(req: Req, res: Res, err: Error) {
+	function bail(res: Res, err: Error|string) {
 		console.error(err);
 
-		const message = dev ? escape_html(err.message) : 'Internal server error';
+		const message = dev ? escape_html(typeof err === 'string' ? err : err.message) : 'Internal server error';
 
 		res.statusCode = 500;
 		res.end(`<pre>${message}</pre>`);
@@ -97,7 +97,7 @@ export function get_page_handler(
 		try {
 			session = await session_getter(req, res);
 		} catch (err) {
-			return bail(req, res, err);
+			return bail(res, err);
 		}
 
 		let redirect: { statusCode: number, location: string };
@@ -192,7 +192,7 @@ export function get_page_handler(
 			preloaded = await Promise.all(toPreload);
 		} catch (err) {
 			if (error) {
-				return bail(req, res, err);
+				return bail(res, err);
 			}
 
 			preload_error = { statusCode: 500, message: err };
@@ -211,7 +211,13 @@ export function get_page_handler(
 			}
 
 			if (preload_error) {
-				handle_error(req, res, preload_error.statusCode, preload_error.message);
+				if (!error) {
+					handle_error(req, res, preload_error.statusCode, preload_error.message);
+				}
+				else {
+					bail(res, preload_error.message);
+				}
+
 				return;
 			}
 
@@ -357,7 +363,7 @@ export function get_page_handler(
 			res.end(body);
 		} catch (err) {
 			if (error) {
-				bail(req, res, err);
+				bail(res, err);
 			} else {
 				handle_error(req, res, 500, err);
 			}

--- a/test/apps/errors/src/routes/_layout.svelte
+++ b/test/apps/errors/src/routes/_layout.svelte
@@ -3,6 +3,14 @@
 	const { page } = stores();
 </script>
 
+<script context="module">
+  export function preload({ params, query }) {
+		if (query['layoutthrows']) {
+			this.error(500, "layout preload threw");
+		}
+  }
+</script>
+
 <div class:error-layout="{!!$page.error}">
   <slot></slot>
 </div>

--- a/test/apps/errors/test.ts
+++ b/test/apps/errors/test.ts
@@ -22,8 +22,8 @@ describe('errors', function() {
 		);
 
 		assert.ok(
-			await r.page.$eval(".error-layout", (el) => !!el),
-			"Layout did not get error in page store"
+			await r.page.$eval('.error-layout', (el) => !!el),
+			'Layout did not get error in page store'
 		);
 	}
 
@@ -96,6 +96,14 @@ describe('errors', function() {
 		await r.sapper.start();
 
 		await assertErrorPageRenders(500);
+	});
+
+	it('handles errors occurring in the layout preload', async () => {
+		const res = await r.load('/?layoutthrows=true');
+
+		const responseText = await res.text();
+
+		assert.ok((responseText).includes('Internal server error'), `Expected response "${responseText}" to say "Internal server error"`);
 	});
 
 	it('does not serve error page for explicit non-page errors', async () => {


### PR DESCRIPTION
If the layout's preload function throws or calls `this.error` on the error page, we'd enter an infinate loop.

Break that by bailing and returning an unstyled error page.

Fixes #1506

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
