### PR TITLE
Revert "Fix dynamic imports in entry chunk (#1595)", which would break source maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-* Fix dynamic imports in Rollup entry chunk ([#1595](https://github.com/sveltejs/sapper/issues/1595))
 * Numerous TypeScript definition improvements ([#1598](https://github.com/sveltejs/sapper/issues/1598), [#1601](https://github.com/sveltejs/sapper/issues/1601), [#1603](https://github.com/sveltejs/sapper/issues/1603), [#1604](https://github.com/sveltejs/sapper/issues/1604))
 
 ## 0.28.10

--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -222,7 +222,7 @@ export default class RollupCompiler {
 
 						if (chunk_has_css) {
 							has_css = true;
-							chunk.code = `import __inject_styles from './${inject_styles_file}';\n` + chunk.code;
+							chunk.code += `\nimport __inject_styles from './${inject_styles_file}';`;
 						}
 					}
 				}


### PR DESCRIPTION
This reverts commit ee84ea29eac879e05ae61b8a0f45138ebf88569f.

Reopens https://github.com/sveltejs/sapper/issues/1593