### PR TITLE
Allow process.env.PORT to be defined via .env file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1679,6 +1679,11 @@
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "test"
   },
   "dependencies": {
+    "dotenv": "^8.2.0",
     "html-minifier": "^4.0.0",
     "http-link-header": "^1.0.2",
     "shimport": "^2.0.4",

--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as http from 'http';


### PR DESCRIPTION
As commented in #1254 current config system doesn't support defining PORT env var via .env file, it's an easy fix, installing dotenv package and requiring it in the same file that port is defined it's enough since its already have in count process.env.PORT.
