### PR TITLE
Restore hashing of all CSS file names (#1716)

### DIFF
--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -161,7 +161,10 @@ export default class RollupCompiler {
 		const that = this;
 
 		// TODO this is hacky. refactor out into an external rollup plugin
-		(mod.plugins || (mod.plugins = [])).push(css_chunks());
+		(mod.plugins || (mod.plugins = [])).push(css_chunks({
+			chunkFileNames: '[name]-[hash].css',
+			entryFileNames: '[name]-[hash].css'
+		}));
 		if (!/[\\/]client\./.test(entry_point)) {
 			return mod;
 		}

--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -162,7 +162,6 @@ export default class RollupCompiler {
 
 		// TODO this is hacky. refactor out into an external rollup plugin
 		(mod.plugins || (mod.plugins = [])).push(css_chunks({
-			chunkFileNames: '[name]-[hash].css',
 			entryFileNames: '[name]-[hash].css'
 		}));
 		if (!/[\\/]client\./.test(entry_point)) {


### PR DESCRIPTION
Explicitly use hash in rollup-plugin-css-chunks:
```
chunkFileNames: '[name]-[hash].css',
entryFileNames: '[name]-[hash].css'
```

fix #1716 

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
