### PR TITLE
Preload modules as modulepreload

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -229,7 +229,7 @@ async function _export({
 			link.refs.forEach((ref: Ref) => {
 				if (ref.rel === 'preload' || ref.rel === 'modulepreload') {
 					body = (body as string).replace('</head>',
-						`<link rel="preload" as=${JSON.stringify(ref.as)} href=${JSON.stringify(ref.uri)} ${ref.as === 'script' ? 'crossorigin="use-credentials"' : ''}></head>`);
+						`<link rel=${ref.rel} as=${JSON.stringify(ref.as)} href=${JSON.stringify(ref.uri)} ${ref.as === 'script' ? 'crossorigin="use-credentials"' : ''}></head>`);
 				}
 			});
 


### PR DESCRIPTION
Found a solution rel="preload" is not suited for modules, so using rel="modulepreload" is working fine in this setup with the credentials attribute as it is. Have been testing it and I don't get any console warnings anymore.

See issue: Preload tags causing troubles - warning in console + google cannot crawl page anymore [#1576](https://github.com/sveltejs/sapper/issues/1576)
