### PR TITLE
When getTimings is exposed from rollup output the info. 

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -306,7 +306,7 @@ async function _export({
 		queue.addSave(save(message.url, message.status, message.type, message.body));
 	});
 
-	return new Promise((res, rej) => {
+	return new Promise<void>((res, rej) => {
 		queue.setCallback('onDone', () => {
 			proc.kill();
 			res();

--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -21,6 +21,12 @@ const INJECT_STYLES_ID = 'inject_styles.js';
 
 let rollup: any;
 
+function printTimings(timings: {[event: string]: [number, number, number]}) {
+	for (const [key, info] of Object.entries(timings)) {
+		console.info(`${key} took ${info[0].toFixed(0)}ms`);
+	}
+}
+
 const inject_styles = `
 export default function(files) {
 	return Promise.all(files.map(function(file) { return new Promise(function(fulfil, reject) {
@@ -319,7 +325,9 @@ export default class RollupCompiler {
 		try {
 			const bundle = await rollup.rollup(config);
 			await bundle.write(config.output);
-
+			if (bundle.getTimings != null) {
+				printTimings(bundle.getTimings());
+			}
 			return new RollupResult(Date.now() - start, this, sourcemap);
 		} catch (err) {
 			// flush warnings
@@ -374,10 +382,7 @@ export default class RollupCompiler {
 
 				case 'BUNDLE_END':
 					if (event.result.getTimings != null) {
-						const timings = event.result.getTimings();
-						for (const [key, info] of Object.entries(timings)) {
-							console.info(`${key} took ${info[0].toFixed(0)}ms`);
-						}
+						printTimings(event.result.getTimings());
 					}
 					cb(null, new RollupResult(Date.now() - this._start, this, sourcemap));
 					break;

--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -373,6 +373,12 @@ export default class RollupCompiler {
 					break;
 
 				case 'BUNDLE_END':
+					if (event.result.getTimings != null) {
+						const timings = event.result.getTimings();
+						for (const [key, info] of Object.entries(timings)) {
+							console.info(`${key} took ${info[0].toFixed(0)}ms`);
+						}
+					}
 					cb(null, new RollupResult(Date.now() - this._start, this, sourcemap));
 					break;
 


### PR DESCRIPTION
`getTimings` is exposed from rollup when `perf: true` is set in the rollup
config https://github.com/rollup/rollup/pull/2065/commits/6913e396544a8976cf18dd3392dccf4a2c5b697c . Previously there was no way to get this information from a
customer's perspective when using sapper in development mode or when building via `sapper build`. This meant that if a customer wanted to understand why their build was slow they had not clear path forward.

With this change, setting `perf: true` in the rollup config  will now display
this information to the command line when running `sapper dev` and `sapper build`