### PR TITLE
Fix dynamic imports in entry chunk

### DIFF
--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -222,7 +222,7 @@ export default class RollupCompiler {
 
 						if (chunk_has_css) {
 							has_css = true;
-							chunk.code += `\nimport __inject_styles from './${inject_styles_file}';`;
+							chunk.code = `import __inject_styles from './${inject_styles_file}';\n` + chunk.code;
 						}
 					}
 				}


### PR DESCRIPTION
Closes https://github.com/sveltejs/sapper/issues/1593

The `import` of `inject_styles` has to come first in case we need to use it in the entry chunk