### PR TITLE
Fixed typings to be compatible with express

### DIFF
--- a/runtime/index.d.ts
+++ b/runtime/index.d.ts
@@ -27,9 +27,11 @@ declare module '@sapper/app' {
 
 declare module '@sapper/server' {
 	import { IncomingMessage, ServerResponse } from 'http';
-	import { TLSSocket } from 'tls';
+	import { Socket } from 'net';
 
 	export type Ignore = string | RegExp | ((uri: string) => boolean) | Ignore[];
+
+	interface ParsedQs { [key: string]: undefined | string | string[] | ParsedQs | ParsedQs[] }
 
 	/**
 	 * The request object passed to middleware and server-side routes. 
@@ -57,16 +59,11 @@ declare module '@sapper/server' {
 		params: Record<string, string>;
 	
 		/**
-		 * The un-parsed querystring
+		 * The parsed query string
 		 */
-		search: string | null;
-	
-		/**
-		 * The parsed querystring
-		 */
-		query: Record<string, string>;
+		query: ParsedQs;
 
-		socket: TLSSocket;
+		socket: Socket;
 	}
 
 	export interface SapperResponse extends ServerResponse {

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -18,6 +18,7 @@ import {
 import App from '@sapper/internal/App.svelte';
 import { PageContext, PreloadResult } from '@sapper/common';
 import detectClientOnlyReferences from './detect_client_only_references';
+import { TLSSocket } from 'tls';
 
 export function get_page_handler(
 	manifest: Manifest,
@@ -128,7 +129,7 @@ export function get_page_handler(
 				preload_error = { statusCode, message };
 			},
 			fetch: (url: string, opts?: any) => {
-				const protocol = req.socket.encrypted ? 'https' : 'http';
+				const protocol = req.socket instanceof TLSSocket && req.socket.encrypted ? 'https' : 'http';
 				const parsed = new URL.URL(url, `${protocol}://127.0.0.1:${process.env.PORT}${req.baseUrl ? req.baseUrl + '/' :''}`);
 
 				opts = Object.assign({}, opts);
@@ -264,7 +265,7 @@ export function get_page_handler(
 			const pageContext: PageContext = {
 				host: req.headers.host,
 				path: req.path,
-				query: req.query,
+				query: req.query as Record<string, string | string[]>,
 				params,
 				error: error
 					? error instanceof Error

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -129,7 +129,7 @@ export function get_page_handler(
 				preload_error = { statusCode, message };
 			},
 			fetch: (url: string, opts?: any) => {
-				const protocol = req.socket instanceof TLSSocket && req.socket.encrypted ? 'https' : 'http';
+				const protocol = (req.socket as TLSSocket).encrypted ? 'https' : 'http';
 				const parsed = new URL.URL(url, `${protocol}://127.0.0.1:${process.env.PORT}${req.baseUrl ? req.baseUrl + '/' :''}`);
 
 				opts = Object.assign({}, opts);


### PR DESCRIPTION
A more conservative version of #1710 that fixes #1706.

There seem to be three issues with the request:

 * the `search` property that's supposed to hold the query string doesn't actually exist. No idea how it wound up in there. It's also not referenced anywhere in the code so easy to remove.
 * `query` can contain a wider range of stuff than `SapperRequest` declares. I grabbed the Express definition but we could also do `Record<string, any>`
 * `socket` assumed it was always an `https` connection

This seems to compile with both Polka and Express when I tested it