### PR TITLE
Deprecate Sapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,10 @@
 # sapper
 
-[The next small thing in web development, powered by Svelte.](https://sapper.svelte.dev)
+[Sapper](https://sapper.svelte.dev) is deprecated in favor of its successor, [SvelteKit](https://kit.svelte.dev/), which we recommend using instead.
 
+## Financial Support
 
-## What is Sapper?
-
-Sapper is a framework for building high-performance universal web apps. [Read the guide](https://sapper.svelte.dev/docs) or the [introductory blog post](https://svelte.dev/blog/sapper-towards-the-ideal-web-app-framework) to learn more.
-
-
-## SvelteKit
-
-Sapper's successor, [SvelteKit](https://kit.svelte.dev/), is currently available for use. Please see [the FAQ](https://sapper.svelte.dev/faq#version-numbers) for more details.
-
-
-## Get started
-
-Clone the [starter project template](https://github.com/sveltejs/sapper-template) with [degit](https://github.com/rich-harris/degit)...
-When cloning you have to choose between rollup or webpack:
-
-```bash
-npx degit "sveltejs/sapper-template#rollup" my-app
-# or: npx degit "sveltejs/sapper-template#webpack" my-app
-```
-
-...then install dependencies and start the dev server...
-
-```bash
-cd my-app
-npm install
-npm run dev
-```
-
-...and navigate to [localhost:3000](http://localhost:3000). To build and run in production mode:
-
-```bash
-npm run build
-npm start
-```
-
-## Development
-
-Pull requests are encouraged and always welcome. [Pick an issue](https://github.com/sveltejs/sapper/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) and help us out!
-
-To install and work on Sapper locally:
-
-```bash
-git clone https://github.com/sveltejs/sapper.git
-cd sapper
-npm install
-npm run dev
-```
-
-### Linking to a Live Project
-
-You can make changes locally to Sapper and test it against a local Sapper project. For a quick project that takes almost no setup, use the default [sapper-template](https://github.com/sveltejs/sapper-template) project. Instruction on setup are found in that project repository.
-
-To link Sapper to your project, from the root of your local Sapper git checkout:
-
-```bash
-cd sapper
-npm link
-```
-
-Then, to link from `sapper-template` (or any other given project):
-
-```bash
-cd sapper-template
-npm link sapper
-```
-
-You should be good to test changes locally.
-
-### Running Tests
-
-```bash
-npm run test
-```
+To support Sapper, SvelteKit, and the rest of the Svelte ecosystem, please consider [contributing via OpenCollective](https://opencollective.com/svelte).
 
 ## License
 

--- a/site/content/faq/100-version-numbers.md
+++ b/site/content/faq/100-version-numbers.md
@@ -2,6 +2,6 @@
 question: Sapper is not 1.0 yet. Should I use it? What about SvelteKit?
 ---
 
-We are currently working on Sapper's successor, [SvelteKit](https://kit.svelte.dev/). There are still some known issues to resolve and aspects of the design that will change. Whether you want to start on SvelteKit will be determined by how willing you are to deal with bumps in the road during a beta period. If you want to evaluate starting on the more stable Sapper project and then migrating to SvelteKit, please see the [migration guide](https://kit.svelte.dev/docs/migrating) for details of what's necessary to do that.
+Sapper has been deprecated in favor of it's successor, [SvelteKit](https://kit.svelte.dev/). Please see the [migration guide](https://kit.svelte.dev/docs/migrating) for details on how to migrate to SvelteKit.
 
-Sapper is operationally stable and some of the Svelte maintainers run their businesses on Sapper. "production readiness" is subjective, and if Sapper fulfils your requirements, then it's production ready. As with any software, a major version number is not an indicator of whether something is suitable for your specific use-case.
+Sapper and SvelteKit are operationally stable and some of the Svelte maintainers run their businesses on them. However, there will be breaking API changes before 1.0. "production readiness" is subjective, and if your requirements are fulfilled, then it's production ready. As with any software, a major version number is not an indicator of whether something is suitable for your specific use-case.


### PR DESCRIPTION
All development efforts have been focused on [SvelteKit](https://kit.svelte.dev/) for quite a long time.