### PR TITLE
Add a note about providing a middleware to set a user session

### DIFF
--- a/site/content/docs/07-state-management.md
+++ b/site/content/docs/07-state-management.md
@@ -27,6 +27,8 @@ As an example, let's look at how to populate the session with the current user. 
 ```js
 // src/server.js
 polka()
+	// Create a middleware to set `req.user` for the Sapper middleware
+	.use(userMiddleware)
 	.use(
 		// ...
 		sapper.middleware({


### PR DESCRIPTION
For a new user it might not be clear that they'll need to provide `req.user` via a middleware, so I've added a line to make this explicit that they'll need to create some sort of middleware to set the user for the `sapper.middleware`

Relates to #1437
