### PR TITLE
Make prefetching styles work more reliably

### DIFF
--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -45,13 +45,10 @@ export default function(files) {
 			link = document.createElement('link');
 			link.rel = 'stylesheet';
 			link.href = href;
+			link.onload = link.onerror = fulfil;
 			document.head.appendChild(link);
-		}
-		if (link.sheet) {
-			fulfil();
 		} else {
-			link.onload = function() { return fulfil() };
-			link.onerror = reject;
+			fulfil();
 		}
 	})}));
 };`.trim();


### PR DESCRIPTION
There was a small race between the element being added to the DOM
and an onload event being triggered, fix this by making sure we have an
onload/onerror handlers set up before adding it to document head. Fixes #1582.

NOTE: All development is currently focused on Sapper's successor, SvelteKit: https://kit.svelte.dev/
We are not adding new features to Sapper. While we might fix some particularly pressing or easy to
address bugs, it's highly unlikely that most PRs will be reviewed.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
