### PR TITLE
Bump timeout to 30 seconds, using port-authority

### DIFF
--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -237,7 +237,7 @@ class Watcher extends EventEmitter {
 					const restart = () => {
 						this.crashed = false;
 
-						return ports.wait(this.port)
+						return ports.wait(this.port, {timeout: 30000})
 							.then((() => {
 								this.emit('ready', {
 									port: this.port,


### PR DESCRIPTION
According to the source code here https://github.com/Rich-Harris/port-authority/blob/bf12e69618cc59dbc0d46a5132902df8a584e39f/src/wait.ts#L3,
we can specify a timeout - and a default timeout of 5 seconds is not
high enough for many bigger express applications (see https://github.com/sveltejs/sapper/issues/730).

This PR is simply inspired by the dialog in pull request: https://github.com/sveltejs/sapper/pull/985,
but I thought it would just be simpler to create a new one.

Closes https://github.com/sveltejs/sapper/pull/985