### PR TITLE
Update rollup-plugin-css-chunks dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5052,9 +5052,9 @@
       "dev": true
     },
     "rollup-plugin-css-chunks": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-css-chunks/-/rollup-plugin-css-chunks-2.0.2.tgz",
-      "integrity": "sha512-Cg/J6ZGPOWgMeGqqdp7fxnmDMr3Y+9V3fJekaFqWp+ceLr7l14Ua3FYtKJ/+m/DnSYYs009PrCt2pitOjYwWxw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-css-chunks/-/rollup-plugin-css-chunks-2.0.3.tgz",
+      "integrity": "sha512-weD4obCIDeMDz3UtvVY9Aoks7Rtd1F1TUghCHVvOZ8eyI5C/8SpAstOl4kJK59wKC5ycn7O5KEzzdiEHWF97tg==",
       "dev": true,
       "requires": {
         "rollup-pluginutils": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.29.0",
     "rollup-dependency-tree": "0.0.14",
-    "rollup-plugin-css-chunks": "^2.0.2",
+    "rollup-plugin-css-chunks": "^2.0.3",
     "rollup-plugin-svelte": "^5.1.0",
     "rollup-plugin-typescript2": "^0.27.1",
     "sade": "^1.6.1",


### PR DESCRIPTION
Fix #1751

> NOTE: All development is currently focused on Sapper's successor, SvelteKit: https://kit.svelte.dev/
We are not adding new features to Sapper. While we might fix some particularly pressing or easy to
address bugs, it's highly unlikely that most PRs will be reviewed.

This PR should be merged, because otherwise the latest version of Sapper is not usable with regex routes.