### PR TITLE
Resolve issues of SAPPER_EXPORT variable

### DIFF
--- a/runtime/src/server/middleware/get_server_route_handler.ts
+++ b/runtime/src/server/middleware/get_server_route_handler.ts
@@ -10,7 +10,7 @@ export function get_server_route_handler(routes: ServerRoute[]) {
 		const method_export = method === 'delete' ? 'del' : method;
 		const handle_method = route.handlers[method_export];
 		if (handle_method) {
-			const isSapperExportEnabled = JSON.parse(process.env.SAPPER_EXPORT)
+			const isSapperExportEnabled = JSON.parse(process.env.SAPPER_EXPORT);
 			if (isSapperExportEnabled) {
 				const { write, end, setHeader } = res;
 				const chunks: any[] = [];

--- a/runtime/src/server/middleware/get_server_route_handler.ts
+++ b/runtime/src/server/middleware/get_server_route_handler.ts
@@ -10,7 +10,7 @@ export function get_server_route_handler(routes: ServerRoute[]) {
 		const method_export = method === 'delete' ? 'del' : method;
 		const handle_method = route.handlers[method_export];
 		if (handle_method) {
-			const isSapperExportEnabled = JSON.parse(process.env.SAPPER_EXPORT);
+			const isSapperExportEnabled = JSON.parse(process.env.SAPPER_EXPORT || null);
 			if (isSapperExportEnabled) {
 				const { write, end, setHeader } = res;
 				const chunks: any[] = [];

--- a/runtime/src/server/middleware/get_server_route_handler.ts
+++ b/runtime/src/server/middleware/get_server_route_handler.ts
@@ -10,7 +10,8 @@ export function get_server_route_handler(routes: ServerRoute[]) {
 		const method_export = method === 'delete' ? 'del' : method;
 		const handle_method = route.handlers[method_export];
 		if (handle_method) {
-			if (process.env.SAPPER_EXPORT) {
+			const isSapperExportEnabled = JSON.parse(process.env.SAPPER_EXPORT)
+			if (isSapperExportEnabled) {
 				const { write, end, setHeader } = res;
 				const chunks: any[] = [];
 				const headers: Record<string, string> = {};


### PR DESCRIPTION
Some repositories that will use Sapper in development will face with issue: 'process.send not found'

It happens when user provides own variable SAPPER_EXPORT in environment, but user not provided 'process' in package.
As I understood, the main goal in checking for environment variable.
Currently, `get_server_route_handler` just checks the existing of variable instead a value

More details in issue of repository that uses Sapper: https://github.com/Zimtir/SENT-template/issues/114

Another solution: write in README.md that user should be sure when provides a value into SAPPER_EXPORT variable

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
