### PR TITLE
Allow layout components to be grouped together

### DIFF
--- a/src/core/create_manifest_data.ts
+++ b/src/core/create_manifest_data.ts
@@ -167,7 +167,7 @@ export default function create_manifest_data(cwd: string, extensions = '.svelte 
 		});
 	}
 
-	const root = find_layout('_layout', 'main') || default_layout;
+	const root = find_layout('_layout', 'main') || find_layout('index', 'main', '_layout') || default_layout;
 	const error = find_layout('_error', 'error') || default_error;
 
 	walk(cwd, [], [], []);


### PR DESCRIPTION
Fixes #708 by trying to load `src/routes/_layout.{ext}` and `src/routes/_layout/index.{ext}` before falling back to the default layout.

Works locally by using `npm link`.