### PR TITLE
Fixed #1592 by ensuring `scroll` exists

### DIFF
--- a/runtime/src/app/router/index.ts
+++ b/runtime/src/app/router/index.ts
@@ -219,7 +219,7 @@ export async function navigate(dest: Target, id: number, noscroll?: boolean, has
 		}
 
 		scroll_history[cid] = scroll;
-		if (popstate || deep_linked) {
+		if (scroll && (popstate || deep_linked)) {
 			scrollTo(scroll.x, scroll.y);
 		} else {
 			scrollTo(0, 0);


### PR DESCRIPTION
This PR fixes #1592 by ensuring that the variable `scroll` exists before accessing its `x` and `y` properties.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
