### PR TITLE
Replace all occurences of sapper.cspnonce

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -351,7 +351,7 @@ export function get_page_handler(
 				.replace('%sapper.html%', () => html)
 				.replace('%sapper.head%', () => head)
 				.replace('%sapper.styles%', () => styles)
-				.replace(/%sapper.cspnonce%/g, nonce_value);
+				.replace(/%sapper\.cspnonce%/g, () => nonce_value);
 
 			res.statusCode = status;
 			res.end(body);

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -351,7 +351,7 @@ export function get_page_handler(
 				.replace('%sapper.html%', () => html)
 				.replace('%sapper.head%', () => head)
 				.replace('%sapper.styles%', () => styles)
-				.replace('%sapper.cspnonce%', () => nonce_value);
+				.replace(/%sapper.cspnonce%/g, nonce_value);
 
 			res.statusCode = status;
 			res.end(body);

--- a/test/apps/cspnonce/src/template.html
+++ b/test/apps/cspnonce/src/template.html
@@ -11,6 +11,7 @@
 	<div id='sapper'>%sapper.html%</div>
 	<!-- nonce should be 'rAnd0m123'; cf., server.js -->
 	<script id="hasNonce" nonce="%sapper.cspnonce%"></script>
+	<script id="hasNonceAgain" nonce="%sapper.cspnonce%"></script>
 	%sapper.scripts%
 </body>
 </html>

--- a/test/apps/cspnonce/test.ts
+++ b/test/apps/cspnonce/test.ts
@@ -21,6 +21,9 @@ describe('cspnonce', function() {
 		assert.equal(
 			await r.page.$eval('#hasNonce', node => node.getAttribute('nonce')), 'rAnd0m123'
 		);
+		assert.equal(
+			await r.page.$eval('#hasNonceAgain', node => node.getAttribute('nonce')), 'rAnd0m123'
+		);
 	});
 
 });


### PR DESCRIPTION
This addresses https://github.com/sveltejs/sapper/issues/1565 and allows use of nonces on multiple scripts and stylesheets.

The changes to test/apps/cspnonce/src/template.html fails on master (reflecting the current issue) but passes after the changes in this PR.