### PR TITLE
Adds HTTPS support for Sapper DevServer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -848,6 +848,16 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -2454,6 +2464,13 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3990,6 +4007,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -6469,7 +6493,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/sapper-dev-client.js
+++ b/sapper-dev-client.js
@@ -5,20 +5,20 @@ function check() {
 
 	if (module.hot.status() === 'idle') {
 		module.hot.check(true).then(modules => {
-			console.log(`[SAPPER] applied HMR update`);
+			console.log('[SAPPER] applied HMR update');
 		});
 	}
 }
 
-export function connect(port) {
+export function connect(serveHttps, port) {
 	if (source || !window.EventSource) return;
 
-	source = new EventSource(`http://${window.location.hostname}:${port}/__sapper__`);
+	source = new EventSource(`${serveHttps ? 'https' : 'http'}://${window.location.hostname}:${port}/__sapper__`);
 
 	window.source = source;
 
 	source.onopen = function(event) {
-		console.log(`[SAPPER] dev client connected`);
+		console.log('[SAPPER] dev client connected');
 	};
 
 	source.onerror = function(error) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,9 @@ prog.command('dev')
 	.option('-p, --port', 'Specify a port')
 	.option('-o, --open', 'Open a browser window')
 	.option('--dev-port', 'Specify a port for development server')
+	.option('--https', 'Specify if development server should be served in https')
+	.option('--https-certfile-path', 'Specify the cert file path for the https development server')
+	.option('--https-keyfile-path', 'Specify the key file path for the https development server')
 	.option('--hot', 'Use hot module replacement (requires webpack)', true)
 	.option('--live', 'Reload on changes if not using --hot', true)
 	.option('--bundler', 'Specify a bundler (rollup or webpack)')
@@ -38,6 +41,9 @@ prog.command('dev')
 		'dev-port': number;
 		live: boolean;
 		hot: boolean;
+		https?: boolean;
+		'https-certfile-path'?: string;
+		'https- keyfile-path'?: string;
 		bundler?: 'rollup' | 'webpack';
 		cwd: string;
 		src: string;
@@ -61,6 +67,9 @@ prog.command('dev')
 				'dev-port': opts['dev-port'],
 				live: opts.live,
 				hot: opts.hot,
+				serveHttps: opts.https,
+				'https-certfile-path': opts['https-certfile-path'],
+				'https-keyfile-path': opts['https-keyfile-path'],
 				bundler: opts.bundler,
 				ext: opts.ext
 			});

--- a/src/core/create_app.ts
+++ b/src/core/create_app.ts
@@ -7,6 +7,7 @@ export function create_app({
 	bundler,
 	manifest_data,
 	dev_port,
+	dev_serveHttps,
 	dev,
 	cwd,
 	src,
@@ -17,6 +18,7 @@ export function create_app({
 	bundler: string;
 	manifest_data: ManifestData;
 	dev_port?: number;
+	dev_serveHttps?: boolean;
 	dev: boolean;
 	cwd: string;
 	src: string;
@@ -28,7 +30,7 @@ export function create_app({
 
 	const path_to_routes = path.relative(`${output}/internal`, routes);
 
-	const client_manifest = generate_client_manifest(manifest_data, path_to_routes, bundler, dev, dev_port);
+	const client_manifest = generate_client_manifest(manifest_data, path_to_routes, bundler, dev, dev_port, dev_serveHttps);
 	const server_manifest = generate_server_manifest(manifest_data, path_to_routes, cwd, src, dest, dev);
 
 	const app = generate_app(manifest_data, path_to_routes);
@@ -81,7 +83,8 @@ function generate_client_manifest(
 	path_to_routes: string,
 	bundler: string,
 	dev: boolean,
-	dev_port?: number
+	dev_port?: number,
+	serveHttps?: boolean
 ) {
 	const page_ids = new Set(manifest_data.pages.map(page =>
 		page.pattern.toString()));
@@ -149,7 +152,7 @@ function generate_client_manifest(
 
 		${dev ? `if (typeof window !== 'undefined') {
 			import(${stringify(posixify(path.resolve(__dirname, '../sapper-dev-client.js')))}).then(client => {
-				client.connect(${dev_port});
+				client.connect(${serveHttps}, ${dev_port});
 			});
 		}` : ''}
 	`.replace(/^\t{2}/gm, '').trim();


### PR DESCRIPTION
Adds HTTPS support for Sapper DevServer, exposing the intent of whether the user want or not the dev server to be server in https with the required SSL options such as cert and key files exposed as well via the configuration.

Reference PRs/Issues: https://github.com/sveltejs/sapper/issues/384, https://github.com/sveltejs/sapper/pull/1379, https://github.com/sveltejs/sapper/pull/1453, https://github.com/sveltejs/sapper/issues/1588

**_DISCLAIMER:_**

Mind our heresy, but We've written no tests... yet. Since this our first PR we are creating this to capture feedback whether this is or not the correct approach. For our project surely is, because it works as expected, but Sapper Dev team may have a different roadmap that we cannot foresee.

Let us know if this is ok or any suggestions really and based on that we can add the required tests for the change. Thanks!

Co-authored-by: João Santos <jsantos@equalexperts.com>

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it. (_please see disclaimer above 👆_)

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
