### PR TITLE
Fix scroll position is not restored after changing search param with `goto`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Please see the [migration guide](https://sapper.svelte.dev/migrating#0_28_to_0_29) for details on migrating from Sapper 0.28 to Sapper 0.29.
 
+* Fix scroll position restoration after changing search param with `goto` ([#1697](https://github.com/sveltejs/sapper/issues/1697))
 * Allow dynamic imports in client.js by upgrading Shimport to properly hoist imports ([#1593](https://github.com/sveltejs/sapper/issues/1593))
 * Change rel=prefetch to sapper:prefetch ([#1566](https://github.com/sveltejs/sapper/pull/1566))
 * Support Rollup's `perf` option ([#1685](https://github.com/sveltejs/sapper/pull/1685))

--- a/runtime/src/app/goto/index.ts
+++ b/runtime/src/app/goto/index.ts
@@ -8,8 +8,9 @@ export default function goto(
 	const target = select_target(new URL(href, get_base_uri(document)));
 
 	if (target) {
+		const res = navigate(target, null, opts.noscroll);
 		history[opts.replaceState ? 'replaceState' : 'pushState']({ id: cid }, '', href);
-		return navigate(target, null, opts.noscroll);
+		return res;
 	}
 
 	location.href = href;

--- a/test/apps/scroll/src/routes/search-page.svelte
+++ b/test/apps/scroll/src/routes/search-page.svelte
@@ -1,0 +1,20 @@
+<script>
+  import { goto } from "@sapper/app";
+  function search(query) {
+    goto(window.location.pathname + `?q=${query}`);
+  }
+</script>
+
+<h1>A search form</h1>
+
+<div style="height: 9999px" />
+
+<div id="search">
+  <button id="submit-search" on:click={() => search('test')}>Search</button>
+</div>
+
+<div style="height: 5000px" />
+
+<div id="end">
+  <button id="navigate" on:click={() => goto('/tall-page')}>Navigate away</button>
+</div>

--- a/test/apps/scroll/src/routes/search-page.svelte
+++ b/test/apps/scroll/src/routes/search-page.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { goto } from "@sapper/app";
+  import { goto } from '@sapper/app';
   function search(query) {
     goto(window.location.pathname + `?q=${query}`);
   }

--- a/test/apps/scroll/test.ts
+++ b/test/apps/scroll/test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { build } from '../../../api';
 import { AppRunner } from '../AppRunner';
 
-describe('scroll', function () {
+describe('scroll', function() {
 	this.timeout(10000);
 
 	let r: AppRunner;

--- a/test/apps/scroll/test.ts
+++ b/test/apps/scroll/test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { build } from '../../../api';
 import { AppRunner } from '../AppRunner';
 
-describe('scroll', function() {
+describe('scroll', function () {
 	this.timeout(10000);
 
 	let r: AppRunner;
@@ -50,10 +50,7 @@ describe('scroll', function() {
 		await r.page.click('[href="another-tall-page"]');
 		await r.wait();
 
-		assert.strictEqual(
-			await r.page.evaluate(() => window.scrollY),
-			0
-		);
+		assert.strictEqual(await r.page.evaluate(() => window.scrollY), 0);
 	});
 
 	it('preserves scroll when a link with sapper:noscroll is clicked', async () => {
@@ -99,6 +96,78 @@ describe('scroll', function() {
 		const secondScrollY = await r.page.evaluate(() => window.scrollY);
 
 		assert.strictEqual(firstScrollY, secondScrollY);
+	});
+
+	it('restores scroll on popstate events', async () => {
+		await r.load('/search-page#end');
+		await r.sapper.start();
+		await r.sapper.prefetchRoutes();
+
+		assert.strictEqual(await r.text('h1'), 'A search form');
+
+		const firstScrollY = await r.page.evaluate(() => window.scrollY);
+
+		assert.ok(firstScrollY > 0, String(firstScrollY));
+
+		await r.page.click('button#navigate');
+
+		const newScrollY = await r.page.evaluate(() => window.scrollY);
+
+		assert.ok(newScrollY === 0);
+
+		await r.page.goBack();
+
+		const secondScrollY = await r.page.evaluate(() => window.scrollY);
+
+		assert.strictEqual(firstScrollY, secondScrollY);
+	});
+
+	it('restores scroll on popstate events preceded by search param changes', async () => {
+		await r.load('/search-page#search');
+		await r.sapper.start();
+
+		assert.strictEqual(await r.text('h1'), 'A search form');
+
+		// We're at the search button, ~9999px down the page
+		const initialScrollY = await r.page.evaluate(() => window.scrollY);
+
+		assert.ok(
+			initialScrollY > 9999,
+			`Scroll pos when loading page for the first time: ${String(initialScrollY)}`
+		);
+
+		// Applies search params (but keep same pathname)
+		await r.page.click('button#submit-search');
+
+		// Now we're scrolled back at the top, at 0px, same page but with search params
+		const newScrollY = await r.page.evaluate(() => window.scrollY);
+
+		assert.ok(newScrollY === 0, 'Scroll pos after updating search params');
+
+		// Scroll down to the 'end' div, near the bottom of the page
+		await r.page.evaluate(() => document.querySelector('#end').scrollIntoView());
+		const beforeClickScrollY = await r.page.evaluate(() => window.scrollY);
+
+		assert.ok(
+			beforeClickScrollY > 14000,
+			`Scroll pos before navigating away from the page: ${String(beforeClickScrollY)}`
+		);
+
+		// Go to a new page
+		await r.page.click('button#navigate');
+
+		// Go back (popstate)
+		await r.page.goBack();
+
+		// We should be at `beforeClickScrollY`
+		// But alas we are at `initialScrollY`
+		const finalScrollY = await r.page.evaluate(() => window.scrollY);
+
+		assert.strictEqual(
+			finalScrollY,
+			beforeClickScrollY,
+			`\nscrollY before navigating away: ${beforeClickScrollY}\nscrollY after popstate: ${finalScrollY}`
+		);
 	});
 
 	it('scrolls to the top when navigating with goto', async () => {

--- a/test/apps/scroll/test.ts
+++ b/test/apps/scroll/test.ts
@@ -159,14 +159,11 @@ describe('scroll', function() {
 		// Go back (popstate)
 		await r.page.goBack();
 
-		// We should be at `beforeClickScrollY`
-		// But alas we are at `initialScrollY`
 		const finalScrollY = await r.page.evaluate(() => window.scrollY);
 
 		assert.strictEqual(
 			finalScrollY,
-			beforeClickScrollY,
-			`\nscrollY before navigating away: ${beforeClickScrollY}\nscrollY after popstate: ${finalScrollY}`
+			beforeClickScrollY
 		);
 	});
 


### PR DESCRIPTION
fixes #1321 

goto must have same order of execution as [handle_click](https://github.com/istarkov/sapper/blob/5757a85d195f9ceb2e329caa5e3e38abd5a1123d/runtime/src/app/router/index.ts#L164-L166)

