### PR TITLE
Prevent crash if exporting with missing `index.svelte`

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -365,20 +365,15 @@ export function get_page_handler(
 	}
 
 	return function find_route(req: Req, res: Res, next: () => void) {
-		if (req.path === '/service-worker-index.html') {
-			const homePage = pages.find(page => page.pattern.test('/'));
-			handle_page(homePage, req, res);
-			return;
-		}
+		const path = req.path === '/service-worker-index.html' ? '/' : req.path;
 
-		for (const page of pages) {
-			if (page.pattern.test(req.path)) {
-				handle_page(page, req, res);
-				return;
-			}
-		}
+		const page = pages.find(page => page.pattern.test(path));
 
-		handle_error(req, res, 404, 'Not found');
+		if (page) {
+			handle_page(page, req, res);
+		} else {
+			handle_error(req, res, 404, 'Not found');
+		}
 	};
 }
 


### PR DESCRIPTION
Do not crash when exporting the site with a missing `index.svelte` (this will instead return a 404 for `service-worker-index.html` which is also confusing, but it's better than the previous `Cannot read property 'parts' of undefined`).

Fixes #1390 

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
