### PR TITLE
Remove injectImports flag from roll-plugin-css-chunks

### DIFF
--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -155,7 +155,7 @@ export default class RollupCompiler {
 		const that = this;
 
 		// TODO this is hacky. refactor out into an external rollup plugin
-		(mod.plugins || (mod.plugins = [])).push(css_chunks({ injectImports: true }));
+		(mod.plugins || (mod.plugins = [])).push(css_chunks());
 		if (!/[\\/]client\./.test(entry_point)) {
 			return mod;
 		}


### PR DESCRIPTION
This can add something like `@import 'Nav-ad2b16a3.css';` into the CSS which causes a second request for the dependent CSS and also breaks source maps

I really don't know why I ever set this. I think I had it confused with `rollup-plugin-svelte`'s `emitCss` option which puts import statements into the JavaScript files