### PR TITLE
Fix runtime router handling of encoded query parameters

### DIFF
--- a/test/apps/encoding/src/routes/index.html
+++ b/test/apps/encoding/src/routes/index.html
@@ -1,3 +1,3 @@
 <h1>Great success!</h1>
 
-<a href="echo/page/encöded?message=hëllö+wörld&föo=bar&=baz&tel=%2B123456789">link</a>
+<a href="echo/page/encöded?message=hëllö+wörld&föo=bar&=baz&tel=%2B123456789&multiline=multi%0Aline">link</a>

--- a/test/apps/encoding/test.ts
+++ b/test/apps/encoding/test.ts
@@ -26,11 +26,11 @@ describe('encoding', function() {
 	});
 
 	it('encodes req.params and req.query for server-rendered pages', async () => {
-		await r.load('/echo/page/encöded?message=hëllö+wörld&föo=bar&=baz&tel=%2B123456789');
+		await r.load('/echo/page/encöded?message=hëllö+wörld&föo=bar&=baz&tel=%2B123456789&multiline=multi%0Aline');
 
 		assert.strictEqual(
 			await r.text('h1'),
-			'encöded {"message":"hëllö wörld","föo":"bar","":"baz","tel":"+123456789"}'
+			'encöded {"message":"hëllö wörld","föo":"bar","":"baz","tel":"+123456789","multiline":"multi\\nline"}'
 		);
 	});
 
@@ -44,7 +44,7 @@ describe('encoding', function() {
 
 		assert.strictEqual(
 			await r.text('h1'),
-			'encöded {"message":"hëllö wörld","föo":"bar","":"baz","tel":"+123456789"}'
+			'encöded {"message":"hëllö wörld","föo":"bar","":"baz","tel":"+123456789","multiline":"multi\\nline"}'
 		);
 	});
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
 		"moduleResolution": "Node",
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
-		"lib": ["es5", "es6", "dom"],
+		"lib": ["es5", "es6", "dom", "dom.iterable"],
 		"importHelpers": true,
 		"target": "ES6",
 		"baseUrl": ".",


### PR DESCRIPTION
Hello Sapper team! Thanks for creating this fantastic framework.

I found an issue where a link such as 

    <a href="/?multiline=multi%0Aline">link</a>

will cause runtime routes to parse the query parameters as

    { multiline: "multi" }

instead of

    { multiline: "multi\nline" }

It looks like sapper@0.6.0 removed the dependency from [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams) with a custom RegExp to accommodate IE11. Using `URLSearchParams` prevents this and potentially future query parsing bugs from happening, so this PR tries to use `URLSearchParams` when available and fixes the old RegExp to allow.

To fix current query parser adding the [RegExp/dotAll `/s`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll) would be sufficient but unfortunately, it does not work on IE11 or FF Android. So the `[\s\S]*` RegExp tick is used as opposed to `.*`.

Since `URLSearchParams` uses iterables, I also had to add `dom.iterable` to the `tsconfig.json` file to get the tests passing. Since I am new to `TypeScript` I am not sure what the implication might be for the final sapper client-side bundle.

I have tested the IE11 code by disabling the `URLSearchParams` block. Are IE11 tests executed automatically by the CI pipeline before pushing a release?