### PR TITLE
Enable to specify host

### DIFF
--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -27,6 +27,7 @@ type Opts = {
 	hot?: boolean;
 	'devtools-port'?: number;
 	bundler?: 'rollup' | 'webpack';
+	host?: string;
 	port?: number;
 	ext: string;
 };
@@ -45,6 +46,7 @@ class Watcher extends EventEmitter {
 		output: string;
 		static: string;
 	}
+	host: string;
 	port: number;
 	closed: boolean;
 
@@ -81,6 +83,7 @@ class Watcher extends EventEmitter {
 		hot,
 		'devtools-port': devtools_port,
 		bundler,
+		host = process.env.HOST,
 		port = +process.env.PORT,
 		ext
 	}: Opts) {
@@ -98,6 +101,7 @@ class Watcher extends EventEmitter {
 			static: path.resolve(cwd, static_files)
 		};
 		this.ext = ext;
+		this.host = host;
 		this.port = port;
 		this.closed = false;
 
@@ -126,6 +130,9 @@ class Watcher extends EventEmitter {
 	}
 
 	async init() {
+		if (!this.host) {
+			this.host = 'localhost';
+		}
 		if (this.port) {
 			if (!await ports.check(this.port)) {
 				this.emit('fatal', {
@@ -240,6 +247,7 @@ class Watcher extends EventEmitter {
 						return ports.wait(this.port)
 							.then((() => {
 								this.emit('ready', {
+									host: this.host,
 									port: this.port,
 									process: this.proc
 								} as ReadyEvent);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ const start = Date.now();
 
 prog.command('dev')
 	.describe('Start a development server')
+	.option('-h, --host', 'Specify a host', 'localhost')
 	.option('-p, --port', 'Specify a port')
 	.option('-o, --open', 'Open a browser window')
 	.option('--dev-port', 'Specify a port for development server')
@@ -33,6 +34,7 @@ prog.command('dev')
 	.option('--build-dir', 'Development build directory', '__sapper__/dev')
 	.option('--ext', 'Custom Route Extension', '.svelte .html')
 	.action(async (opts: {
+		host: string;
 		port: number;
 		open: boolean;
 		'dev-port': number;
@@ -57,6 +59,7 @@ prog.command('dev')
 				static: opts.static,
 				output: opts.output,
 				dest: opts['build-dir'],
+				host: opts.host,
 				port: opts.port,
 				'dev-port': opts['dev-port'],
 				live: opts.live,
@@ -77,10 +80,10 @@ prog.command('dev')
 
 			watcher.on('ready', async (event: ReadyEvent) => {
 				if (first) {
-					console.log(colors.bold().cyan(`> Listening on http://localhost:${event.port}`));
+					console.log(colors.bold().cyan(`> Listening on http://${event.host}:${event.port}`));
 					if (opts.open) {
 						const { exec } = await import('child_process');
-						exec(`open http://localhost:${event.port}`);
+						exec(`open http://${event.host}:${event.port}`);
 					}
 					first = false;
 				}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -62,6 +62,7 @@ export type ManifestData = {
 };
 
 export type ReadyEvent = {
+	host: string;
 	port: number;
 	process: child_process.ChildProcess;
 };


### PR DESCRIPTION
### Summary
- This amendment accelerates us to do dev work in case your development environment does not let you open `http://localhost:3000` right away, or you want to do dev work with an external server.
- In my case, I got stuck at `npm run dev` mentioned in https://github.com/sveltejs/sapper#get-started so I had to dig the code to figure how I can actually Get Started.
  + My Chrome somehow kept redirecting to `https://localhost:3000` from `http://localhost:3000`.
- Although I ended up being able to make it work without this amendment, I thought it is better to let us just suggest to try using this option when someone else claimed about the hardcoded hostname so that we can avoid spending time for the case.

### Use Cases

Amend `package.json` before/after `npm install` at https://github.com/sveltejs/sapper#get-started

#### Use Hostname

```
"scripts": {
  "dev": "sapper dev --host my.external-server",
```

#### Use IP Address

```
"scripts": {
  "dev": "sapper dev --host 192.168.0.100",
```

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
