### PR TITLE
Fixed Dynamic Parameters in routes containing spaces

### DIFF
--- a/runtime/src/server/middleware/index.ts
+++ b/runtime/src/server/middleware/index.ts
@@ -24,7 +24,7 @@ export default function middleware(opts: {
 				}
 
 				req.baseUrl = originalUrl
-					? originalUrl.slice(0, -req.url.length)
+					? decodeURI(originalUrl).slice(0, -req.url.length)
 					: '';
 			}
 


### PR DESCRIPTION
The change here is to appropriately fetch the baseUrl in cases where the URL is encoded.

- **req.originalUrl** - http://localhost:3000/blog/how-to-use%20sapper
- **req.url** - http://localhost:3000/blog/how-to-use sapper

Current **req.baseUrl** - http://localhost:3000/b/ (Fails loading of assets)
Expected **req.baseUrl** - http://localhost:3000/
