### PR TITLE
Downgrade Rollup to working version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -180,8 +180,8 @@
       }
     },
     "@sveltejs/eslint-config": {
-      "version": "github:sveltejs/eslint-config#673335baf2ebc4b845eca9ea8eb51a050fd5cc25",
-      "from": "github:sveltejs/eslint-config#v5.2.0",
+      "version": "github:sveltejs/eslint-config#5d1ba28f99568e42f26d9b7484ab57720f6ec9b4",
+      "from": "github:sveltejs/eslint-config#v5.4.0",
       "dev": true
     },
     "@types/color-name": {
@@ -5037,9 +5037,9 @@
       }
     },
     "rollup": {
-      "version": "2.28.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.28.2.tgz",
-      "integrity": "sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==",
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.23.1.tgz",
+      "integrity": "sha512-Heyl885+lyN/giQwxA8AYT2GY3U+gOlTqVLrMQYno8Z1X9lAOpfXPiKiZCyPc25e9BLJM3Zlh957dpTlO4pa8A==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "puppeteer": "^5.0.0",
     "require-relative": "^0.8.7",
     "rimraf": "^3.0.2",
-    "rollup": "^2.28.2",
+    "rollup": "2.23.1",
     "rollup-dependency-tree": "0.0.14",
     "rollup-plugin-css-chunks": "^1.2.6",
     "rollup-plugin-svelte": "^5.1.0",


### PR DESCRIPTION
Closes https://github.com/sveltejs/sapper/issues/1634. Sapper works Rollup with 2.23.1, but not with 2.24.0