### PR TITLE
Add dev-port-timeout opt to dev command

### DIFF
--- a/src/api/dev.ts
+++ b/src/api/dev.ts
@@ -23,6 +23,7 @@ type Opts = {
 	output?: string;
 	static?: string;
 	'dev-port'?: number;
+	'dev-port-timeout'?: number;
 	live?: boolean;
 	hot?: boolean;
 	'devtools-port'?: number;
@@ -49,6 +50,7 @@ class Watcher extends EventEmitter {
 	closed: boolean;
 
 	dev_port: number;
+	dev_port_timeout: number;
 	live: boolean;
 	hot: boolean;
 
@@ -77,6 +79,7 @@ class Watcher extends EventEmitter {
 		static: static_files = 'static',
 		dest = '__sapper__/dev',
 		'dev-port': dev_port,
+		'dev-port-timeout': dev_port_timeout = 5000, // Value found in `port-authority` https://github.com/Rich-Harris/port-authority/blob/master/src/wait.ts#L3
 		live,
 		hot,
 		'devtools-port': devtools_port,
@@ -102,6 +105,7 @@ class Watcher extends EventEmitter {
 		this.closed = false;
 
 		this.dev_port = dev_port;
+		this.dev_port_timeout = dev_port_timeout;
 		this.live = live;
 		this.hot = hot;
 
@@ -237,7 +241,7 @@ class Watcher extends EventEmitter {
 					const restart = () => {
 						this.crashed = false;
 
-						return ports.wait(this.port)
+						return ports.wait(this.port, { timeout: this.dev_port_timeout })
 							.then((() => {
 								this.emit('ready', {
 									port: this.port,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ prog.command('dev')
 	.option('-p, --port', 'Specify a port')
 	.option('-o, --open', 'Open a browser window')
 	.option('--dev-port', 'Specify a port for development server')
+	.option('--dev-port-timeout', 'Specify a timeout for the dev port watcher', 5000)
 	.option('--hot', 'Use hot module replacement (requires webpack)', true)
 	.option('--live', 'Reload on changes if not using --hot', true)
 	.option('--bundler', 'Specify a bundler (rollup or webpack)')
@@ -36,6 +37,7 @@ prog.command('dev')
 		port: number;
 		open: boolean;
 		'dev-port': number;
+		'dev-port-timeout': number;
 		live: boolean;
 		hot: boolean;
 		bundler?: 'rollup' | 'webpack';
@@ -59,6 +61,7 @@ prog.command('dev')
 				dest: opts['build-dir'],
 				port: opts.port,
 				'dev-port': opts['dev-port'],
+				'dev-port-timeout': opts['dev-port-timeout'],
 				live: opts.live,
 				hot: opts.hot,
 				bundler: opts.bundler,


### PR DESCRIPTION
Added support for `--dev-port-timeout` to solve `Server is not listening on port XXXX` within some environments. (#1007 #730 #486 #431)

> Failing lint job is solved in #1633

Tests were not implemented since I could not find any existing tests covering `src/api/dev.ts` or `src/cli.ts`.

```
./sapper dev -h

  Description
    Start a development server

  Usage
    $ sapper dev [options]

  Options
    //...
    --dev-port            Specify a port for development server
    --dev-port-timeout    Specify a timeout for the dev port watcher  (default 5000)
   //...
```

--- 

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
