### PR TITLE
Service worker would fail if accessing static assets with query string

### DIFF
--- a/site/src/service-worker.js
+++ b/site/src/service-worker.js
@@ -45,7 +45,7 @@ self.addEventListener('fetch', event => {
 
 	// always serve static files and bundler-generated assets from cache
 	if (url.host === self.location.host && cached.has(url.pathname)) {
-		event.respondWith(caches.match(event.request));
+		event.respondWith(caches.match(event.request, { ignoreSearch: true }));
 		return;
 	}
 


### PR DESCRIPTION
Fixes #1587. The service worker would assume that is the request path matches an asset, then the asset is in the cache. It would then use `CacheStorage.match` to retrieve the request, but that would fail if the query string was different.

I don't think there's any reasonably simple way of writing a test for this unfortunately.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
