### PR TITLE
Fixes #1667 prefetching fails if clicking quickly back and forth

### DIFF
--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -240,8 +240,7 @@ export async function hydrate_target(dest: Target): Promise<HydratedTarget> {
 
 			if (!session_dirty && !segment_dirty && current_branch[i] && current_branch[i].part === part.i) {
 				result = current_branch[i];
-			}
-			else {
+			} else {
 				segment_dirty = false;
 	
 				const { default: component, preload } = await components[part.i].js();

--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -236,29 +236,35 @@ export async function hydrate_target(dest: Target): Promise<HydratedTarget> {
 
 			const j = l++;
 
+			let result;
+
 			if (!session_dirty && !segment_dirty && current_branch[i] && current_branch[i].part === part.i) {
-				return current_branch[i];
+				result = current_branch[i];
+			}
+			else {
+				segment_dirty = false;
+	
+				const { default: component, preload } = await components[part.i].js();
+	
+				let preloaded: object;
+	
+				if (ready || !initial_data.preloaded[i + 1]) {
+					preloaded = preload
+						? await preload.call(preload_context, {
+							host: page.host,
+							path: page.path,
+							query: page.query,
+							params: part.params ? part.params(dest.match) : {}
+						}, $session)
+						: {};
+				} else {
+					preloaded = initial_data.preloaded[i + 1];
+				}
+
+				result = { component, props: preloaded, segment, match, part: part.i };
 			}
 
-			segment_dirty = false;
-
-			const { default: component, preload } = await components[part.i].js();
-
-			let preloaded: object;
-			if (ready || !initial_data.preloaded[i + 1]) {
-				preloaded = preload
-					? await preload.call(preload_context, {
-						host: page.host,
-						path: page.path,
-						query: page.query,
-						params: part.params ? part.params(dest.match) : {}
-					}, $session)
-					: {};
-			} else {
-				preloaded = initial_data.preloaded[i + 1];
-			}
-
-			return (props[`level${j}`] = { component, props: preloaded, segment, match, part: part.i });
+			return (props[`level${j}`] = result);
 		}));
 	} catch (error) {
 		props.error = error;

--- a/test/apps/basics/src/routes/prefetch-timing/prefetched/index.svelte
+++ b/test/apps/basics/src/routes/prefetch-timing/prefetched/index.svelte
@@ -15,7 +15,7 @@
 
 				/**
 				 * This emulates the logic in start prefetching. Just firing after the first mouse move
-				 * would also work fine in the Pupetteer tests, just not if you try it manually.
+				 * would also work fine in the Puppeteer tests, just not if you try it manually.
 				 */
 				prefetchlink.addEventListener('mousemove', () => {
 						clearTimeout(timeout);

--- a/test/apps/basics/src/routes/prefetch-timing/prefetched/index.svelte
+++ b/test/apps/basics/src/routes/prefetch-timing/prefetched/index.svelte
@@ -1,0 +1,35 @@
+<script context="module">
+		export function preload() {
+				if (typeof window !== 'undefined' && window.onPrefetched) {
+						Promise.resolve().then(() => window.onPrefetched());
+				}
+		}
+</script>
+
+<script>
+		import { onMount } from 'svelte';
+		let prefetchlink;
+
+		onMount(() => {
+				let timeout;
+
+				/**
+				 * This emulates the logic in start prefetching. Just firing after the first mouse move
+				 * would also work fine in the Pupetteer tests, just not if you try it manually.
+				 */
+				prefetchlink.addEventListener('mousemove', () => {
+						clearTimeout(timeout);
+
+						if (window.onPrefetched) {
+								timeout = setTimeout(() => {
+										window.onPrefetched();
+								}, 50);
+						}
+				});
+		});
+</script>
+
+<h1>Prefetched</h1>
+
+<a href="/prefetch-timing/prefetcher">prefetcher</a>
+<a href="/prefetch-timing/prefetched" rel="prefetch" bind:this={prefetchlink}>prefetched</a>

--- a/test/apps/basics/src/routes/prefetch-timing/prefetcher/index.svelte
+++ b/test/apps/basics/src/routes/prefetch-timing/prefetcher/index.svelte
@@ -1,0 +1,13 @@
+<script context="module">
+    export function preload() {
+        if (typeof window !== 'undefined') {
+            return new Promise((resolve) => {
+                window.onPrefetched = resolve;
+            });
+        }
+    }
+</script>
+
+<h1>Prefetcher</h1>
+
+<a href="/prefetch-timing/prefetched" rel="prefetch">prefetched</a>

--- a/test/apps/basics/test.ts
+++ b/test/apps/basics/test.ts
@@ -389,10 +389,6 @@ describe('basics', function() {
 		assert.equal(await r.text('h2'), 'Called 1 time');
 	});
 
-	it('survives the tests with no server errors', () => {
-		assert.deepEqual(r.errors, []);
-	});
-
 	/**
 	 * Before a page navigation finishes, hover over a prefetching link back to the page we came from.
 	 * Prefetching starts, but we're still on the page being preloaded! 
@@ -400,26 +396,30 @@ describe('basics', function() {
 	 * https://github.com/sveltejs/sapper/issues/1667
 	 */
 	it('handles prefetching to the current page', async () => {
-			await r.load('/prefetch-timing/prefetched');
-			await r.sapper.start();
-			await r.sapper.prefetchRoutes();
+		await r.load('/prefetch-timing/prefetched');
+		await r.sapper.start();
+		await r.sapper.prefetchRoutes();
 
-			assert.strictEqual(await r.text('h1'), 'Prefetched');
+		assert.strictEqual(await r.text('h1'), 'Prefetched');
 
-			const prefetchedSelector = 'a[href="/prefetch-timing/prefetched"]';
-			const prefetcherSelector = 'a[href="/prefetch-timing/prefetcher"]';
+		const prefetchedSelector = 'a[href="/prefetch-timing/prefetched"]';
+		const prefetcherSelector = 'a[href="/prefetch-timing/prefetcher"]';
 
-			await r.page.click(prefetcherSelector);
-			await r.wait();
+		await r.page.click(prefetcherSelector);
+		await r.wait();
 
-			await r.page.hover(prefetchedSelector);
-			await r.wait(50);
+		await r.page.hover(prefetchedSelector);
+		await r.wait(50);
 
-			await r.page.waitForFunction(() => document.querySelector('h1').innerHTML == 'Prefetcher');
+		await r.page.waitForFunction(() => document.querySelector('h1').innerHTML == 'Prefetcher');
 
-			await r.page.click(prefetchedSelector);
-			await r.wait();
+		await r.page.click(prefetchedSelector);
+		await r.wait();
 
-			assert.strictEqual(await r.text('h1'), 'Prefetched');
+		assert.strictEqual(await r.text('h1'), 'Prefetched');
+	});
+
+	it('survives the tests with no server errors', () => {
+		assert.deepEqual(r.errors, []);
 	});
 });

--- a/test/apps/basics/test.ts
+++ b/test/apps/basics/test.ts
@@ -392,4 +392,34 @@ describe('basics', function() {
 	it('survives the tests with no server errors', () => {
 		assert.deepEqual(r.errors, []);
 	});
+
+	/**
+	 * Before a page navigation finishes, hover over a prefetching link back to the page we came from.
+	 * Prefetching starts, but we're still on the page being preloaded! 
+	 * After that happened, clicking on the link back to the original page did not work.
+	 * https://github.com/sveltejs/sapper/issues/1667
+	 */
+	it('handles prefetching to the current page', async () => {
+			await r.load('/prefetch-timing/prefetched');
+			await r.sapper.start();
+			await r.sapper.prefetchRoutes();
+
+			assert.strictEqual(await r.text('h1'), 'Prefetched');
+
+			const prefetchedSelector = 'a[href="/prefetch-timing/prefetched"]';
+			const prefetcherSelector = 'a[href="/prefetch-timing/prefetcher"]';
+
+			await r.page.click(prefetcherSelector);
+			await r.wait();
+
+			await r.page.hover(prefetchedSelector);
+			await r.wait(50);
+
+			await r.page.waitForFunction(() => document.querySelector('h1').innerHTML == 'Prefetcher');
+
+			await r.page.click(prefetchedSelector);
+			await r.wait();
+
+			assert.strictEqual(await r.text('h1'), 'Prefetched');
+	});
 });


### PR DESCRIPTION
Fixes #1667 

When prefetching a page that is the current page, no props got stored in `prefetching`

~I'm not entirely sure how to best write a test for this. Any pointers?~ Managed to add a test. It's a bit brittle (in the sense that if the prefetching logic changes it might pass even if the bug were to be reintroduced, not in the sense of sporadically failing) but I don't see any better way to handle it.

This is the kind of thing that unit tests might be better at, but the routing/preloading logic has so much global state that's pretty much impossible.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
