### PR TITLE
Enable sapper dev mode on https with non-localhost domain

### DIFF
--- a/sapper-dev-client.js
+++ b/sapper-dev-client.js
@@ -13,7 +13,7 @@ function check() {
 export function connect(port) {
 	if (source || !window.EventSource) return;
 
-	source = new EventSource(`http://${window.location.hostname}:${port}/__sapper__`);
+	source = new EventSource(`${window.location.protocol}//${window.location.hostname}:${port}/__sapper__`);
 
 	window.source = source;
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- this fixes #1588
- the problem is in file `sapper-dev-client.js` the protocol (http) is hard coded
- this PR change the protocol so it follows the "parent" protocol

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
