### PR TITLE
Make type definitions compatible with Express and Polka

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -184,11 +184,30 @@
       "from": "github:sveltejs/eslint-config#v5.4.0",
       "dev": true
     },
+    "@types/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
+    },
+    "@types/connect": {
+      "version": "3.4.34",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
+      "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/cookie": {
       "version": "0.4.0",
@@ -202,6 +221,29 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/express": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
+      "integrity": "sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.18",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.18.tgz",
+      "integrity": "sha512-m4JTwx5RUBNZvky/JJ8swEJPKFd8si08pPF2PfizYjGZOKr/svUWPcoUmLow6MmPzhasphB7gSTINY67xn3JNA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
@@ -212,6 +254,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
     "@types/mocha": {
@@ -245,12 +293,34 @@
         "@types/node": "*"
       }
     },
+    "@types/qs": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+      "dev": true
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
       "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
       "dev": true,
       "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.9.tgz",
+      "integrity": "sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "^1",
         "@types/node": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@rollup/plugin-replace": "^2.3.3",
     "@sveltejs/eslint-config": "github:sveltejs/eslint-config#v5.4.0",
     "@types/cookie": "^0.4.0",
+    "@types/express": "^4.17.11",
     "@types/mocha": "^8.0.0",
     "@types/node": "^10.0.0",
     "@types/node-fetch": "^2.5.7",

--- a/runtime/index.d.ts
+++ b/runtime/index.d.ts
@@ -26,54 +26,17 @@ declare module '@sapper/app' {
 }
 
 declare module '@sapper/server' {
-	import { IncomingMessage, ServerResponse } from 'http';
-	import { TLSSocket } from 'tls';
+	// eslint-disable-next-line import/no-unresolved
+	import type { Request, Response } from 'express';
 
 	export type Ignore = string | RegExp | ((uri: string) => boolean) | Ignore[];
 
-	/**
-	 * The request object passed to middleware and server-side routes. 
-	 * These fields are common to both Polka and Express, but you are free to 
-	 * instead use the typings that come with the server you use.
-	 */
-	export interface SapperRequest extends IncomingMessage {
-		url: string;
-		method: string;	
-		baseUrl: string;
-	
-		/**
-		 * The originally requested URL, including parent router segments.
-		 */
-		originalUrl: string;
-	
-		/**
-		 * The path portion of the requested URL.
-		 */
-		path: string;
-	
-		/**
-		 * The values of named parameters within your route pattern
-		 */
-		params: Record<string, string>;
-	
-		/**
-		 * The un-parsed querystring
-		 */
-		search: string | null;
-	
-		/**
-		 * The parsed querystring
-		 */
-		query: Record<string, string>;
-
-		socket: TLSSocket;
+	// eslint-disable-next-line @typescript-eslint/no-empty-interface
+	export interface SapperRequest extends Request {
 	}
 
-	export interface SapperResponse extends ServerResponse {
-		locals?: {
-			nonce?: string;
-			name?: string;
-		};
+	// eslint-disable-next-line @typescript-eslint/no-empty-interface
+	export interface SapperResponse extends Response {
 	}
 		
 	export interface MiddlewareOptions {

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -128,7 +128,7 @@ export function get_page_handler(
 				preload_error = { statusCode, message };
 			},
 			fetch: (url: string, opts?: any) => {
-				const protocol = req.socket.encrypted ? 'https' : 'http';
+				const protocol = (<any>req.socket).encrypted ? 'https' : 'http';
 				const parsed = new URL.URL(url, `${protocol}://127.0.0.1:${process.env.PORT}${req.baseUrl ? req.baseUrl + '/' :''}`);
 
 				opts = Object.assign({}, opts);
@@ -264,7 +264,7 @@ export function get_page_handler(
 			const pageContext: PageContext = {
 				host: req.headers.host,
 				path: req.path,
-				query: req.query,
+				query: <any>req.query,
 				params,
 				error: error
 					? error instanceof Error

--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -112,7 +112,7 @@ export function serve({ prefix, pathname, cache_control }: {
 
 	return (req: SapperRequest, res: SapperResponse, next: () => void) => {
 		if (filter(req)) {
-			const type = mime.getType(req.path);
+			const type = (<any>mime).getType(req.path);
 
 			try {
 				const file = path.posix.normalize(decodeURIComponent(req.path));


### PR DESCRIPTION
Closes #1706 

The type definition for `SapperRequest` and `SapperResponse` is totally borked. It won't work with Express or Polka. This changes it to use the Express types instead which work on both.

I ignored several issues in the codebase as a result of this change. That's probably not the best solution, but everything's been working just fine and it's not worth investing more time with Sapper eventually going away. My priority is just getting Sapper unbroken

I left the `SapperRequest` and `SapperResponse` types instead of replacing them with the Express types in order to maintain backwards compatibility