### PR TITLE
Supply `req.url` value as `should_ignore` fallback

### DIFF
--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -80,7 +80,7 @@ export function compose_handlers(ignore: IgnoreValue, handlers: Handler[]): Hand
 	return !ignore
 		? (req, res, next) => nth_handler(0, req, res, next)
 		: (req, res, next) => {
-			if (should_ignore(req.path, ignore)) {
+			if (should_ignore(req.path || req.url, ignore)) {
 				next();
 			} else {
 				nth_handler(0, req, res, next);


### PR DESCRIPTION
When used with the Fastify compatibility layer for Express-like plugins ([`middie`](https://github.com/fastify/middie)), the value of `req.path` is undefined which causes an error.

This PR proposes to add `req.url` as a fallback path in the event that `req.path` is undefined - fixing the optional ignore option

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
