### PR TITLE
Support for dynamically setting the `lang` attribute

### DIFF
--- a/runtime/src/app/types.ts
+++ b/runtime/src/app/types.ts
@@ -5,14 +5,19 @@ export interface HydratedTarget {
 	preload_error?: any;
 	props: any;
 	branch: Branch;
+	lang?: string;
 }
 
-export type Branch = Array<{
+export interface BranchSegment {
 	segment: string;
+	props?: object;
 	match?: RegExpExecArray;
 	component?: DOMComponentConstructor;
 	part?: number;
-}>;
+	lang?: string;
+}
+
+export type Branch = BranchSegment[];
 
 export type InitialData = {
 	session: any;

--- a/runtime/src/internal/manifest-client.d.ts
+++ b/runtime/src/internal/manifest-client.d.ts
@@ -1,4 +1,4 @@
-import { PageParams } from '@sapper/common';
+import { PageContext, PageParams } from '@sapper/common';
 import {
 	Preload
 } from './shared';
@@ -6,6 +6,7 @@ import {
 export interface DOMComponentModule {
 	default: DOMComponentConstructor;
 	preload?: Preload;
+	lang?: (ctx: PageContext) => string;
 }
 
 export interface DOMComponent {
@@ -32,5 +33,5 @@ export interface Route {
 export const ErrorComponent: DOMComponentConstructor;
 export const components: DOMComponentLoader[];
 export const ignore: RegExp[];
-export const root_comp: { preload: Preload };
+export const root_comp: { preload: Preload; lang?: (ctx: PageContext) => string };
 export const routes: Route[];

--- a/runtime/src/internal/manifest-server.d.ts
+++ b/runtime/src/internal/manifest-server.d.ts
@@ -1,5 +1,6 @@
 import {
-	Preload
+	Preload,
+	PageContext
 } from './shared';
 
 export const src_dir: string;
@@ -12,6 +13,7 @@ export { SapperRequest, SapperResponse } from '@sapper/server';
 export interface SSRComponentModule {
 	default: SSRComponent;
 	preload?: Preload;
+	lang?: (ctx: PageContext) => string;
 }
 
 export interface SSRComponent {

--- a/site/src/template.html
+++ b/site/src/template.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang='en' class="theme-default typo-default">
+<html lang='%sapper.lang%' class="theme-default typo-default">
 <head>
 	<meta charset='utf-8'>
 	<meta name='viewport' content='width=device-width,initial-scale=1.0'>

--- a/test/apps/basics/src/routes/lang/[lang].svelte
+++ b/test/apps/basics/src/routes/lang/[lang].svelte
@@ -1,0 +1,8 @@
+<script context="module">
+    export function lang(context) {
+        return context.params.lang;
+    }
+</script>
+
+<a id="sv" href="/lang/sv">sv</a>
+<a id="en" href="/lang/en">en</a>

--- a/test/apps/basics/src/template.html
+++ b/test/apps/basics/src/template.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="%sapper.lang%">
 <head>
 	<meta charset='utf-8'>
 

--- a/test/apps/basics/test.ts
+++ b/test/apps/basics/test.ts
@@ -277,6 +277,18 @@ describe('basics', function() {
 		assert.equal(html.indexOf('%sapper'), -1);
 	});
 
+	it('replaces %sapper.lang%', async () => {
+		await r.load('/lang/sv');
+		await r.sapper.start();
+
+		const get_document_lang = () => r.page.evaluate(() => document.documentElement.lang);
+		assert.equal(await get_document_lang(), 'sv');
+
+		await r.page.click('#en');
+		await r.wait();
+		assert.equal(await get_document_lang(), 'en');
+	});
+
 	it('navigates between routes with empty parts', async () => {
 		await r.load('/dirs/foo');
 		await r.sapper.start();


### PR DESCRIPTION
Currently the `lang` attribute in the `html` tag is hard-coded in `template.html`. This makes it impossible to build multi-language sites with Sapper.

This PR allows routes to export a `lang` function in addition to `preload`. It gets the same path information as `preload` and returns a language code to use for the page. The most specific component wins.

See discussion in #576 

I know Sapper is currently in maintenance mode and that this is tied up in the much larger internationalization question, but this feels like a fairly straightforward extension. At Hyperlab we are currently building two multi-language sites. Without the ability to determine the language dynamically we would need to fork Sapper. 

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
