### PR TITLE
Remove duped module definitions

### DIFF
--- a/runtime/index.d.ts
+++ b/runtime/index.d.ts
@@ -1,8 +1,3 @@
-declare module '@sapper/app'
-declare module '@sapper/server'
-declare module '@sapper/service-worker'
-declare module '@sapper/common'
-
 declare module '@sapper/app' {
 	export interface Redirect {
 		statusCode: number


### PR DESCRIPTION
I'm on windows, and I can't figure out how to take a screenshot of the auto-complete. However this is trivial to repro, create a new sapper project, run the TS migration then go to `servert.ts` and try get auto-complete in ` sapper.middleware({})` - it will give nothing useful, if you cmd click in to middleware then delete these it will get fixed

I don't know the history, of how it got setup here, but TS sees the first `declare modules` which effectively says 'make it an any` then later TS sees the more concrete types but they get eaten by the 'any' in the compiler (because all types are a subtype of any)
