### PR TITLE
replace onload with addEventListener in inject_styles

### DIFF
--- a/src/core/create_compilers/RollupCompiler.ts
+++ b/src/core/create_compilers/RollupCompiler.ts
@@ -50,8 +50,8 @@ export default function(files) {
 		if (link.sheet) {
 			fulfil();
 		} else {
-			link.onload = function() { return fulfil() };
-			link.onerror = reject;
+			link.addEventListener('load', function() { return fulfil() });
+			link.addEventListener('error', reject);
 		}
 	})}));
 };`.trim();


### PR DESCRIPTION
When multiple dynamically imported components are loaded, only one of them resolves the promise. Upon further investigation, I found out that those components were loading `.css` files and `inject_styles` function was using `onload` in order to resolve `inject_styles` promise.

If two components use the same `css` file, the first `onload` will be overridden by the second one.

The solution is to replace `onload` with  `addEventListener("load", ...`.

@Rich-Harris  pushed a fix for this in svelte kit ([kit#347](https://github.com/sveltejs/kit/pull/347))